### PR TITLE
feat(ui): selection emphasis on active fields (#10)

### DIFF
--- a/.changeset/selection-emphasis.md
+++ b/.changeset/selection-emphasis.md
@@ -1,0 +1,5 @@
+---
+'template-goblin-ui': minor
+---
+
+Selected fields now show unmistakable visual feedback in both the canvas and the toolbar. On the canvas the field's background rect darkens (or the stroke widens for transparent-fill fields like static / image-with-placeholder) and switches to the per-type accent. In the toolbar, the Text / Image / Table button for the selected field's type flips to its full active state (solid accent background, white text) — identical weight to the drawing-tool-active state — so you can always see which field type is in play. Multi-type selection lights up multiple buttons simultaneously. Closes #10.

--- a/packages/ui/e2e/selection-emphasis.spec.ts
+++ b/packages/ui/e2e/selection-emphasis.spec.ts
@@ -1,0 +1,301 @@
+/**
+ * E2E coverage for GH issue #10 — selected fields must show unmistakable
+ * visual emphasis beyond Fabric's default corner handles.
+ *
+ * What we assert:
+ *   - A field's background Rect has its `fill` / `stroke` / `strokeWidth`
+ *     swapped to the selected-state tokens when the Group becomes active.
+ *   - Deselecting (clicking empty canvas / selecting a different field)
+ *     restores the defaults.
+ *   - Multi-select (shift+click) emphasizes every member of the active set
+ *     independently.
+ */
+import type { Page } from '@playwright/test'
+import { test, expect } from '@playwright/test'
+
+test.describe.configure({ mode: 'serial' })
+
+interface SeedField {
+  id: string
+  x: number
+  y: number
+  width: number
+  height: number
+  zIndex: number
+}
+
+const SEEDS: SeedField[] = [
+  { id: 'f1', x: 60, y: 60, width: 180, height: 100, zIndex: 0 },
+  { id: 'f2', x: 280, y: 60, width: 180, height: 100, zIndex: 1 },
+  { id: 'f3', x: 60, y: 220, width: 180, height: 100, zIndex: 2 },
+]
+
+const TEXT_STYLE = {
+  fontId: null,
+  fontFamily: 'Helvetica',
+  fontSize: 12,
+  fontSizeDynamic: false,
+  fontSizeMin: 8,
+  lineHeight: 1.2,
+  fontWeight: 'normal',
+  fontStyle: 'normal',
+  textDecoration: 'none',
+  color: '#000000',
+  align: 'left',
+  verticalAlign: 'top',
+  maxRows: 2,
+  overflowMode: 'truncate',
+  snapToGrid: false,
+}
+
+async function seedTemplate(page: Page): Promise<void> {
+  const payload = {
+    state: {
+      meta: {
+        schemaVersion: 1,
+        name: 'selection-emphasis-test',
+        version: '0.0.0',
+        width: 600,
+        height: 500,
+        locked: false,
+      },
+      fields: SEEDS.map((s) => ({
+        id: s.id,
+        label: s.id,
+        type: 'text',
+        groupId: null,
+        pageId: null,
+        x: s.x,
+        y: s.y,
+        width: s.width,
+        height: s.height,
+        zIndex: s.zIndex,
+        source: { mode: 'dynamic', jsonKey: s.id, required: false, placeholder: null },
+        style: TEXT_STYLE,
+      })),
+      fonts: [],
+      groups: [],
+      pages: [
+        {
+          id: 'page-0',
+          index: 0,
+          backgroundType: 'color',
+          backgroundColor: '#ffffff',
+          backgroundFilename: null,
+        },
+      ],
+      backgroundDataUrl: null,
+      backgroundBuffer: null,
+      pageBackgroundDataUrls: [],
+      pageBackgroundBuffers: [],
+      fontBuffers: [],
+      placeholderBuffers: [],
+      staticImageBuffers: [],
+      staticImageDataUrls: [],
+    },
+    version: 2,
+  }
+  await page.addInitScript((seed: string) => {
+    localStorage.setItem('template-goblin-template', seed)
+    // Reset any prior UI-store currentPageId so onboarding doesn't appear.
+    localStorage.removeItem('template-goblin-ui')
+  }, JSON.stringify(payload))
+}
+
+function fabricCanvas(page: Page) {
+  return page.locator('[data-testid="canvas-stage-wrapper"] canvas').first()
+}
+
+interface RectVisuals {
+  fill: string
+  stroke: string
+  strokeWidth: number
+  defaultFill: string
+  defaultStroke: string
+  defaultStrokeWidth: number
+}
+
+/** Read the current fill / stroke / strokeWidth of a field Group's bgRect. */
+async function readFieldVisuals(page: Page, fieldId: string): Promise<RectVisuals> {
+  return await page.evaluate((id) => {
+    interface FabricLike {
+      getObjects: () => Array<{
+        __fieldId?: string
+        getObjects?: () => Array<{
+          fill?: string | unknown
+          stroke?: string
+          strokeWidth?: number
+          __defaultFill?: string
+          __defaultStroke?: string
+          __defaultStrokeWidth?: number
+        }>
+      }>
+    }
+    const fc = (window as unknown as { __fabricCanvas?: FabricLike }).__fabricCanvas
+    if (!fc) throw new Error('Fabric canvas not ready')
+    const group = fc.getObjects().find((o) => o.__fieldId === id)
+    if (!group || !group.getObjects) throw new Error(`group ${id} missing`)
+    const bg = group.getObjects()[0]
+    if (!bg) throw new Error(`bg rect for ${id} missing`)
+    return {
+      fill: typeof bg.fill === 'string' ? bg.fill : '',
+      stroke: bg.stroke ?? '',
+      strokeWidth: bg.strokeWidth ?? 0,
+      defaultFill: bg.__defaultFill ?? '',
+      defaultStroke: bg.__defaultStroke ?? '',
+      defaultStrokeWidth: bg.__defaultStrokeWidth ?? 0,
+    }
+  }, fieldId)
+}
+
+async function boundingBoxCenter(page: Page, fieldId: string): Promise<{ x: number; y: number }> {
+  // Use Fabric's own scene → screen conversion to find the click point.
+  return await page.evaluate((id) => {
+    interface FabricLike {
+      getObjects: () => Array<{
+        __fieldId?: string
+        left?: number
+        top?: number
+        width?: number
+        height?: number
+      }>
+      viewportTransform?: number[]
+      getElement?: () => HTMLCanvasElement
+      upperCanvasEl?: HTMLCanvasElement
+    }
+    const fc = (window as unknown as { __fabricCanvas?: FabricLike }).__fabricCanvas
+    if (!fc) throw new Error('Fabric canvas not ready')
+    const g = fc.getObjects().find((o) => o.__fieldId === id)
+    if (!g) throw new Error(`group ${id} missing`)
+    const vpt = fc.viewportTransform ?? [1, 0, 0, 1, 0, 0]
+    const zoom = vpt[0] ?? 1
+    const tx = vpt[4] ?? 0
+    const ty = vpt[5] ?? 0
+    const gx = g.left ?? 0
+    const gy = g.top ?? 0
+    const gw = g.width ?? 0
+    const gh = g.height ?? 0
+    const el = fc.upperCanvasEl ?? fc.getElement?.()
+    if (!el) throw new Error('canvas element missing')
+    const rect = el.getBoundingClientRect()
+    return {
+      x: rect.left + (gx + gw / 2) * zoom + tx,
+      y: rect.top + (gy + gh / 2) * zoom + ty,
+    }
+  }, fieldId)
+}
+
+test.describe('Selection emphasis (#10)', () => {
+  test.beforeEach(async ({ page }) => {
+    await seedTemplate(page)
+    await page.goto('/')
+    await expect(fabricCanvas(page)).toBeVisible({ timeout: 5000 })
+    await expect
+      .poll(
+        () =>
+          page.evaluate(() => !!(window as unknown as { __fabricCanvas?: unknown }).__fabricCanvas),
+        { timeout: 5000 },
+      )
+      .toBe(true)
+  })
+
+  test('unselected fields render with default fill + stroke', async ({ page }) => {
+    for (const s of SEEDS) {
+      const v = await readFieldVisuals(page, s.id)
+      expect(v.fill).toBe(v.defaultFill)
+      expect(v.stroke).toBe(v.defaultStroke)
+      expect(v.strokeWidth).toBe(v.defaultStrokeWidth)
+    }
+  })
+
+  test('clicking a field swaps its bg to the selected-state tokens', async ({ page }) => {
+    const before = await readFieldVisuals(page, 'f1')
+
+    const center = await boundingBoxCenter(page, 'f1')
+    await page.mouse.click(center.x, center.y)
+
+    await expect
+      .poll(async () => (await readFieldVisuals(page, 'f1')).strokeWidth)
+      .toBeGreaterThan(before.strokeWidth)
+
+    const after = await readFieldVisuals(page, 'f1')
+    expect(after.fill).not.toBe(before.defaultFill)
+    expect(after.stroke).not.toBe(before.defaultStroke)
+    expect(after.strokeWidth).toBeGreaterThan(before.defaultStrokeWidth)
+
+    // Untouched fields remain at defaults.
+    const f2 = await readFieldVisuals(page, 'f2')
+    expect(f2.fill).toBe(f2.defaultFill)
+    expect(f2.stroke).toBe(f2.defaultStroke)
+    expect(f2.strokeWidth).toBe(f2.defaultStrokeWidth)
+  })
+
+  test('switching selection restores the previous field and emphasizes the new one', async ({
+    page,
+  }) => {
+    const c1 = await boundingBoxCenter(page, 'f1')
+    await page.mouse.click(c1.x, c1.y)
+    await expect
+      .poll(async () => (await readFieldVisuals(page, 'f1')).strokeWidth)
+      .toBeGreaterThan(1)
+
+    const c2 = await boundingBoxCenter(page, 'f2')
+    await page.mouse.click(c2.x, c2.y)
+
+    await expect
+      .poll(async () => (await readFieldVisuals(page, 'f2')).strokeWidth)
+      .toBeGreaterThan(1)
+
+    const f1 = await readFieldVisuals(page, 'f1')
+    expect(f1.fill).toBe(f1.defaultFill)
+    expect(f1.stroke).toBe(f1.defaultStroke)
+    expect(f1.strokeWidth).toBe(f1.defaultStrokeWidth)
+
+    const f2 = await readFieldVisuals(page, 'f2')
+    expect(f2.strokeWidth).toBeGreaterThan(f2.defaultStrokeWidth)
+  })
+
+  test('clicking empty canvas clears emphasis from every field', async ({ page }) => {
+    const c1 = await boundingBoxCenter(page, 'f1')
+    await page.mouse.click(c1.x, c1.y)
+    await expect
+      .poll(async () => (await readFieldVisuals(page, 'f1')).strokeWidth)
+      .toBeGreaterThan(1)
+
+    // Click empty area far from any field.
+    const canvasBox = await fabricCanvas(page).boundingBox()
+    if (!canvasBox) throw new Error('canvas has no bbox')
+    await page.mouse.click(canvasBox.x + canvasBox.width - 10, canvasBox.y + canvasBox.height - 10)
+
+    await expect.poll(async () => (await readFieldVisuals(page, 'f1')).strokeWidth).toBe(1)
+
+    for (const s of SEEDS) {
+      const v = await readFieldVisuals(page, s.id)
+      expect(v.fill).toBe(v.defaultFill)
+      expect(v.stroke).toBe(v.defaultStroke)
+      expect(v.strokeWidth).toBe(v.defaultStrokeWidth)
+    }
+  })
+
+  test('shift+click multi-select emphasizes every member of the active selection', async ({
+    page,
+  }) => {
+    const c1 = await boundingBoxCenter(page, 'f1')
+    await page.mouse.click(c1.x, c1.y)
+
+    const c2 = await boundingBoxCenter(page, 'f2')
+    await page.keyboard.down('Shift')
+    await page.mouse.click(c2.x, c2.y)
+    await page.keyboard.up('Shift')
+
+    await expect
+      .poll(async () => (await readFieldVisuals(page, 'f1')).strokeWidth)
+      .toBeGreaterThan(1)
+    await expect
+      .poll(async () => (await readFieldVisuals(page, 'f2')).strokeWidth)
+      .toBeGreaterThan(1)
+
+    const f3 = await readFieldVisuals(page, 'f3')
+    expect(f3.strokeWidth).toBe(f3.defaultStrokeWidth)
+  })
+})

--- a/packages/ui/src/App.css
+++ b/packages/ui/src/App.css
@@ -120,15 +120,6 @@ html, body, #root {
 .tg-btn:active { background: var(--border); }
 .tg-btn--active { background: var(--accent); color: #fff; }
 .tg-btn--active:hover { background: var(--accent-hover); }
-/* Selection-aware ring: applied to the field-type toolbar buttons when a
- * field of that type is currently selected on the canvas. The ring uses
- * the button's own foreground colour (set via inline style) so it inherits
- * the per-type accent. */
-.tg-btn--selected-ring {
-  box-shadow:
-    0 0 0 2px var(--bg-primary),
-    0 0 0 4px currentColor;
-}
 .tg-btn:disabled { @apply opacity-40 cursor-not-allowed; }
 .tg-btn:disabled:hover { background: transparent; }
 .tg-btn--danger:hover { background: var(--error); color: #fff; }

--- a/packages/ui/src/App.css
+++ b/packages/ui/src/App.css
@@ -120,6 +120,15 @@ html, body, #root {
 .tg-btn:active { background: var(--border); }
 .tg-btn--active { background: var(--accent); color: #fff; }
 .tg-btn--active:hover { background: var(--accent-hover); }
+/* Selection-aware ring: applied to the field-type toolbar buttons when a
+ * field of that type is currently selected on the canvas. The ring uses
+ * the button's own foreground colour (set via inline style) so it inherits
+ * the per-type accent. */
+.tg-btn--selected-ring {
+  box-shadow:
+    0 0 0 2px var(--bg-primary),
+    0 0 0 4px currentColor;
+}
 .tg-btn:disabled { @apply opacity-40 cursor-not-allowed; }
 .tg-btn:disabled:hover { background: transparent; }
 .tg-btn--danger:hover { background: var(--error); color: #fff; }

--- a/packages/ui/src/components/Canvas/fabric.d.ts
+++ b/packages/ui/src/components/Canvas/fabric.d.ts
@@ -19,5 +19,11 @@ declare module 'fabric' {
     __fieldType?: string
     /** Internal flag: marks Fabric objects that are part of the grid overlay. */
     __isGrid?: boolean
+    /** Default (un-selected) fill saved on the field's background Rect. */
+    __defaultFill?: string
+    /** Default (un-selected) stroke saved on the field's background Rect. */
+    __defaultStroke?: string
+    /** Default (un-selected) strokeWidth saved on the field's background Rect. */
+    __defaultStrokeWidth?: number
   }
 }

--- a/packages/ui/src/components/Canvas/fabricUtils.ts
+++ b/packages/ui/src/components/Canvas/fabricUtils.ts
@@ -308,6 +308,11 @@ export function applySelectionVisuals(group: Group, selected: boolean): void {
       strokeWidth: defaultStrokeWidth,
     })
   }
+  // Fabric v6 caches Group renders; mutating a child's fill/stroke does NOT
+  // invalidate the parent cache on its own, so the viewport stays stale
+  // until the group is marked dirty.
+  bgRect.set('dirty', true)
+  group.set('dirty', true)
 }
 
 /**

--- a/packages/ui/src/components/Canvas/fabricUtils.ts
+++ b/packages/ui/src/components/Canvas/fabricUtils.ts
@@ -35,7 +35,7 @@
 import { Rect, Group, FabricText, FabricImage, Point, Line } from 'fabric'
 import type { FabricObject } from 'fabric'
 import type { FieldDefinition } from '@template-goblin/types'
-import { FIELD_COLORS } from '../../theme/fieldColors.js'
+import { FIELD_COLORS, SELECTED_STROKE_WIDTH } from '../../theme/fieldColors.js'
 import { fieldCanvasLabel } from './fieldLabel.js'
 import { shouldRenderFillRect } from './rectFill.js'
 
@@ -252,6 +252,85 @@ export function applyFieldToGroup(
   })
   group.setCoords()
   group.__fieldType = field.type
+
+  // Re-apply current selection visuals — children were just rebuilt so the
+  // bgRect is back to defaults; if the group is still part of the canvas's
+  // active selection we need to restore the emphasis.
+  const canvas = group.canvas
+  if (canvas) {
+    const active = canvas.getActiveObjects().some((o) => o.__fieldId === field.id)
+    applySelectionVisuals(group, active)
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Selection visual emphasis (GH #10)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Toggle the visual emphasis on a field Group to reflect selection state.
+ *
+ * Design: a subtle default fill/stroke makes unselected fields easy to skim
+ * past; when the user clicks or drag-selects a field Fabric's corner handles
+ * alone are too small to register at a glance. We darken the bgRect fill to
+ * `selectedFill` (same hue, higher alpha) and widen the stroke to
+ * `SELECTED_STROKE_WIDTH` in `selectedStroke`. Fields with a transparent
+ * default fill (static / image-with-placeholder fields per REQ-047) get
+ * stroke-only emphasis so we don't paint over a rendered image.
+ *
+ * @param group - The field Group to update.
+ * @param selected - True if the group is (or is part of) the active selection.
+ */
+export function applySelectionVisuals(group: Group, selected: boolean): void {
+  const bgRect = group.getObjects()[0] as Rect | undefined
+  if (!bgRect) return
+  const fieldType = group.__fieldType
+  if (!fieldType || !(fieldType in FIELD_COLORS)) return
+  const tokens = FIELD_COLORS[fieldType as keyof typeof FIELD_COLORS]
+
+  const defaultFill = bgRect.__defaultFill ?? tokens.fill
+  const defaultStroke = bgRect.__defaultStroke ?? tokens.stroke
+  const defaultStrokeWidth = bgRect.__defaultStrokeWidth ?? 1
+
+  if (selected) {
+    // Transparent-default fields keep a transparent fill on selection so a
+    // rendered image / placeholder isn't painted over — stroke alone signals.
+    const nextFill = defaultFill === 'transparent' ? 'transparent' : tokens.selectedFill
+    bgRect.set({
+      fill: nextFill,
+      stroke: tokens.selectedStroke,
+      strokeWidth: SELECTED_STROKE_WIDTH,
+    })
+  } else {
+    bgRect.set({
+      fill: defaultFill,
+      stroke: defaultStroke,
+      strokeWidth: defaultStrokeWidth,
+    })
+  }
+}
+
+/**
+ * Refresh every field Group on the canvas so its visuals reflect the current
+ * Fabric active-object set. Call from `selection:created` / `selection:updated`
+ * / `selection:cleared` handlers. Cheap: iterates top-level objects once.
+ */
+export function syncSelectionEmphasis(canvas: {
+  getObjects: () => FabricObject[]
+  getActiveObjects: () => FabricObject[]
+  requestRenderAll: () => void
+}): void {
+  const activeIds = new Set(
+    canvas
+      .getActiveObjects()
+      .map((o) => o.__fieldId)
+      .filter((id): id is string => !!id),
+  )
+  for (const obj of canvas.getObjects()) {
+    if (!obj.__fieldId || obj.__isGrid) continue
+    applySelectionVisuals(obj as Group, activeIds.has(obj.__fieldId))
+  }
+  canvas.requestRenderAll()
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -452,14 +531,17 @@ export function buildGroupChildren(
   // 1. Background rect — always present so the Group has a stable bounding box
   //    and hit-testing works (Fabric needs a non-zero area; fill: 'transparent'
   //    still participates in hit-detection unlike fill: null or fill: '').
+  const defaultFill = shouldFill ? colors.fill : 'transparent'
+  const defaultStroke = colors.stroke
+  const defaultStrokeWidth = 1
   const bgRect = new Rect({
     left: 0,
     top: 0,
     width: w,
     height: h,
-    fill: shouldFill ? colors.fill : 'transparent',
-    stroke: colors.stroke,
-    strokeWidth: 1,
+    fill: defaultFill,
+    stroke: defaultStroke,
+    strokeWidth: defaultStrokeWidth,
     strokeUniform: true,
     rx: 2,
     ry: 2,
@@ -468,6 +550,9 @@ export function buildGroupChildren(
     originX: 'left',
     originY: 'top',
   })
+  bgRect.__defaultFill = defaultFill
+  bgRect.__defaultStroke = defaultStroke
+  bgRect.__defaultStrokeWidth = defaultStrokeWidth
 
   const children: FabricObject[] = [bgRect]
 

--- a/packages/ui/src/components/Canvas/useFabricCanvas.ts
+++ b/packages/ui/src/components/Canvas/useFabricCanvas.ts
@@ -17,7 +17,13 @@ import type { FieldType } from '@template-goblin/types'
 import type { FieldCreationDraft } from './FieldCreationPopup.js'
 import { useTemplateStore } from '../../store/templateStore.js'
 import { useUiStore } from '../../store/uiStore.js'
-import { groupToFieldPatch, fitZoomLevel, centreViewport, snap } from './fabricUtils.js'
+import {
+  groupToFieldPatch,
+  fitZoomLevel,
+  centreViewport,
+  snap,
+  syncSelectionEmphasis,
+} from './fabricUtils.js'
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -137,18 +143,23 @@ function wireSelectionEvents(fc: FabricCanvas) {
     const current = useUiStore.getState().selectedFieldIds
     const sortedNew = [...ids].sort()
     const sortedCur = [...current].sort()
-    if (sortedNew.length === sortedCur.length && sortedNew.every((id, i) => id === sortedCur[i])) {
-      return
+    const storeInSync =
+      sortedNew.length === sortedCur.length && sortedNew.every((id, i) => id === sortedCur[i])
+    if (!storeInSync) {
+      if (ids.length === 0) {
+        if (current.length > 0) useUiStore.getState().clearSelection()
+      } else if (ids.length === 1) {
+        const onlyId = ids[0]
+        if (onlyId) useUiStore.getState().selectAndFocus(onlyId)
+      } else {
+        useUiStore.getState().selectFields(ids)
+        useUiStore.getState().setShowRightPanel(true)
+      }
     }
-    if (ids.length === 0) {
-      if (current.length > 0) useUiStore.getState().clearSelection()
-    } else if (ids.length === 1) {
-      const onlyId = ids[0]
-      if (onlyId) useUiStore.getState().selectAndFocus(onlyId)
-    } else {
-      useUiStore.getState().selectFields(ids)
-      useUiStore.getState().setShowRightPanel(true)
-    }
+    // Visual emphasis reflects the canvas active-object set regardless of
+    // whether the store changed (the set itself may still differ from the
+    // previous emphasis state — e.g. on a shift-click that grew the selection).
+    syncSelectionEmphasis(fc)
   }
 
   fc.on('selection:created', sync)
@@ -157,6 +168,7 @@ function wireSelectionEvents(fc: FabricCanvas) {
     if (useUiStore.getState().selectedFieldIds.length > 0) {
       useUiStore.getState().clearSelection()
     }
+    syncSelectionEmphasis(fc)
   })
 }
 

--- a/packages/ui/src/components/Toolbar/Toolbar.tsx
+++ b/packages/ui/src/components/Toolbar/Toolbar.tsx
@@ -238,14 +238,22 @@ export function Toolbar() {
       {/* Field tools */}
       <div className="tg-toolbar-group">
         <button
-          className={`tg-btn ${activeTool === 'addText' ? 'tg-btn--active' : ''} ${selectedFieldTypes.has('text') ? 'tg-btn--selected-ring' : ''}`}
+          className={`tg-btn ${activeTool === 'addText' || selectedFieldTypes.has('text') ? 'tg-btn--active' : ''}`}
           onClick={() => setActiveTool(activeTool === 'addText' ? 'select' : 'addText')}
           disabled={locked || !hasBackground}
-          style={{
-            background: FIELD_COLORS.text.toolbarBg,
-            color: FIELD_COLORS.text.toolbarFg,
-            borderColor: FIELD_COLORS.text.stroke,
-          }}
+          style={
+            activeTool === 'addText' || selectedFieldTypes.has('text')
+              ? {
+                  background: FIELD_COLORS.text.stroke,
+                  color: '#fff',
+                  borderColor: FIELD_COLORS.text.stroke,
+                }
+              : {
+                  background: FIELD_COLORS.text.toolbarBg,
+                  color: FIELD_COLORS.text.toolbarFg,
+                  borderColor: FIELD_COLORS.text.stroke,
+                }
+          }
         >
           <svg
             width="14"
@@ -262,14 +270,22 @@ export function Toolbar() {
           Text
         </button>
         <button
-          className={`tg-btn ${activeTool === 'addImage' ? 'tg-btn--active' : ''} ${selectedFieldTypes.has('image') ? 'tg-btn--selected-ring' : ''}`}
+          className={`tg-btn ${activeTool === 'addImage' || selectedFieldTypes.has('image') ? 'tg-btn--active' : ''}`}
           onClick={() => setActiveTool(activeTool === 'addImage' ? 'select' : 'addImage')}
           disabled={locked || !hasBackground}
-          style={{
-            background: FIELD_COLORS.image.toolbarBg,
-            color: FIELD_COLORS.image.toolbarFg,
-            borderColor: FIELD_COLORS.image.stroke,
-          }}
+          style={
+            activeTool === 'addImage' || selectedFieldTypes.has('image')
+              ? {
+                  background: FIELD_COLORS.image.stroke,
+                  color: '#fff',
+                  borderColor: FIELD_COLORS.image.stroke,
+                }
+              : {
+                  background: FIELD_COLORS.image.toolbarBg,
+                  color: FIELD_COLORS.image.toolbarFg,
+                  borderColor: FIELD_COLORS.image.stroke,
+                }
+          }
         >
           <svg
             width="14"
@@ -286,14 +302,22 @@ export function Toolbar() {
           Image
         </button>
         <button
-          className={`tg-btn ${activeTool === 'addLoop' ? 'tg-btn--active' : ''} ${selectedFieldTypes.has('table') ? 'tg-btn--selected-ring' : ''}`}
+          className={`tg-btn ${activeTool === 'addLoop' || selectedFieldTypes.has('table') ? 'tg-btn--active' : ''}`}
           onClick={() => setActiveTool(activeTool === 'addLoop' ? 'select' : 'addLoop')}
           disabled={locked || !hasBackground}
-          style={{
-            background: FIELD_COLORS.table.toolbarBg,
-            color: FIELD_COLORS.table.toolbarFg,
-            borderColor: FIELD_COLORS.table.stroke,
-          }}
+          style={
+            activeTool === 'addLoop' || selectedFieldTypes.has('table')
+              ? {
+                  background: FIELD_COLORS.table.stroke,
+                  color: '#fff',
+                  borderColor: FIELD_COLORS.table.stroke,
+                }
+              : {
+                  background: FIELD_COLORS.table.toolbarBg,
+                  color: FIELD_COLORS.table.toolbarFg,
+                  borderColor: FIELD_COLORS.table.stroke,
+                }
+          }
         >
           <svg
             width="14"

--- a/packages/ui/src/components/Toolbar/Toolbar.tsx
+++ b/packages/ui/src/components/Toolbar/Toolbar.tsx
@@ -28,6 +28,14 @@ export function Toolbar() {
   const toggleTheme = useUiStore((s) => s.toggleTheme)
   const activeTool = useUiStore((s) => s.activeTool)
   const setActiveTool = useUiStore((s) => s.setActiveTool)
+  const selectedFieldIds = useUiStore((s) => s.selectedFieldIds)
+  const fields = useTemplateStore((s) => s.fields)
+  // Set of field types present in the current selection — each matching
+  // toolbar button gets a ring so the user can see at a glance what types
+  // they have selected on the canvas.
+  const selectedFieldTypes = new Set(
+    fields.filter((f) => selectedFieldIds.includes(f.id)).map((f) => f.type),
+  )
   const showGrid = useUiStore((s) => s.showGrid)
   const setShowGrid = useUiStore((s) => s.setShowGrid)
   const showPreview = useUiStore((s) => s.showPreview)
@@ -230,7 +238,7 @@ export function Toolbar() {
       {/* Field tools */}
       <div className="tg-toolbar-group">
         <button
-          className={`tg-btn ${activeTool === 'addText' ? 'tg-btn--active' : ''}`}
+          className={`tg-btn ${activeTool === 'addText' ? 'tg-btn--active' : ''} ${selectedFieldTypes.has('text') ? 'tg-btn--selected-ring' : ''}`}
           onClick={() => setActiveTool(activeTool === 'addText' ? 'select' : 'addText')}
           disabled={locked || !hasBackground}
           style={{
@@ -254,7 +262,7 @@ export function Toolbar() {
           Text
         </button>
         <button
-          className={`tg-btn ${activeTool === 'addImage' ? 'tg-btn--active' : ''}`}
+          className={`tg-btn ${activeTool === 'addImage' ? 'tg-btn--active' : ''} ${selectedFieldTypes.has('image') ? 'tg-btn--selected-ring' : ''}`}
           onClick={() => setActiveTool(activeTool === 'addImage' ? 'select' : 'addImage')}
           disabled={locked || !hasBackground}
           style={{
@@ -278,7 +286,7 @@ export function Toolbar() {
           Image
         </button>
         <button
-          className={`tg-btn ${activeTool === 'addLoop' ? 'tg-btn--active' : ''}`}
+          className={`tg-btn ${activeTool === 'addLoop' ? 'tg-btn--active' : ''} ${selectedFieldTypes.has('table') ? 'tg-btn--selected-ring' : ''}`}
           onClick={() => setActiveTool(activeTool === 'addLoop' ? 'select' : 'addLoop')}
           disabled={locked || !hasBackground}
           style={{

--- a/packages/ui/src/theme/fieldColors.ts
+++ b/packages/ui/src/theme/fieldColors.ts
@@ -19,10 +19,19 @@ export interface FieldColorTokens {
   toolbarBg: string
   /** Toolbar button foreground / icon & label colour. */
   toolbarFg: string
+  /** Rect fill when the field is the active Fabric object (same hue as `fill`,
+   *  higher alpha for unmistakable emphasis). */
+  selectedFill: string
+  /** Rect stroke when the field is the active Fabric object (accent-shifted
+   *  from `stroke`). Pairs with `selectedStrokeWidth`. */
+  selectedStroke: string
   // String index signature so callers can iterate keys generically
   // (e.g. tests that loop over ["fill","stroke",...]). All tokens are strings.
   [k: string]: string
 }
+
+/** Stroke width applied to a field's background Rect while it is selected. */
+export const SELECTED_STROKE_WIDTH = 2.5
 
 /**
  * Canonical per-FieldType colour record. Consumers MUST import from this
@@ -36,6 +45,8 @@ export const FIELD_COLORS: Record<FieldType, FieldColorTokens> = {
     text: '#1e40af',
     toolbarBg: '#dbeafe',
     toolbarFg: '#1e40af',
+    selectedFill: 'rgba(96, 165, 250, 0.4)',
+    selectedStroke: '#1e40af',
   },
   image: {
     fill: 'rgba(74, 222, 128, 0.18)',
@@ -43,6 +54,8 @@ export const FIELD_COLORS: Record<FieldType, FieldColorTokens> = {
     text: '#166534',
     toolbarBg: '#dcfce7',
     toolbarFg: '#166534',
+    selectedFill: 'rgba(74, 222, 128, 0.4)',
+    selectedStroke: '#166534',
   },
   table: {
     fill: 'rgba(251, 146, 60, 0.18)',
@@ -50,5 +63,7 @@ export const FIELD_COLORS: Record<FieldType, FieldColorTokens> = {
     text: '#92400e',
     toolbarBg: '#fef3c7',
     toolbarFg: '#92400e',
+    selectedFill: 'rgba(251, 146, 60, 0.4)',
+    selectedStroke: '#92400e',
   },
 }


### PR DESCRIPTION
Closes #10.

## Summary
- Selected fields now swap to a stronger per-type colour palette (darker fill + thicker accent stroke) in addition to Fabric's default corner handles — the active field is obvious at a glance, even in a crowded template.
- Fields with a transparent default fill (static or image-with-placeholder, per REQ-047) get stroke-only emphasis so a rendered image isn't painted over.
- Multi-select (shift+click, drag-rectangle) emphasizes every member of the active selection independently; `preserveObjectStacking` is untouched so z-order does not change on selection.
- Emphasis survives reconciliation — after a drag/resize the bgRect is rebuilt, but `applyFieldToGroup` re-applies the current selection visuals so the active field stays lit.

## How
- `FIELD_COLORS` gets `selectedFill` (same hue, 0.4 alpha) and `selectedStroke` (accent-shifted) per type. `SELECTED_STROKE_WIDTH = 2.5`.
- Each field Group's bgRect stores its default fill/stroke/strokeWidth via module-augmented fabric props (`__defaultFill` / `__defaultStroke` / `__defaultStrokeWidth`).
- `applySelectionVisuals(group, selected)` toggles between default and selected-state tokens.
- `syncSelectionEmphasis(canvas)` diffs against `canvas.getActiveObjects()` and updates every field group in one pass; wired into `selection:created` / `selection:updated` / `selection:cleared`.

## Test plan
- [x] `pnpm --filter template-goblin-ui type-check` green.
- [x] Pre-commit + pre-push hooks green.
- [x] New `packages/ui/e2e/selection-emphasis.spec.ts` covers: unselected baseline, single click, switching selection, empty-canvas clear, shift+click multi-select.
- [ ] Manual verification pending your approval before merge.