### PR TITLE
fix(ui): canvas visible immediately after onboarding on first visit (#17)

### DIFF
--- a/.changeset/first-visit-canvas.md
+++ b/.changeset/first-visit-canvas.md
@@ -1,0 +1,5 @@
+---
+'template-goblin-ui': patch
+---
+
+Fix the canvas appearing invisible on a first-time visit until a page refresh. The root cause was that `useFabricSync`'s effects (ResizeObserver in particular) depended on stable `RefObject` identities for the container and canvas, so when the onboarding picker unmounted and the canvas subtree mounted in its place, the observer stayed bound to the orphaned onboarding `<div>` and never reported the real canvas container's dimensions — Fabric kept its 800×600 fallback instead of resizing to the actual container. The Fabric canvas instance and container element are now mirrored into React state; every effect that used to depend on the ref objects now depends on those state mirrors, so they correctly re-run when the DOM swaps. Closes #17.

--- a/packages/ui/src/components/Canvas/CanvasArea.tsx
+++ b/packages/ui/src/components/Canvas/CanvasArea.tsx
@@ -9,7 +9,7 @@
  *   - OnboardingPicker → empty-state onboarding
  *   - AddPageDialog    → add-page dialog
  */
-import React, { useRef, useCallback } from 'react'
+import React, { useRef, useCallback, useState } from 'react'
 import { useTemplateStore } from '../../store/templateStore.js'
 import { useUiStore } from '../../store/uiStore.js'
 import { FieldCreationPopup } from './FieldCreationPopup.js'
@@ -103,11 +103,16 @@ export function CanvasArea() {
 
   // ── Refs ───────────────────────────────────────────────────────────────
   const containerRef = useRef<HTMLDivElement | null>(null)
+  // State mirror of containerRef.current — effects that must react to the
+  // container element changing (e.g. the ResizeObserver setup) depend on
+  // this. Without it, the observer stays attached to the onboarding picker
+  // after the canvas subtree mounts (GH #17).
+  const [containerEl, setContainerEl] = useState<HTMLDivElement | null>(null)
 
   // ── Custom hooks ───────────────────────────────────────────────────────
   const pageHandlers = usePageHandlers()
 
-  const { fabricRef, setCanvasEl, spacePanModeRef } = useFabricCanvas(
+  const { fabricRef, fabricInstance, setCanvasEl, spacePanModeRef } = useFabricCanvas(
     containerRef,
     pageHandlers.setPendingDraft,
   )
@@ -131,7 +136,9 @@ export function CanvasArea() {
   // ── Sync effects ───────────────────────────────────────────────────────
   useFabricSync({
     fabricRef,
+    fabricInstance,
     containerRef,
+    containerEl,
     pageFields,
     bgImage,
     currentBgColor,
@@ -147,6 +154,7 @@ export function CanvasArea() {
   // ── Container ref callback (for OnboardingPicker compatibility) ────────
   const setContainerRef = useCallback((el: HTMLDivElement | null) => {
     containerRef.current = el
+    setContainerEl(el)
   }, [])
 
   // ═══════════════════════════════════════════════════════════════════════

--- a/packages/ui/src/components/Canvas/useFabricCanvas.ts
+++ b/packages/ui/src/components/Canvas/useFabricCanvas.ts
@@ -6,7 +6,7 @@
  *
  * Returns `{ fabricRef, setCanvasEl }` to be consumed by CanvasArea.
  */
-import { useRef, useCallback } from 'react'
+import { useRef, useCallback, useState } from 'react'
 import {
   Canvas as FabricCanvas,
   Rect as FabricRect,
@@ -30,6 +30,14 @@ import {
 export interface FabricCanvasHandle {
   /** Ref to the live Fabric canvas instance (null before mount). */
   fabricRef: React.RefObject<FabricCanvas | null>
+  /**
+   * State mirror of `fabricRef.current`. Effects that react to the canvas
+   * being created or disposed MUST depend on this (refs have stable identity
+   * and don't re-fire deps). Introduced to fix GH #17 — the ResizeObserver
+   * and auto-fit effects were attached to the onboarding picker on first
+   * render and never re-ran after the canvas subtree mounted.
+   */
+  fabricInstance: FabricCanvas | null
   /** Ref-callback for the <canvas> element. */
   setCanvasEl: (el: HTMLCanvasElement | null) => void
   /** Ref for pan-mode state (read/written by keyboard handler). */
@@ -43,6 +51,9 @@ export function useFabricCanvas(
   setPendingDraft: React.Dispatch<React.SetStateAction<FieldCreationDraft | null>>,
 ): FabricCanvasHandle {
   const fabricRef = useRef<FabricCanvas | null>(null)
+  // State mirror of fabricRef — used by effects as a dep so they re-run when
+  // the Fabric instance is created or disposed (fixes GH #17).
+  const [fabricInstance, setFabricInstance] = useState<FabricCanvas | null>(null)
 
   // Draw-to-create state (refs for perf — no re-render during gestures)
   const drawStartRef = useRef<{ x: number; y: number } | null>(null)
@@ -59,6 +70,7 @@ export function useFabricCanvas(
       if (fabricRef.current) {
         fabricRef.current.dispose()
         fabricRef.current = null
+        setFabricInstance(null)
       }
       if (!el) return
 
@@ -82,6 +94,7 @@ export function useFabricCanvas(
         fireRightClick: true,
       })
       fabricRef.current = fc
+      setFabricInstance(fc)
 
       // Expose for Playwright / dev-mode inspection
       if (import.meta.env.DEV) {
@@ -123,7 +136,7 @@ export function useFabricCanvas(
     [setPendingDraft, containerRef],
   )
 
-  return { fabricRef, setCanvasEl, spacePanModeRef }
+  return { fabricRef, fabricInstance, setCanvasEl, spacePanModeRef }
 }
 
 // ─── Event wiring helpers (pure functions, no hooks) ─────────────────────────

--- a/packages/ui/src/components/Canvas/useFabricSync.ts
+++ b/packages/ui/src/components/Canvas/useFabricSync.ts
@@ -28,7 +28,20 @@ import {
 
 export interface SyncDeps {
   fabricRef: React.RefObject<FabricCanvas | null>
+  /**
+   * State mirror of `fabricRef.current`. Effects that react to canvas
+   * creation/disposal MUST depend on this — refs have stable identity and
+   * don't trigger dep re-fires (GH #17).
+   */
+  fabricInstance: FabricCanvas | null
   containerRef: React.RefObject<HTMLDivElement | null>
+  /**
+   * State mirror of `containerRef.current`. Effects that must re-attach to
+   * a new container element (e.g. the ResizeObserver) depend on this so the
+   * observer doesn't stay bound to the unmounted onboarding picker on the
+   * first visit (GH #17).
+   */
+  containerEl: HTMLDivElement | null
   pageFields: FieldDefinition[]
   bgImage: HTMLImageElement | null
   currentBgColor: string | null
@@ -46,7 +59,9 @@ export interface SyncDeps {
 export function useFabricSync(deps: SyncDeps) {
   const {
     fabricRef,
+    fabricInstance,
     containerRef,
+    containerEl,
     pageFields,
     bgImage,
     currentBgColor,
@@ -96,7 +111,7 @@ export function useFabricSync(deps: SyncDeps) {
     })
 
     fc.requestRenderAll()
-  }, [fabricRef, pageFields, resolveImage])
+  }, [fabricRef, fabricInstance, pageFields, resolveImage])
 
   // ═══════════════ Selection sync: store → canvas ═════════════════════════
   useEffect(() => {
@@ -131,7 +146,7 @@ export function useFabricSync(deps: SyncDeps) {
       }
     }
     fc.requestRenderAll()
-  }, [fabricRef, selectedFieldIds])
+  }, [fabricRef, fabricInstance, selectedFieldIds])
 
   // ═══════════════ Background sync (REQ-034, AC-001) ═════════════════════
   useEffect(() => {
@@ -161,7 +176,7 @@ export function useFabricSync(deps: SyncDeps) {
       fc.backgroundColor = ''
     }
     fc.requestRenderAll()
-  }, [fabricRef, bgImage, currentBgColor, meta.width, meta.height])
+  }, [fabricRef, fabricInstance, bgImage, currentBgColor, meta.width, meta.height])
 
   // ═══════════════ Grid sync (REQ-009, AC-008) ═══════════════════════════
   useEffect(() => {
@@ -177,7 +192,7 @@ export function useFabricSync(deps: SyncDeps) {
       lines.forEach((l) => fc.sendObjectToBack(l))
     }
     fc.requestRenderAll()
-  }, [fabricRef, showGrid, gridSize, meta.width, meta.height])
+  }, [fabricRef, fabricInstance, showGrid, gridSize, meta.width, meta.height])
 
   // ═══════════════ Zoom sync: store → canvas (REQ-037..042) ══════════════
   useEffect(() => {
@@ -190,7 +205,7 @@ export function useFabricSync(deps: SyncDeps) {
     const vpt = centreViewport(zoom, meta.width, meta.height, canW, canH)
     fc.setViewportTransform(vpt)
     fc.requestRenderAll()
-  }, [fabricRef, zoom, meta.width, meta.height])
+  }, [fabricRef, fabricInstance, zoom, meta.width, meta.height])
 
   // ═══════════════ Auto-fit Zoom on Meta Change ══════════════════════════
   useEffect(() => {
@@ -201,18 +216,21 @@ export function useFabricSync(deps: SyncDeps) {
     const canH = containerRef.current?.clientHeight ?? fc.height ?? 600
     const z = fitZoomLevel(meta.width, meta.height, canW, canH, 40)
     useUiStore.getState().setZoom(z)
-  }, [fabricRef, containerRef, meta.width, meta.height])
+  }, [fabricRef, fabricInstance, containerRef, containerEl, meta.width, meta.height])
 
   // ═══════════════ Resize observer ═══════════════════════════════════════
+  // Depend on `containerEl` (state mirror) and `fabricInstance` rather than
+  // the ref objects — refs have stable identity so the old implementation
+  // stayed bound to the onboarding picker's <div> after the canvas subtree
+  // mounted on the first visit (GH #17).
   useEffect(() => {
-    const container = containerRef.current
-    if (!container) return
+    if (!containerEl || !fabricInstance) return
 
     const observer = new ResizeObserver(() => {
       const fc = fabricRef.current
       if (!fc) return
-      const w = container.clientWidth
-      const h = container.clientHeight
+      const w = containerEl.clientWidth
+      const h = containerEl.clientHeight
       fc.setDimensions({ width: w, height: h })
 
       const z = fc.getZoom()
@@ -223,9 +241,9 @@ export function useFabricSync(deps: SyncDeps) {
         fc.requestRenderAll()
       }
     })
-    observer.observe(container)
+    observer.observe(containerEl)
     return () => observer.disconnect()
-  }, [fabricRef, containerRef])
+  }, [fabricRef, fabricInstance, containerEl])
 
   // ═══════════════ Cursor sync (REQ-043) ═════════════════════════════════
   useEffect(() => {
@@ -238,7 +256,7 @@ export function useFabricSync(deps: SyncDeps) {
       fc.defaultCursor = 'default'
       fc.hoverCursor = 'move'
     }
-  }, [fabricRef, isPlacing])
+  }, [fabricRef, fabricInstance, isPlacing])
 }
 
 // ─── Standalone hooks for background & placeholder image loading ─────────────


### PR DESCRIPTION
Closes #17.

## Problem
On a first visit (clean localStorage), completing onboarding via solid colour OR image upload left the canvas blank. A page refresh fixed it. Reported by user.

## Root cause
\`useFabricSync\`'s effects depended on the **stable RefObject identities** of the Fabric canvas and container DOM elements. React never re-fires dep arrays on \`.current\` value changes, so when the onboarding picker unmounted and the canvas subtree mounted in its place, the \`ResizeObserver\` stayed bound to the orphaned onboarding \`<div>\` and never reported the real canvas container's dimensions. Fabric kept its 800×600 fallback; the real container (after the side panels appeared) was a different size; the page rendered outside the visible viewport.

After a refresh the app started in the canvas branch directly (no onboarding transition), so the observer was attached to the right element from the start.

## Fix
Mirror \`fabricRef.current\` and \`containerRef.current\` into React state via \`useState\`. Every effect in \`useFabricSync\` that previously depended on the ref objects now depends on the state mirrors (\`fabricInstance\`, \`containerEl\`), so they correctly re-run when either element is swapped in the DOM. The \`setCanvasEl\` ref callback and \`setContainerRef\` ref callback update both the ref AND the state. Refs are kept for synchronous access by event handlers.

## Test plan
- [x] \`pnpm --filter template-goblin-ui type-check\` green
- [x] \`pnpm --filter template-goblin-ui test\` — 305/305 passing
- [x] \`pnpm --filter template-goblin-ui lint\` green
- [x] Existing e2e specs (onboarding-to-canvas, selection-emphasis, label-max-fit) are unaffected
- [ ] Manual: clear localStorage, open the UI, pick a solid colour → canvas visible immediately with no refresh; upload an image → same.

Changeset: \`.changeset/first-visit-canvas.md\` (patch).