### PR TITLE
fix(ui): labels render at max-fit size with auto re-fit on resize (#12)

### DIFF
--- a/.changeset/label-max-fit.md
+++ b/.changeset/label-max-fit.md
@@ -1,0 +1,5 @@
+---
+'template-goblin-ui': minor
+---
+
+Static and placeholder field labels now render at the largest font size that fits their bounding rectangle and re-fit automatically when the field is resized. The previous implementation clipped labels to a sliver of their intended area (users saw "tiny vertical lines" instead of real text). Switched from `FabricText` + `clipPath` to a centred `Textbox` that wraps to the rect's width, with the font-size ceiling raised so big rects get big type. Closes #12.

--- a/packages/ui/e2e/label-max-fit.spec.ts
+++ b/packages/ui/e2e/label-max-fit.spec.ts
@@ -1,0 +1,224 @@
+/**
+ * E2E coverage for GH issue #12 — static / placeholder labels must render
+ * at the largest possible font size that fits their bounding rect, and must
+ * re-fit when the field is resized.
+ *
+ * Regression target: the old implementation rendered labels through a
+ * `FabricText` with an `absolutePositioned: false` clipPath whose origin
+ * landed at the text's centre, effectively hiding most characters behind a
+ * thin slice. Users saw "tiny vertical lines" instead of legible text.
+ */
+import type { Page } from '@playwright/test'
+import { test, expect } from '@playwright/test'
+
+test.describe.configure({ mode: 'serial' })
+
+interface SeedField {
+  id: string
+  x: number
+  y: number
+  width: number
+  height: number
+  zIndex: number
+}
+
+const SEEDS: SeedField[] = [
+  // Large dynamic text — should get a generous fontSize.
+  { id: 'big', x: 40, y: 40, width: 260, height: 160, zIndex: 0 },
+  // Narrow — width-limited, font should shrink accordingly.
+  { id: 'narrow', x: 320, y: 40, width: 60, height: 160, zIndex: 1 },
+  // Short — height-limited.
+  { id: 'short', x: 40, y: 220, width: 260, height: 30, zIndex: 2 },
+]
+
+const TEXT_STYLE = {
+  fontId: null,
+  fontFamily: 'Helvetica',
+  fontSize: 12,
+  fontSizeDynamic: false,
+  fontSizeMin: 8,
+  lineHeight: 1.2,
+  fontWeight: 'normal',
+  fontStyle: 'normal',
+  textDecoration: 'none',
+  color: '#000000',
+  align: 'left',
+  verticalAlign: 'top',
+  maxRows: 2,
+  overflowMode: 'truncate',
+  snapToGrid: false,
+}
+
+async function seedTemplate(page: Page): Promise<void> {
+  const payload = {
+    state: {
+      meta: {
+        schemaVersion: 1,
+        name: 'label-max-fit-test',
+        version: '0.0.0',
+        width: 600,
+        height: 500,
+        locked: false,
+      },
+      fields: SEEDS.map((s) => ({
+        id: s.id,
+        label: s.id,
+        type: 'text',
+        groupId: null,
+        pageId: null,
+        x: s.x,
+        y: s.y,
+        width: s.width,
+        height: s.height,
+        zIndex: s.zIndex,
+        // Use a non-trivial placeholder so the label is obvious on the canvas.
+        source: { mode: 'dynamic', jsonKey: s.id, required: false, placeholder: 'Hello' },
+        style: TEXT_STYLE,
+      })),
+      fonts: [],
+      groups: [],
+      pages: [
+        {
+          id: 'page-0',
+          index: 0,
+          backgroundType: 'color',
+          backgroundColor: '#ffffff',
+          backgroundFilename: null,
+        },
+      ],
+      backgroundDataUrl: null,
+      backgroundBuffer: null,
+      pageBackgroundDataUrls: [],
+      pageBackgroundBuffers: [],
+      fontBuffers: [],
+      placeholderBuffers: [],
+      staticImageBuffers: [],
+      staticImageDataUrls: [],
+    },
+    version: 2,
+  }
+  await page.addInitScript((seed: string) => {
+    localStorage.setItem('template-goblin-template', seed)
+    localStorage.removeItem('template-goblin-ui')
+  }, JSON.stringify(payload))
+}
+
+function fabricCanvas(page: Page) {
+  return page.locator('[data-testid="canvas-stage-wrapper"] canvas').first()
+}
+
+interface LabelInfo {
+  fontSize: number
+  charCount: number
+  width: number
+}
+
+/** Read the current fontSize + text + width of a field Group's label child. */
+async function readFieldLabel(page: Page, fieldId: string): Promise<LabelInfo> {
+  return await page.evaluate((id) => {
+    interface FabricLike {
+      getObjects: () => Array<{
+        __fieldId?: string
+        getObjects?: () => Array<{
+          fontSize?: number
+          text?: string
+          width?: number
+        }>
+      }>
+    }
+    const fc = (window as unknown as { __fabricCanvas?: FabricLike }).__fabricCanvas
+    if (!fc) throw new Error('Fabric canvas not ready')
+    const group = fc.getObjects().find((o) => o.__fieldId === id)
+    if (!group || !group.getObjects) throw new Error(`group ${id} missing`)
+    // Children: [bgRect, ...maybeImage..., label].  Label is the Textbox —
+    // find it by the presence of a `text` property.
+    const children = group.getObjects()
+    const label = children.find((c) => typeof c.text === 'string' && (c.text as string).length > 0)
+    if (!label) throw new Error(`label for ${id} missing`)
+    return {
+      fontSize: label.fontSize ?? 0,
+      charCount: (label.text ?? '').length,
+      width: label.width ?? 0,
+    }
+  }, fieldId)
+}
+
+test.describe('Label max-fit (#12)', () => {
+  test.beforeEach(async ({ page }) => {
+    await seedTemplate(page)
+    await page.goto('/')
+    await expect(fabricCanvas(page)).toBeVisible({ timeout: 5000 })
+    await expect
+      .poll(
+        () =>
+          page.evaluate(() => !!(window as unknown as { __fabricCanvas?: unknown }).__fabricCanvas),
+        { timeout: 5000 },
+      )
+      .toBe(true)
+  })
+
+  test('large rect produces a big font size (not the old 8pt floor)', async ({ page }) => {
+    const info = await readFieldLabel(page, 'big')
+    expect(info.charCount).toBeGreaterThan(0)
+    // A 260×160 rect with "Hello" should comfortably fit > 40pt.
+    expect(info.fontSize).toBeGreaterThan(40)
+  })
+
+  test('narrow rect produces a smaller font size than the wide one', async ({ page }) => {
+    const big = await readFieldLabel(page, 'big')
+    const narrow = await readFieldLabel(page, 'narrow')
+    expect(narrow.fontSize).toBeLessThan(big.fontSize)
+    expect(narrow.fontSize).toBeGreaterThanOrEqual(8)
+  })
+
+  test('short rect produces a font bounded by height', async ({ page }) => {
+    const info = await readFieldLabel(page, 'short')
+    // Height is 30pt, max is floor(30*0.8) = 24.
+    expect(info.fontSize).toBeLessThanOrEqual(24)
+    expect(info.fontSize).toBeGreaterThanOrEqual(8)
+  })
+
+  test('resizing a field re-fits the label font', async ({ page }) => {
+    const before = await readFieldLabel(page, 'big')
+
+    // Shrink the field via the store — triggers the same reconciliation
+    // path as a drag-resize.
+    await page.evaluate((id) => {
+      interface Store {
+        getState: () => { resizeField: (id: string, w: number, h: number) => void }
+      }
+      const tpl = (window as unknown as { __templateStore?: Store }).__templateStore
+      // Fallback: reach into zustand via any exposed hook — if the store
+      // isn't exposed globally, use a Fabric-driven resize instead.
+      if (tpl?.getState) {
+        tpl.getState().resizeField(id, 80, 40)
+      } else {
+        // Resize via Fabric directly, then trigger object:modified.
+        interface FabricLike {
+          getObjects: () => Array<{
+            __fieldId?: string
+            set?: (props: Record<string, number>) => void
+            setCoords?: () => void
+            fire?: (ev: string, opt: Record<string, unknown>) => void
+          }>
+          fire?: (ev: string, opt: Record<string, unknown>) => void
+        }
+        const fc = (window as unknown as { __fabricCanvas?: FabricLike }).__fabricCanvas
+        if (!fc) throw new Error('no fabric canvas')
+        const g = fc.getObjects().find((o) => o.__fieldId === id)
+        if (!g) throw new Error(`no group ${id}`)
+        g.set?.({ width: 80, height: 40, scaleX: 1, scaleY: 1 })
+        g.setCoords?.()
+        fc.fire?.('object:modified', { target: g })
+      }
+    }, 'big')
+
+    await expect
+      .poll(async () => (await readFieldLabel(page, 'big')).fontSize)
+      .toBeLessThan(before.fontSize)
+
+    const after = await readFieldLabel(page, 'big')
+    expect(after.fontSize).toBeGreaterThanOrEqual(8)
+    expect(after.fontSize).toBeLessThan(before.fontSize)
+  })
+})

--- a/packages/ui/src/components/Canvas/fabricUtils.ts
+++ b/packages/ui/src/components/Canvas/fabricUtils.ts
@@ -18,10 +18,13 @@
  *  non-evented) so they pan and zoom with the Fabric viewport transform. A CSS
  *  background-image alternative would not move with the viewport.
  *
- *  ITEXT_CHOICE: we use `FabricText` (read-only) rather than `IText` for field
- *  labels because IText fires keyboard events and enters edit mode on double-
- *  click, interfering with the right-panel workflow. Full inline editing via
- *  IText could be added per-field in a future iteration.
+ *  ITEXT_CHOICE: we use `Textbox` (read-only, auto-wrap) rather than `IText`
+ *  for field labels because IText fires keyboard events and enters edit mode
+ *  on double-click, interfering with the right-panel workflow. Textbox is
+ *  preferred over plain `FabricText` because it wraps to its `width`, which
+ *  lets us fit the largest possible font size for the bounding rect (GH #12).
+ *  Full inline editing via IText could be added per-field in a future
+ *  iteration.
  *
  *  ORIGIN: every Group uses `originX: 'left', originY: 'top'` so `group.left`
  *  and `group.top` directly equal the field's `x` and `y` in page pt.
@@ -32,7 +35,7 @@
  *  box math stays in sync.
  */
 
-import { Rect, Group, FabricText, FabricImage, Point, Line } from 'fabric'
+import { Rect, Group, Textbox, FabricImage, Point, Line } from 'fabric'
 import type { FabricObject } from 'fabric'
 import type { FieldDefinition } from '@template-goblin/types'
 import { FIELD_COLORS, SELECTED_STROKE_WIDTH } from '../../theme/fieldColors.js'
@@ -74,9 +77,13 @@ function getMeasureCtx(): CanvasRenderingContext2D | null {
   return _measureCtx
 }
 
+/** Maximum font size the label auto-fit will return. */
+const LABEL_MAX_FONT_SIZE = 160
+
 /**
  * Fit font size to a bounding rect using greedy word-wrap and binary search.
- * Returns a size in the range [8, min(48, rectHeight * 0.8)].
+ * Returns the largest integer size in `[8, min(LABEL_MAX_FONT_SIZE, rectHeight * 0.8)]`
+ * such that the wrapped text fits within `rectWidth × rectHeight`.
  */
 function fitFontSize(
   text: string,
@@ -86,9 +93,9 @@ function fitFontSize(
 ): number {
   if (!text || rectWidth <= 0 || rectHeight <= 0) return 8
   const ctx = getMeasureCtx()
-  if (!ctx) return Math.max(8, Math.min(48, Math.floor(rectHeight * 0.4)))
+  if (!ctx) return Math.max(8, Math.min(LABEL_MAX_FONT_SIZE, Math.floor(rectHeight * 0.6)))
 
-  const upper = Math.max(8, Math.min(48, Math.floor(rectHeight * 0.8)))
+  const upper = Math.max(8, Math.min(LABEL_MAX_FONT_SIZE, Math.floor(rectHeight * 0.8)))
   let lo = 8
   let hi = upper
   let best = 8
@@ -587,37 +594,38 @@ export function buildGroupChildren(
     })
   }
 
-  // 3. Auto-fit label (REQ-044, REQ-045) — skipped when an image is rendered.
+  // 3. Auto-fit label (GH #12) — skipped when an image is rendered.
+  //    Uses a centred `Textbox` (wraps to `labelW`) rather than a plain
+  //    `FabricText` with a clipPath.  The previous clipPath approach was
+  //    fragile: Fabric positions clipPath relative to the clipped object's
+  //    centre, so a clipPath at (0, 0) with origin top-left could sit
+  //    entirely below the text and effectively hide it.  Textbox + centre
+  //    origin + a sensible fontSize upper bound gives a reliable
+  //    "max-fit" label that rerenders correctly when the field is
+  //    resized (`applyFieldToGroup` rebuilds children on every field
+  //    update, so fontSize is recomputed against the new bounds).
   if (!placeholderResolved) {
     const label = fieldCanvasLabel(field)
     if (label) {
       const innerPad = 6
-      const labelW = Math.max(0, w - innerPad * 2)
-      const labelH = Math.max(0, h - innerPad * 2)
+      const labelW = Math.max(1, w - innerPad * 2)
+      const labelH = Math.max(1, h - innerPad * 2)
       const fontSize = fitFontSize(label, labelW, labelH, 'sans-serif')
       if (fontSize >= 8) {
-        const textObj = new FabricText(label, {
-          left: innerPad,
-          top: innerPad,
+        const textObj = new Textbox(label, {
+          left: w / 2,
+          top: h / 2,
+          width: labelW,
           fontSize,
           fontFamily: 'sans-serif',
           fill: colors.text,
-          width: labelW,
-          textAlign: 'left',
+          textAlign: 'center',
           selectable: false,
           evented: false,
-          originX: 'left',
-          originY: 'top',
-          // Prevent the text from overflowing the bounding rect.
-          clipPath: new Rect({
-            left: 0,
-            top: 0,
-            width: labelW,
-            height: labelH,
-            absolutePositioned: false,
-            originX: 'left',
-            originY: 'top',
-          }),
+          originX: 'center',
+          originY: 'center',
+          splitByGrapheme: false,
+          lineHeight: 1.2,
         })
         children.push(textObj)
       }


### PR DESCRIPTION
Closes #12.

## Summary
- Placeholder / static field labels now render at the **largest font size that fits** the bounding rect instead of showing as tiny vertical slivers.
- Resizing a field **re-fits the font** automatically via the existing reconciliation path (`applyFieldToGroup` rebuilds children on every field update).
- Font-size ceiling raised from 48 → 160 so big rectangles get big type.

## How
- Swapped `fabric.FabricText` + `clipPath` for a centred `fabric.Textbox`. The old clipPath had `originX/originY: 'left'/'top'` at `(0, 0)` but Fabric positions clipPath relative to the clipped object's **centre** — so the clip sat below the text and hid most glyphs, leaving only the "tiny vertical lines" the user reported.
- Textbox wraps to `width: labelW`, so multi-word labels break naturally and the fit algorithm picks the biggest size that still fits both width and height.

## Test plan
- [x] `pnpm --filter template-goblin-ui type-check`
- [x] `pnpm --filter template-goblin-ui test` — 305/305 passing
- [x] New `packages/ui/e2e/label-max-fit.spec.ts` covers: (a) big rect → big font, (b) narrow rect → smaller than the wide one, (c) short rect → bounded by height, (d) shrinking via store decreases the rendered fontSize.
- [ ] Manual verification pending your approval.

Changeset: `.changeset/label-max-fit.md` (minor).