### PR TITLE
feat(ui): restructure sidebars — styling left, structure right, hamburger toggles (#19)

### DIFF
--- a/.changeset/sidebar-restructure.md
+++ b/.changeset/sidebar-restructure.md
@@ -1,0 +1,5 @@
+---
+'template-goblin-ui': minor
+---
+
+Sidebar layout restructure. The styling / properties editor now lives in the **left** sidebar (it used to be on the right) and the structural tree — field + group list, JSON preview, and PDF size estimate — now lives in the **right** sidebar. Two hamburger buttons in the toolbar (one at each end) fully collapse the matching panel, and the canvas expands to fill any freed width. Selecting a field still auto-opens the panel that contains its properties; the collapse state persists across reloads via the existing `uiStore` persist. Closes #19.

--- a/packages/ui/e2e/selection-and-move.spec.ts
+++ b/packages/ui/e2e/selection-and-move.spec.ts
@@ -405,10 +405,12 @@ function describeSweep(title: string, buildSeeds: (count: number) => SeedField[]
         })
       }
 
-      test(`clicking any field shows the right panel`, async ({ page }) => {
+      test(`clicking any field shows the properties (left) panel`, async ({ page }) => {
         const c = await centerOfFieldInViewport(page, seeds[0]!.id)
         await page.mouse.click(c.x, c.y)
-        await expect(page.locator('.tg-right-panel')).toBeVisible()
+        // Under the GH #19 layout the properties editor lives on the left
+        // and `selectAndFocus` auto-opens the left panel.
+        await expect(page.locator('.tg-left-panel')).toBeVisible()
       })
     })
   }

--- a/packages/ui/src/App.css
+++ b/packages/ui/src/App.css
@@ -128,7 +128,11 @@ html, body, #root {
 
 /* ===== Panels ===== */
 .tg-left-panel {
-  @apply relative shrink-0 flex flex-col overflow-y-auto;
+  /* `overflow: hidden` on the OUTER panel prevents the browser scrollbar
+   * from landing on the right edge where the resize handle lives (any
+   * overlap would eat the handle's mousedown and make the panel
+   * non-resizable — GH #19 follow-up). Scrolling moves to `.tg-panel-scroll`. */
+  @apply relative shrink-0 flex flex-col overflow-hidden;
   min-width: 180px; max-width: 400px;
   background: var(--bg-secondary);
   border-right: 1px solid var(--border);
@@ -141,10 +145,18 @@ html, body, #root {
 }
 
 .tg-right-panel {
-  @apply relative shrink-0 overflow-y-auto;
+  /* Same reasoning as `.tg-left-panel` — keep the scrollbar off the edge
+   * that holds the resize handle. */
+  @apply relative shrink-0 flex flex-col overflow-hidden;
   min-width: 220px; max-width: 500px;
   background: var(--bg-secondary);
   border-left: 1px solid var(--border);
+}
+
+/* Inner scroll container used by both sidebars so the outer panel can
+ * keep its edges free for the resize handle. */
+.tg-panel-scroll {
+  @apply flex-1 overflow-y-auto min-h-0;
 }
 
 .tg-panel-section {

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -48,8 +48,11 @@ export function App() {
           <div className="tg-left-panel" style={{ width: leftWidth }}>
             {/* Left panel now renders the styling/properties editor for the
                 active selection (GH #19 — content swapped with the right
-                panel). */}
-            <PropertiesPanel />
+                panel). The scrollable content is wrapped so the outer
+                panel's right edge stays free for the resize handle. */}
+            <div className="tg-panel-scroll">
+              <PropertiesPanel />
+            </div>
             <ResizeHandle
               side="right"
               width={leftWidth}
@@ -90,8 +93,12 @@ export function App() {
               max={500}
             />
             {/* Right panel now renders the structural tree — field list +
-                JSON preview + PDF size estimate (GH #19). */}
-            <StructurePanel />
+                JSON preview + PDF size estimate (GH #19). Scrollable
+                content wrapped so the outer panel edge stays free for the
+                resize handle. */}
+            <div className="tg-panel-scroll">
+              <StructurePanel />
+            </div>
           </div>
         )}
       </div>

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1,8 +1,8 @@
 import { useState } from 'react'
 import { Toolbar } from './components/Toolbar/Toolbar.js'
-import { LeftPanel } from './components/LeftPanel/FieldList.js'
+import { PropertiesPanel } from './components/LeftPanel/PropertiesPanel.js'
 import { CanvasArea } from './components/Canvas/CanvasArea.js'
-import { RightPanel } from './components/RightPanel/RightPanel.js'
+import { StructurePanel } from './components/RightPanel/StructurePanel.js'
 import { PageSizeDialog } from './components/Toolbar/PageSizeDialog.js'
 import { ContextMenu } from './components/Canvas/ContextMenu.js'
 import { FontManager } from './components/Toolbar/FontManager.js'
@@ -46,7 +46,10 @@ export function App() {
       <div className="tg-workspace">
         {hasBackground && showLeftPanel && (
           <div className="tg-left-panel" style={{ width: leftWidth }}>
-            <LeftPanel />
+            {/* Left panel now renders the styling/properties editor for the
+                active selection (GH #19 — content swapped with the right
+                panel). */}
+            <PropertiesPanel />
             <ResizeHandle
               side="right"
               width={leftWidth}
@@ -86,7 +89,9 @@ export function App() {
               min={220}
               max={500}
             />
-            <RightPanel />
+            {/* Right panel now renders the structural tree — field list +
+                JSON preview + PDF size estimate (GH #19). */}
+            <StructurePanel />
           </div>
         )}
       </div>

--- a/packages/ui/src/components/Canvas/useFabricCanvas.ts
+++ b/packages/ui/src/components/Canvas/useFabricCanvas.ts
@@ -166,7 +166,10 @@ function wireSelectionEvents(fc: FabricCanvas) {
         if (onlyId) useUiStore.getState().selectAndFocus(onlyId)
       } else {
         useUiStore.getState().selectFields(ids)
-        useUiStore.getState().setShowRightPanel(true)
+        // Multi-select still wants the properties panel visible so the user
+        // can see "Multiple fields selected" context. Under GH #19 that
+        // panel lives on the left.
+        useUiStore.getState().setShowLeftPanel(true)
       }
     }
     // Visual emphasis reflects the canvas active-object set regardless of

--- a/packages/ui/src/components/LeftPanel/PropertiesPanel.tsx
+++ b/packages/ui/src/components/LeftPanel/PropertiesPanel.tsx
@@ -1,0 +1,46 @@
+import { useTemplateStore } from '../../store/templateStore.js'
+import { useUiStore } from '../../store/uiStore.js'
+import { TextFieldProps } from '../RightPanel/TextFieldProps.js'
+import { ImageFieldProps } from '../RightPanel/ImageFieldProps.js'
+import { LoopFieldProps } from '../RightPanel/LoopFieldProps.js'
+
+/**
+ * Left-panel content under the new layout (GH #19): the styling / properties
+ * editor for the currently selected field. The old sidebar layout had these
+ * controls on the right; they moved to the left so the canvas and the
+ * structural tree (field list + JSON preview) sit side-by-side on the right.
+ */
+export function PropertiesPanel() {
+  const selectedIds = useUiStore((s) => s.selectedFieldIds)
+  const fields = useTemplateStore((s) => s.fields)
+
+  const selectedField =
+    selectedIds.length === 1 ? (fields.find((f) => f.id === selectedIds[0]) ?? null) : null
+
+  if (selectedField === null) {
+    return (
+      <div className="tg-panel-section">
+        <div
+          style={{
+            color: 'var(--text-muted)',
+            fontSize: 12,
+            textAlign: 'center',
+            padding: '24px 8px',
+          }}
+        >
+          {selectedIds.length > 1
+            ? 'Multiple fields selected'
+            : 'Select a field to edit its properties'}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <>
+      {selectedField.type === 'text' && <TextFieldProps field={selectedField} />}
+      {selectedField.type === 'image' && <ImageFieldProps field={selectedField} />}
+      {selectedField.type === 'table' && <LoopFieldProps field={selectedField} />}
+    </>
+  )
+}

--- a/packages/ui/src/components/RightPanel/StructurePanel.tsx
+++ b/packages/ui/src/components/RightPanel/StructurePanel.tsx
@@ -1,0 +1,20 @@
+import { LeftPanel as FieldList } from '../LeftPanel/FieldList.js'
+import { JsonPreview } from './JsonPreview.js'
+import { PdfSizeEstimate } from './PdfSizeEstimate.js'
+
+/**
+ * Right-panel content under the new layout (GH #19): the structural view
+ * of the template — the field + group list, the JSON preview, and the
+ * PDF size estimate. The styling controls moved to the left panel
+ * (`PropertiesPanel`). The field list component is still exported as
+ * `LeftPanel` from its original file; re-aliased here to avoid a rename.
+ */
+export function StructurePanel() {
+  return (
+    <>
+      <FieldList />
+      <JsonPreview />
+      <PdfSizeEstimate />
+    </>
+  )
+}

--- a/packages/ui/src/components/Toolbar/Toolbar.tsx
+++ b/packages/ui/src/components/Toolbar/Toolbar.tsx
@@ -30,6 +30,10 @@ export function Toolbar() {
   const setActiveTool = useUiStore((s) => s.setActiveTool)
   const selectedFieldIds = useUiStore((s) => s.selectedFieldIds)
   const fields = useTemplateStore((s) => s.fields)
+  const showLeftPanel = useUiStore((s) => s.showLeftPanel)
+  const setShowLeftPanel = useUiStore((s) => s.setShowLeftPanel)
+  const showRightPanelUi = useUiStore((s) => s.showRightPanel)
+  const setShowRightPanelUi = useUiStore((s) => s.setShowRightPanel)
   // Set of field types present in the current selection — each matching
   // toolbar button gets a ring so the user can see at a glance what types
   // they have selected on the canvas.
@@ -199,7 +203,34 @@ export function Toolbar() {
 
   return (
     <div className="tg-toolbar">
-      {/* Open / Upload — leftmost */}
+      {/* Left-sidebar hamburger — toggles the styling / properties panel. */}
+      <div className="tg-toolbar-group">
+        <button
+          className={`tg-btn ${showLeftPanel ? 'tg-btn--active' : ''}`}
+          onClick={() => setShowLeftPanel(!showLeftPanel)}
+          title={showLeftPanel ? 'Hide properties panel' : 'Show properties panel'}
+          data-testid="toolbar-toggle-left-panel"
+          aria-pressed={showLeftPanel}
+          aria-label="Toggle properties panel"
+        >
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+          >
+            <line x1="3" y1="6" x2="21" y2="6" />
+            <line x1="3" y1="12" x2="21" y2="12" />
+            <line x1="3" y1="18" x2="21" y2="18" />
+          </svg>
+        </button>
+      </div>
+
+      <div className="tg-toolbar-separator" />
+
+      {/* Open / Upload — leftmost of the action groups */}
       <div className="tg-toolbar-group">
         <button className="tg-btn" onClick={handleOpen}>
           <svg
@@ -488,6 +519,31 @@ export function Toolbar() {
         </svg>
         {locked ? 'Unlock' : 'Lock'}
       </button>
+
+      {/* Right-sidebar hamburger — toggles the structure / JSON panel. */}
+      <button
+        className={`tg-btn ${showRightPanelUi ? 'tg-btn--active' : ''}`}
+        onClick={() => setShowRightPanelUi(!showRightPanelUi)}
+        title={showRightPanelUi ? 'Hide structure panel' : 'Show structure panel'}
+        data-testid="toolbar-toggle-right-panel"
+        aria-pressed={showRightPanelUi}
+        aria-label="Toggle structure panel"
+      >
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+        >
+          <line x1="3" y1="6" x2="21" y2="6" />
+          <line x1="3" y1="12" x2="21" y2="12" />
+          <line x1="3" y1="18" x2="21" y2="18" />
+        </svg>
+      </button>
+
+      <div className="tg-toolbar-separator" />
 
       {/* Save — last, green */}
       <button

--- a/packages/ui/src/store/__tests__/uiStore.test.ts
+++ b/packages/ui/src/store/__tests__/uiStore.test.ts
@@ -368,59 +368,59 @@ describe('uiStore', () => {
   /*  so users saw no feedback.                                              */
   /* --------------------------------------------------------------------- */
   describe('selectAndFocus', () => {
-    it('selects the field and opens the right panel', () => {
-      useUiStore.setState({ showRightPanel: false, selectedFieldIds: [] })
+    it('selects the field and opens the properties (left) panel', () => {
+      useUiStore.setState({ showLeftPanel: false, selectedFieldIds: [] })
       useUiStore.getState().selectAndFocus('field-42')
       const s = useUiStore.getState()
       expect(s.selectedFieldIds).toEqual(['field-42'])
-      expect(s.showRightPanel).toBe(true)
+      expect(s.showLeftPanel).toBe(true)
     })
 
     it('replaces any prior selection with just the new id', () => {
-      useUiStore.setState({ selectedFieldIds: ['a', 'b', 'c'], showRightPanel: true })
+      useUiStore.setState({ selectedFieldIds: ['a', 'b', 'c'], showLeftPanel: true })
       useUiStore.getState().selectAndFocus('field-x')
       expect(useUiStore.getState().selectedFieldIds).toEqual(['field-x'])
     })
 
-    it('leaves showRightPanel=true untouched when it is already true', () => {
-      useUiStore.setState({ showRightPanel: true, selectedFieldIds: [] })
+    it('leaves showLeftPanel=true untouched when it is already true', () => {
+      useUiStore.setState({ showLeftPanel: true, selectedFieldIds: [] })
       useUiStore.getState().selectAndFocus('f1')
-      expect(useUiStore.getState().showRightPanel).toBe(true)
+      expect(useUiStore.getState().showLeftPanel).toBe(true)
     })
 
-    it('always flips showRightPanel from false to true (fixes silent-selection bug)', () => {
-      useUiStore.setState({ showRightPanel: false, selectedFieldIds: ['f0'] })
+    it('always flips showLeftPanel from false to true (fixes silent-selection bug)', () => {
+      useUiStore.setState({ showLeftPanel: false, selectedFieldIds: ['f0'] })
       useUiStore.getState().selectAndFocus('f1')
       const s = useUiStore.getState()
-      expect(s.showRightPanel).toBe(true)
+      expect(s.showLeftPanel).toBe(true)
       expect(s.selectedFieldIds).toEqual(['f1'])
     })
 
     it('canvas click path: simulating handleFieldClick single-click produces select + panel open', () => {
       // Mirror of what CanvasArea.handleFieldClick does when the user clicks
       // a field's rect without shift.
-      useUiStore.setState({ showRightPanel: false, selectedFieldIds: [] })
+      useUiStore.setState({ showLeftPanel: false, selectedFieldIds: [] })
       useUiStore.getState().selectAndFocus('field-click')
       expect(useUiStore.getState().selectedFieldIds).toEqual(['field-click'])
-      expect(useUiStore.getState().showRightPanel).toBe(true)
+      expect(useUiStore.getState().showLeftPanel).toBe(true)
     })
 
-    it('left-panel click path: clicking a list row runs the same action', () => {
-      // Mirror of what LeftPanel.FieldList onSelect handler does.
-      useUiStore.setState({ showRightPanel: false, selectedFieldIds: [] })
+    it('field-list click path: clicking a list row runs the same action', () => {
+      // Mirror of what the field list onSelect handler does.
+      useUiStore.setState({ showLeftPanel: false, selectedFieldIds: [] })
       useUiStore.getState().selectAndFocus('field-from-list')
       expect(useUiStore.getState().selectedFieldIds).toEqual(['field-from-list'])
-      expect(useUiStore.getState().showRightPanel).toBe(true)
+      expect(useUiStore.getState().showLeftPanel).toBe(true)
     })
 
     it('double-click path: same action — no drift between single and double click semantics', () => {
-      useUiStore.setState({ showRightPanel: false, selectedFieldIds: [] })
+      useUiStore.setState({ showLeftPanel: false, selectedFieldIds: [] })
       // handleFieldDblClick also reduces to selectAndFocus. Two rapid calls
-      // (Konva fires click then dblclick) must converge on the same state.
+      // (single then double) must converge on the same state.
       useUiStore.getState().selectAndFocus('field-dbl')
       useUiStore.getState().selectAndFocus('field-dbl')
       expect(useUiStore.getState().selectedFieldIds).toEqual(['field-dbl'])
-      expect(useUiStore.getState().showRightPanel).toBe(true)
+      expect(useUiStore.getState().showLeftPanel).toBe(true)
     })
   })
 
@@ -460,7 +460,7 @@ describe('uiStore', () => {
   /* --------------------------------------------------------------------- */
   describe('select any of N elements regression', () => {
     it('5 sequentially created field ids are each selectable without bias', () => {
-      useUiStore.setState({ selectedFieldIds: [], showRightPanel: false })
+      useUiStore.setState({ selectedFieldIds: [], showLeftPanel: false })
 
       const ids = ['f-1', 'f-2', 'f-3', 'f-4', 'f-5']
 
@@ -468,7 +468,7 @@ describe('uiStore', () => {
         useUiStore.getState().selectAndFocus(id)
         const s = useUiStore.getState()
         expect(s.selectedFieldIds).toEqual([id])
-        expect(s.showRightPanel).toBe(true)
+        expect(s.showLeftPanel).toBe(true)
       }
     })
 
@@ -486,31 +486,31 @@ describe('uiStore', () => {
       expect(useUiStore.getState().selectedFieldIds).not.toContain('f-1')
     })
 
-    it('left-panel selection path for 5 elements matches canvas path', () => {
-      // Both the canvas mousedown handler and the left-panel list handler
-      // route through selectAndFocus — assert that end-state is identical
-      // when the user picks the Nth element via either route.
+    it('list selection path for 5 elements matches canvas path', () => {
+      // Both the canvas mousedown handler and the structure-panel list
+      // handler route through selectAndFocus — assert that end-state is
+      // identical when the user picks the Nth element via either route.
       const ids = ['a', 'b', 'c', 'd', 'e']
 
       // Canvas route
-      useUiStore.setState({ selectedFieldIds: [], showRightPanel: false })
+      useUiStore.setState({ selectedFieldIds: [], showLeftPanel: false })
       useUiStore.getState().selectAndFocus(ids[2]!)
       const canvasState = {
         selectedFieldIds: [...useUiStore.getState().selectedFieldIds],
-        showRightPanel: useUiStore.getState().showRightPanel,
+        showLeftPanel: useUiStore.getState().showLeftPanel,
       }
 
-      // Left-panel route
-      useUiStore.setState({ selectedFieldIds: [], showRightPanel: false })
+      // List route
+      useUiStore.setState({ selectedFieldIds: [], showLeftPanel: false })
       useUiStore.getState().selectAndFocus(ids[2]!)
-      const leftPanelState = {
+      const listState = {
         selectedFieldIds: [...useUiStore.getState().selectedFieldIds],
-        showRightPanel: useUiStore.getState().showRightPanel,
+        showLeftPanel: useUiStore.getState().showLeftPanel,
       }
 
-      expect(canvasState).toEqual(leftPanelState)
+      expect(canvasState).toEqual(listState)
       expect(canvasState.selectedFieldIds).toEqual(['c'])
-      expect(canvasState.showRightPanel).toBe(true)
+      expect(canvasState.showLeftPanel).toBe(true)
     })
 
     it('shift+click builds multi-selection uniformly — any element can join', () => {

--- a/packages/ui/src/store/uiStore.ts
+++ b/packages/ui/src/store/uiStore.ts
@@ -53,12 +53,11 @@ export interface UiState {
   toggleFieldSelection: (id: string) => void
   clearSelection: () => void
   /**
-   * Select a single field AND ensure its properties panel is visible. This is
-   * the canonical "user picks an element" action: a click on the canvas, a
-   * click on the left-panel list, or a double-click all ultimately reduce to
-   * this. Keeping the two store updates in one action prevents selection+panel
-   * drift (old bug: single-click on canvas only ran `selectField` and the
-   * right panel stayed hidden, so users believed the click had done nothing).
+   * Select a single field AND ensure the properties panel (left under
+   * GH #19) is visible. This is the canonical "user picks an element"
+   * action: a click on the canvas, a click on the structure-panel list,
+   * or a double-click all ultimately reduce to this. Keeping the two
+   * store updates in one action prevents selection+panel drift.
    */
   selectAndFocus: (id: string) => void
   setActiveTool: (tool: ActiveTool) => void
@@ -125,7 +124,10 @@ export const useUiStore = create<UiState>()(
       drawStart: null,
 
       selectField: (id) => set({ selectedFieldIds: [id] }),
-      selectAndFocus: (id) => set({ selectedFieldIds: [id], showRightPanel: true }),
+      // The properties panel lives on the LEFT under the GH #19 layout —
+      // picking a field must make the left panel visible so the user can
+      // see and edit its properties. (Pre-#19 this flipped showRightPanel.)
+      selectAndFocus: (id) => set({ selectedFieldIds: [id], showLeftPanel: true }),
       selectFields: (ids) => set({ selectedFieldIds: ids }),
       toggleFieldSelection: (id) =>
         set((state) => {


### PR DESCRIPTION
Closes #19.

## Summary
- **Left** sidebar now hosts the styling / properties editor (what used to be on the right). New \`components/LeftPanel/PropertiesPanel.tsx\`.
- **Right** sidebar now hosts the structural tree — field + group list, JSON preview, PDF size estimate. New \`components/RightPanel/StructurePanel.tsx\`.
- Two **hamburger toggles** added to the toolbar, one at each end. They fully collapse the matching sidebar; the canvas expands to fill the freed width. Collapse state is persisted across reloads (existing \`uiStore\` persist).
- \`selectAndFocus\` (and the Fabric multi-select handler) now auto-open the LEFT panel instead of the right so picking a field still surfaces its properties.

## Test plan
- [x] \`pnpm --filter template-goblin-ui type-check\` green
- [x] \`pnpm --filter template-goblin-ui lint\` green
- [x] \`pnpm --filter template-goblin-ui test\` — 307/307 passing (updated \`uiStore.test.ts\` assertions to expect \`showLeftPanel\` instead of \`showRightPanel\`)
- [x] Playwright \`selection-and-move.spec.ts\` updated: the \"clicking a field shows the properties panel\" assertion now targets \`.tg-left-panel\`
- [ ] Manual verification pending your approval.

Changeset: \`.changeset/sidebar-restructure.md\` (minor).