### PR TITLE
fix(ci): build template-goblin before the UI in deploy-ui workflow (#16)

### DIFF
--- a/.github/workflows/deploy-ui.yml
+++ b/.github/workflows/deploy-ui.yml
@@ -38,6 +38,12 @@ jobs:
       - name: Build types
         run: pnpm --filter @template-goblin/types build
 
+      - name: Build core (template-goblin)
+        # The UI imports `template-goblin/validateManifest` (subpath export)
+        # whose `.d.ts` lives under `packages/core/dist/`. Without this step
+        # the UI's `tsc` fails with TS2307 in CI — see GH issue #16.
+        run: pnpm --filter template-goblin build
+
       - name: Build UI for GitHub Pages
         run: pnpm --filter template-goblin-ui build
         env:


### PR DESCRIPTION
Closes #16.

## Problem
Every push to \`main\` was failing the **Deploy UI to GitHub Pages** action with:

\`\`\`
src/utils/saveOpen.ts(4,34): error TS2307: Cannot find module 'template-goblin/validateManifest' or its corresponding type declarations.
\`\`\`

Run 24892460382 (after PR #15 merge) is the latest casualty.

## Root cause
The UI imports \`template-goblin/validateManifest\` — a subpath export declared in \`packages/core/package.json\` that resolves to \`./dist/validateManifest.d.ts\`. In CI, \`deploy-ui.yml\` only built \`@template-goblin/types\` before running \`pnpm --filter template-goblin-ui build\`, so \`packages/core/dist/\` never existed and tsc couldn't resolve the subpath. Locally it appeared fine because \`dist/\` was left over from prior builds.

## Fix
Added a **Build core (template-goblin)** step between Build types and Build UI. Single extra step; no other changes.

## Local verification
Replayed the CI sequence from a clean state (\`rm -rf packages/*/dist && pnpm install --frozen-lockfile\`):
- \`pnpm --filter @template-goblin/types build\` → ✓
- \`pnpm --filter template-goblin build\` → ✓  (new)
- \`pnpm --filter template-goblin-ui build\` with \`VITE_BASE=/template-goblin/\` → ✓

Also ran the full **CI** workflow sequence locally:
- \`pnpm type-check\` → 5/5 green
- \`pnpm lint\` → 3/3 green
- \`pnpm --filter template-goblin test\` → 255/255 tests across 26 suites
- \`pnpm --filter template-goblin-ui test\` → 305/305 tests across 20 files
- \`pnpm build\` → 3/3 green

## Test plan
- [x] Local reproduction of the failure (clean state) then local fix verification.
- [ ] CI run on this PR — merging will retrigger the Deploy UI workflow on main; confirm it goes green.