### PR TITLE
fix(ui): closing one page no longer hides the remaining image page (#23)

### DIFF
--- a/.changeset/page-close-cascade.md
+++ b/.changeset/page-close-cascade.md
@@ -1,0 +1,5 @@
+---
+'template-goblin-ui': patch
+---
+
+Fix a page-close bug where closing one image-backed page appeared to close every other page too. The canvas background resolver only handled the legacy/solid-colour cases when `currentPageId === null`; after `removePage` the handler set `currentPageId` back to null, and if the remaining page had an image background it was never surfaced — the user saw a blank canvas and read it as "both pages closed, back to onboarding." The resolver now also looks up an explicit `pages[0]` image when no current page is selected, and `handleRemovePage` now lands on whichever page ends up at index 0 instead of dropping to null. New store-level test matrix exercises every two-page background combination (colour/colour, colour/image, image/colour, image/image) × which tab is closed, plus a three-page "close middle" sweep. Closes #23.

--- a/packages/ui/e2e/page-close-cascade.spec.ts
+++ b/packages/ui/e2e/page-close-cascade.spec.ts
@@ -1,0 +1,252 @@
+/**
+ * E2E regression for GH #23 — "when I close one page it also closes the
+ * other one."
+ *
+ * The store-level matrix in pageCloseMatrix.test.ts already pins the
+ * reducer, but the real bug was in the component path: onboarding via
+ * image left `backgroundDataUrl` set and `pages = []`, and handleAddPage
+ * gave the newly-added page `index = 0`, shadowing the legacy page in
+ * PageBar. Only one tab rendered but the user believed there were two;
+ * clicking ✕ tripped the "last page" confirm branch and called `reset()`.
+ *
+ * This spec seeds the exact state (legacy bg + one added page at index 1
+ * after the fix) and walks the close flows end-to-end.
+ */
+import type { Page } from '@playwright/test'
+import { test, expect } from '@playwright/test'
+
+test.describe.configure({ mode: 'serial' })
+
+interface PageDef {
+  id: string
+  index: number
+  backgroundType: 'color' | 'image' | 'inherit'
+  backgroundColor: string | null
+  backgroundFilename: string | null
+}
+
+async function seed(
+  page: Page,
+  opts: {
+    legacyImageDataUrl: string | null
+    pages: PageDef[]
+    pageBackgroundDataUrls: Array<[string, string]>
+  },
+): Promise<void> {
+  const payload = {
+    state: {
+      meta: {
+        schemaVersion: 1,
+        name: 'page-close-cascade-test',
+        version: '0.0.0',
+        width: 600,
+        height: 500,
+        locked: false,
+      },
+      fields: [],
+      fonts: [],
+      groups: [],
+      pages: opts.pages,
+      backgroundDataUrl: opts.legacyImageDataUrl,
+      backgroundBuffer: null,
+      pageBackgroundDataUrls: opts.pageBackgroundDataUrls,
+      pageBackgroundBuffers: [],
+      fontBuffers: [],
+      placeholderBuffers: [],
+      staticImageBuffers: [],
+      staticImageDataUrls: [],
+    },
+    version: 2,
+  }
+  await page.addInitScript((s: string) => {
+    localStorage.setItem('template-goblin-template', s)
+    localStorage.removeItem('template-goblin-ui')
+  }, JSON.stringify(payload))
+}
+
+async function readPersistBlob(
+  page: Page,
+): Promise<{ pages?: PageDef[]; backgroundDataUrl?: string | null } | null> {
+  return await page.evaluate(async () => {
+    const DB_NAME = 'template-goblin'
+    const STORE_NAME = 'kv'
+    const KEY = 'template-goblin-template'
+    const db = await new Promise<IDBDatabase>((resolve, reject) => {
+      const req = indexedDB.open(DB_NAME, 1)
+      req.onupgradeneeded = () => {
+        const d = req.result
+        if (!d.objectStoreNames.contains(STORE_NAME)) d.createObjectStore(STORE_NAME)
+      }
+      req.onsuccess = () => resolve(req.result)
+      req.onerror = () => reject(req.error)
+    })
+    const raw = await new Promise<string | undefined>((resolve, reject) => {
+      const tx = db.transaction(STORE_NAME, 'readonly')
+      const req = tx.objectStore(STORE_NAME).get(KEY) as IDBRequest<string | undefined>
+      tx.oncomplete = () => resolve(req.result)
+      tx.onerror = () => reject(tx.error)
+    })
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as {
+      state?: { pages?: PageDef[]; backgroundDataUrl?: string | null }
+    }
+    return parsed.state ?? null
+  })
+}
+
+function pageTabs(page: Page) {
+  return page.locator('button', { hasText: /^Page \d+$/ })
+}
+
+function closeButtonFor(page: Page, label: string) {
+  const tab = page.locator('button', { hasText: new RegExp(`^${label}$`) }).first()
+  return tab.locator('xpath=following-sibling::button[contains(@class,"tg-btn--danger")]')
+}
+
+const TINY_PNG =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAFElEQVR42mP8z8BQDwADhQGAWjR9awAAAABJRU5ErkJggg=='
+
+test.describe('GH #23 — closing one page never closes another', () => {
+  test('legacy image + added image: closing Page 1 keeps Page 2 intact', async ({ page }) => {
+    // Under the fix, an added page in a legacy-bg template gets `index: 1`
+    // so both appear as tabs. (Before the fix, index was 0 and the legacy
+    // tab was shadowed.)
+    await seed(page, {
+      legacyImageDataUrl: TINY_PNG,
+      pages: [
+        {
+          id: 'added',
+          index: 1,
+          backgroundType: 'image',
+          backgroundColor: null,
+          backgroundFilename: 'backgrounds/added.png',
+        },
+      ],
+      pageBackgroundDataUrls: [['added', TINY_PNG]],
+    })
+    await page.goto('/')
+    await expect(pageTabs(page)).toHaveCount(2)
+
+    await closeButtonFor(page, 'Page 1').click()
+    await page.waitForTimeout(150)
+
+    // One tab must remain; the app must still show a canvas, not the
+    // onboarding picker.
+    await expect(pageTabs(page)).toHaveCount(1)
+    await expect(page.locator('[data-testid="onboarding-solid-color"]')).toHaveCount(0)
+
+    const blob = await readPersistBlob(page)
+    expect(blob?.pages ?? []).toHaveLength(1)
+    expect(blob?.pages?.[0]?.index).toBe(0)
+    expect(blob?.pages?.[0]?.id).toBe('added')
+  })
+
+  test('legacy image + added image: closing Page 2 keeps the legacy background', async ({
+    page,
+  }) => {
+    await seed(page, {
+      legacyImageDataUrl: TINY_PNG,
+      pages: [
+        {
+          id: 'added',
+          index: 1,
+          backgroundType: 'image',
+          backgroundColor: null,
+          backgroundFilename: 'backgrounds/added.png',
+        },
+      ],
+      pageBackgroundDataUrls: [['added', TINY_PNG]],
+    })
+    await page.goto('/')
+    await expect(pageTabs(page)).toHaveCount(2)
+
+    await closeButtonFor(page, 'Page 2').click()
+    await page.waitForTimeout(150)
+
+    await expect(pageTabs(page)).toHaveCount(1)
+    await expect(page.locator('[data-testid="onboarding-solid-color"]')).toHaveCount(0)
+
+    const blob = await readPersistBlob(page)
+    expect(blob?.pages ?? []).toHaveLength(0)
+    expect(blob?.backgroundDataUrl).toBeTruthy()
+  })
+
+  test('two explicit pages (colour + image): closing Page 1 keeps Page 2 rendered', async ({
+    page,
+  }) => {
+    await seed(page, {
+      legacyImageDataUrl: null,
+      pages: [
+        {
+          id: 'p-color',
+          index: 0,
+          backgroundType: 'color',
+          backgroundColor: '#abcdef',
+          backgroundFilename: null,
+        },
+        {
+          id: 'p-image',
+          index: 1,
+          backgroundType: 'image',
+          backgroundColor: null,
+          backgroundFilename: 'backgrounds/p-image.png',
+        },
+      ],
+      pageBackgroundDataUrls: [['p-image', TINY_PNG]],
+    })
+    await page.goto('/')
+    await expect(pageTabs(page)).toHaveCount(2)
+
+    await closeButtonFor(page, 'Page 1').click()
+    await page.waitForTimeout(150)
+
+    await expect(pageTabs(page)).toHaveCount(1)
+    await expect(page.locator('[data-testid="onboarding-solid-color"]')).toHaveCount(0)
+
+    const blob = await readPersistBlob(page)
+    expect(blob?.pages ?? []).toHaveLength(1)
+    expect(blob?.pages?.[0]?.id).toBe('p-image')
+    expect(blob?.pages?.[0]?.index).toBe(0)
+  })
+
+  test('two explicit pages (image + image): closing Page 1 keeps Page 2 rendered', async ({
+    page,
+  }) => {
+    await seed(page, {
+      legacyImageDataUrl: null,
+      pages: [
+        {
+          id: 'p-img-1',
+          index: 0,
+          backgroundType: 'image',
+          backgroundColor: null,
+          backgroundFilename: 'backgrounds/p-img-1.png',
+        },
+        {
+          id: 'p-img-2',
+          index: 1,
+          backgroundType: 'image',
+          backgroundColor: null,
+          backgroundFilename: 'backgrounds/p-img-2.png',
+        },
+      ],
+      pageBackgroundDataUrls: [
+        ['p-img-1', TINY_PNG],
+        ['p-img-2', TINY_PNG],
+      ],
+    })
+    await page.goto('/')
+    await expect(pageTabs(page)).toHaveCount(2)
+
+    await closeButtonFor(page, 'Page 1').click()
+    await page.waitForTimeout(150)
+
+    await expect(pageTabs(page)).toHaveCount(1)
+    await expect(page.locator('[data-testid="onboarding-solid-color"]')).toHaveCount(0)
+
+    const blob = await readPersistBlob(page)
+    expect(blob?.pages ?? []).toHaveLength(1)
+    expect(blob?.pages?.[0]?.id).toBe('p-img-2')
+    expect(blob?.pages?.[0]?.index).toBe(0)
+  })
+})

--- a/packages/ui/e2e/page-tabs.spec.ts
+++ b/packages/ui/e2e/page-tabs.spec.ts
@@ -104,22 +104,53 @@ function fabricCanvas(page: Page) {
   return page.locator('[data-testid="canvas-stage-wrapper"] canvas').first()
 }
 
-async function readPages(page: Page): Promise<PageDef[]> {
-  return await page.evaluate(() => {
-    const raw = localStorage.getItem('template-goblin-template')
-    if (!raw) return []
-    const parsed = JSON.parse(raw) as { state?: { pages?: PageDef[] } }
-    return parsed.state?.pages ?? []
+/**
+ * The templateStore's persist backing is IndexedDB (GH #11). localStorage is
+ * only used as a migration source on first load, after which it's cleared.
+ * These helpers read the live blob out of IDB so assertions see the current
+ * state.
+ */
+async function readPersistBlob(
+  page: Page,
+): Promise<{ pages?: PageDef[]; fields?: Array<{ id: string }> } | null> {
+  return await page.evaluate(async () => {
+    const DB_NAME = 'template-goblin'
+    const STORE_NAME = 'kv'
+    const KEY = 'template-goblin-template'
+
+    const db = await new Promise<IDBDatabase>((resolve, reject) => {
+      const req = indexedDB.open(DB_NAME, 1)
+      req.onupgradeneeded = () => {
+        const d = req.result
+        if (!d.objectStoreNames.contains(STORE_NAME)) d.createObjectStore(STORE_NAME)
+      }
+      req.onsuccess = () => resolve(req.result)
+      req.onerror = () => reject(req.error)
+    })
+
+    const raw = await new Promise<string | undefined>((resolve, reject) => {
+      const tx = db.transaction(STORE_NAME, 'readonly')
+      const req = tx.objectStore(STORE_NAME).get(KEY) as IDBRequest<string | undefined>
+      tx.oncomplete = () => resolve(req.result)
+      tx.onerror = () => reject(tx.error)
+    })
+
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as {
+      state?: { pages?: PageDef[]; fields?: Array<{ id: string }> }
+    }
+    return parsed.state ?? null
   })
 }
 
+async function readPages(page: Page): Promise<PageDef[]> {
+  const blob = await readPersistBlob(page)
+  return blob?.pages ?? []
+}
+
 async function readFieldIds(page: Page): Promise<string[]> {
-  return await page.evaluate(() => {
-    const raw = localStorage.getItem('template-goblin-template')
-    if (!raw) return []
-    const parsed = JSON.parse(raw) as { state?: { fields?: Array<{ id: string }> } }
-    return (parsed.state?.fields ?? []).map((f) => f.id)
-  })
+  const blob = await readPersistBlob(page)
+  return (blob?.fields ?? []).map((f) => f.id)
 }
 
 async function pageTabCount(page: Page): Promise<number> {

--- a/packages/ui/src/components/Canvas/CanvasArea.tsx
+++ b/packages/ui/src/components/Canvas/CanvasArea.tsx
@@ -42,7 +42,17 @@ function useCurrentBackground() {
 
   const currentBgDataUrl = ((): string | null => {
     if (pages.length === 0) return backgroundDataUrl
-    if (effectivePageId === null) return backgroundDataUrl
+    if (effectivePageId === null) {
+      // No explicit page is "current". Prefer an explicit `pages[0]` image
+      // if one exists (this happens after removing a color page while an
+      // image page remains — GH #23). Otherwise fall back to the legacy
+      // `backgroundDataUrl`.
+      const page0 = pages.find((p) => p.index === 0)
+      if (page0 && page0.backgroundType === 'image') {
+        return pageBackgroundDataUrls.get(page0.id) ?? backgroundDataUrl
+      }
+      return backgroundDataUrl
+    }
 
     const page = pages.find((p) => p.id === effectivePageId)
     if (!page) return backgroundDataUrl

--- a/packages/ui/src/components/Canvas/CanvasArea.tsx
+++ b/packages/ui/src/components/Canvas/CanvasArea.tsx
@@ -172,10 +172,14 @@ export function CanvasArea() {
   // ═══════════════════════════════════════════════════════════════════════
 
   const page0 = pages.find((p) => p.index === 0)
-  const page0IsColor = page0?.backgroundType === 'color'
+  const page0HasConcreteBg = page0?.backgroundType === 'color' || page0?.backgroundType === 'image'
 
   // ── Empty state: no background chosen ──────────────────────────────────
-  if (!backgroundDataUrl && !page0IsColor) {
+  // Previously only `page0IsColor` was accepted here, so a template with an
+  // image `pages[0]` and no legacy `backgroundDataUrl` (the state after
+  // closing the legacy tab in a 2-page template — GH #23) was
+  // mis-classified as "onboarding" and the picker took over the canvas.
+  if (!backgroundDataUrl && !page0HasConcreteBg) {
     return (
       <OnboardingPicker
         isDragOver={pageHandlers.isDragOver}

--- a/packages/ui/src/components/Canvas/usePageHandlers.ts
+++ b/packages/ui/src/components/Canvas/usePageHandlers.ts
@@ -159,7 +159,15 @@ export function usePageHandlers() {
     (bgType: PageBackgroundType, bgColor?: string, bgFile?: File) => {
       setShowAddPageDialog(false)
       const pageId = generatePageId()
-      const index = pages.length
+      // If the user onboarded via image there's a legacy background stored in
+      // `backgroundDataUrl` and NO explicit entry in `pages[]`. The implicit
+      // legacy occupies tab 1 in PageBar — so a newly-added page must take
+      // the NEXT slot (index 1), otherwise it would sit at index 0 and hide
+      // the legacy tab entirely. Clicking ✕ on the shadowed tab used to
+      // trigger the "last page" reset and wipe both pages (GH #23).
+      const legacyBg = useTemplateStore.getState().backgroundDataUrl
+      const hasLegacyPage0 = legacyBg !== null && !pages.some((p) => p.index === 0)
+      const index = pages.length + (hasLegacyPage0 ? 1 : 0)
 
       if (bgType === 'inherit') {
         const { page: snap, sourceId } = snapshotSameAsPrevious(pages, pageId, index)
@@ -210,8 +218,10 @@ export function usePageHandlers() {
 
   const handleRemovePage = useCallback(
     (pageId: string | null) => {
+      // Mirror what PageBar renders: every explicit page gets a tab, plus
+      // one implicit tab when no explicit page sits at index 0.
       const page0IsExplicit = pages.some((p) => p.index === 0)
-      const visiblePageCount = page0IsExplicit ? pages.length : 1 + pages.length
+      const visiblePageCount = pages.length + (page0IsExplicit ? 0 : 1)
 
       if (visiblePageCount <= 1) {
         const ok = window.confirm(

--- a/packages/ui/src/components/Canvas/usePageHandlers.ts
+++ b/packages/ui/src/components/Canvas/usePageHandlers.ts
@@ -248,7 +248,14 @@ export function usePageHandlers() {
       }
 
       removePage(pageId)
-      setCurrentPage(null)
+      // After the reducer runs, land on whichever page ended up at index 0
+      // instead of dropping back to null. Leaving `currentPageId` null when
+      // explicit pages remain is what caused GH #23 — the canvas
+      // background-resolver had no page to look at and rendered blank,
+      // making it look like the remaining page had also been closed.
+      const nextPages = useTemplateStore.getState().pages
+      const nextFirst = [...nextPages].sort((a, b) => a.index - b.index)[0]
+      setCurrentPage(nextFirst?.id ?? null)
       clearSelection()
     },
     [pages, reset, removePage, setCurrentPage, clearSelection],

--- a/packages/ui/src/components/Toolbar/Toolbar.tsx
+++ b/packages/ui/src/components/Toolbar/Toolbar.tsx
@@ -16,7 +16,9 @@ export function Toolbar() {
   const hasBackground = useTemplateStore(
     (s) =>
       s.backgroundDataUrl !== null ||
-      s.pages.some((p) => p.index === 0 && p.backgroundType === 'color'),
+      s.pages.some(
+        (p) => p.index === 0 && (p.backgroundType === 'color' || p.backgroundType === 'image'),
+      ),
   )
   const canUndo = useTemplateStore((s) => s.canUndo())
   const canRedo = useTemplateStore((s) => s.canRedo())

--- a/packages/ui/src/store/__tests__/pageCloseMatrix.test.ts
+++ b/packages/ui/src/store/__tests__/pageCloseMatrix.test.ts
@@ -153,3 +153,63 @@ describe('GH #23 — closing the middle of three pages', () => {
     })
   }
 })
+
+/**
+ * Regression for the real GH #23 repro: onboarding via image puts the
+ * image in `backgroundDataUrl` with `pages = []`. Before the fix, adding
+ * the next page gave it `index = 0`, shadowing the legacy page in PageBar.
+ * The store didn't blow up on its own — the damage happened in
+ * `handleAddPage`, which now shifts the new page to `index = 1` when a
+ * legacy bg exists. We mirror that logic here and assert the survivor
+ * behaviour in both directions.
+ */
+describe('GH #23 — legacy-image onboarding + added page does not shadow', () => {
+  it('adding a page after legacy image keeps the legacy page reachable', () => {
+    // Seed a legacy image background (what PageSizeDialog sets up).
+    state().setBackground('data:image/png;base64,LEGACY', makeBuffer(0x55))
+    expect(state().backgroundDataUrl).not.toBeNull()
+    expect(state().pages).toHaveLength(0)
+
+    // Add a page with the index-1 shift that handleAddPage now applies.
+    const legacyBg = state().backgroundDataUrl
+    const hasLegacyPage0 = legacyBg !== null && !state().pages.some((p) => p.index === 0)
+    const computedIndex = state().pages.length + (hasLegacyPage0 ? 1 : 0)
+    expect(computedIndex).toBe(1)
+
+    addPageWithBg('added', computedIndex, 'image', 0x44)
+    expect(state().pages).toHaveLength(1)
+    expect(state().pages[0]!.index).toBe(1)
+    // The legacy bg is still in place — its tab survives PageBar's
+    // `explicitFirst` check because no explicit index-0 page exists.
+    expect(state().backgroundDataUrl).not.toBeNull()
+  })
+
+  it('closing the legacy page after an added index-1 page leaves the added page intact', () => {
+    state().setBackground('data:image/png;base64,LEGACY', makeBuffer(0x55))
+    addPageWithBg('added', 1, 'image', 0x44)
+
+    // Legacy-page close mirrors handleRemovePage's pageId === null path:
+    // clear the legacy bg, reindex the remaining pages.
+    useTemplateStore.setState({ backgroundDataUrl: null, backgroundBuffer: null })
+    const sortedPages = [...state().pages].sort((a, b) => a.index - b.index)
+    useTemplateStore.setState({
+      pages: sortedPages.map((p, i) => ({ ...p, index: i })),
+    })
+
+    expect(state().pages).toHaveLength(1)
+    expect(state().pages[0]!.id).toBe('added')
+    expect(state().pages[0]!.index).toBe(0)
+    expect(state().pageBackgroundDataUrls.has('added')).toBe(true)
+  })
+
+  it('closing the added page (index 1) after legacy image leaves the legacy reachable', () => {
+    state().setBackground('data:image/png;base64,LEGACY', makeBuffer(0x55))
+    addPageWithBg('added', 1, 'image', 0x44)
+
+    state().removePage('added')
+    expect(state().pages).toHaveLength(0)
+    // Legacy bg still there — implicit page 1 covers it.
+    expect(state().backgroundDataUrl).not.toBeNull()
+    expect(state().backgroundBuffer).not.toBeNull()
+  })
+})

--- a/packages/ui/src/store/__tests__/pageCloseMatrix.test.ts
+++ b/packages/ui/src/store/__tests__/pageCloseMatrix.test.ts
@@ -1,0 +1,155 @@
+/**
+ * GH #23 — closing one page must remove exactly one page, never two, for
+ * every combination of background types. The previous bug surfaced when
+ * the remaining page had an image background and `currentPageId` was set
+ * to `null` after the close: the canvas background resolver fell back to
+ * the (now empty) legacy `backgroundDataUrl` and the UI looked as if both
+ * pages had been deleted.
+ *
+ * These tests pin the contract at the store level (no browser needed).
+ * Every two-page combination (colour × colour, colour × image,
+ * image × colour, image × image) is exercised, closing each of the two
+ * pages in turn. After the close we assert:
+ *   1. Exactly one page remains.
+ *   2. The survivor is the one we expected.
+ *   3. Its background data is still reachable — for colour pages that
+ *      means `backgroundColor` is intact; for image pages that means the
+ *      corresponding entry in `pageBackgroundDataUrls` / `pageBackgroundBuffers`
+ *      is still present.
+ *   4. The reindexed survivor sits at `index: 0`.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { PageDefinition } from '@template-goblin/types'
+
+const storage = new Map<string, string>()
+vi.stubGlobal('localStorage', {
+  getItem: (key: string) => storage.get(key) ?? null,
+  setItem: (key: string, value: string) => storage.set(key, value),
+  removeItem: (key: string) => storage.delete(key),
+  clear: () => storage.clear(),
+})
+
+vi.mock('../idbStorage', () => ({
+  idbGet: async (key: string) => storage.get(key),
+  idbSet: async (key: string, value: string) => {
+    storage.set(key, value)
+  },
+  idbDelete: async (key: string) => {
+    storage.delete(key)
+  },
+  migrateFromLocalStorage: async () => {},
+}))
+
+import { useTemplateStore } from '../templateStore'
+
+function state() {
+  return useTemplateStore.getState()
+}
+
+function makeBuffer(byte: number): ArrayBuffer {
+  return new Uint8Array([byte, byte, byte, byte]).buffer
+}
+
+type BgKind = 'color' | 'image'
+
+function addPageWithBg(id: string, index: number, kind: BgKind, byteSeed: number): void {
+  if (kind === 'color') {
+    const page: PageDefinition = {
+      id,
+      index,
+      backgroundType: 'color',
+      backgroundColor: `#${byteSeed.toString(16).padStart(2, '0').repeat(3)}`,
+      backgroundFilename: null,
+    }
+    state().addPage(page)
+  } else {
+    const page: PageDefinition = {
+      id,
+      index,
+      backgroundType: 'image',
+      backgroundColor: null,
+      backgroundFilename: `backgrounds/${id}.png`,
+    }
+    state().addPage(page, `data:image/png;base64,${'A'.repeat(byteSeed)}`, makeBuffer(byteSeed))
+  }
+}
+
+beforeEach(() => {
+  storage.clear()
+  state().reset()
+})
+
+/**
+ * Matrix: [firstBg, secondBg, indexClosed, expectedSurvivorId, expectedSurvivorKind]
+ *
+ * `indexClosed` is 0 or 1 — which page the user clicks ✕ on.
+ */
+const CASES: Array<[BgKind, BgKind, 0 | 1, string, BgKind]> = [
+  ['color', 'color', 0, 'p2', 'color'],
+  ['color', 'color', 1, 'p1', 'color'],
+  ['color', 'image', 0, 'p2', 'image'],
+  ['color', 'image', 1, 'p1', 'color'],
+  ['image', 'color', 0, 'p2', 'color'],
+  ['image', 'color', 1, 'p1', 'image'],
+  ['image', 'image', 0, 'p2', 'image'],
+  ['image', 'image', 1, 'p1', 'image'],
+]
+
+describe('GH #23 — closing one page never closes two (every bg combination)', () => {
+  for (const [firstBg, secondBg, indexClosed, expectedId, expectedKind] of CASES) {
+    const name = `first=${firstBg} + second=${secondBg}, close tab ${indexClosed + 1} → ${expectedId}:${expectedKind} remains`
+    it(name, () => {
+      addPageWithBg('p1', 0, firstBg, 0x11)
+      addPageWithBg('p2', 1, secondBg, 0x22)
+      expect(state().pages).toHaveLength(2)
+
+      const toClose = indexClosed === 0 ? 'p1' : 'p2'
+      state().removePage(toClose)
+
+      expect(state().pages).toHaveLength(1)
+      const survivor = state().pages[0]!
+      expect(survivor.id).toBe(expectedId)
+      expect(survivor.index).toBe(0)
+      expect(survivor.backgroundType).toBe(expectedKind)
+
+      if (expectedKind === 'color') {
+        expect(survivor.backgroundColor).toMatch(/^#[0-9a-f]{6}$/i)
+      } else {
+        expect(state().pageBackgroundDataUrls.has(expectedId)).toBe(true)
+        expect(state().pageBackgroundBuffers.has(expectedId)).toBe(true)
+      }
+
+      // Closed page's bg data must be gone from the maps (no leak).
+      expect(state().pageBackgroundDataUrls.has(toClose)).toBe(false)
+      expect(state().pageBackgroundBuffers.has(toClose)).toBe(false)
+    })
+  }
+})
+
+/**
+ * Three-page variant: closing the middle page leaves exactly two, both at
+ * the correct reindexed positions, and none of them are collateral damage.
+ */
+describe('GH #23 — closing the middle of three pages', () => {
+  const THREE_CASES: Array<[BgKind, BgKind, BgKind]> = [
+    ['color', 'color', 'color'],
+    ['color', 'image', 'color'],
+    ['image', 'color', 'image'],
+    ['image', 'image', 'image'],
+  ]
+  for (const [b1, b2, b3] of THREE_CASES) {
+    it(`bgs=${b1}/${b2}/${b3}, close middle → pages 1 and 3 remain in order`, () => {
+      addPageWithBg('p1', 0, b1, 0x11)
+      addPageWithBg('p2', 1, b2, 0x22)
+      addPageWithBg('p3', 2, b3, 0x33)
+
+      state().removePage('p2')
+
+      expect(state().pages).toHaveLength(2)
+      expect(state().pages.map((p) => p.id)).toEqual(['p1', 'p3'])
+      expect(state().pages.map((p) => p.index)).toEqual([0, 1])
+      expect(state().pageBackgroundDataUrls.has('p2')).toBe(false)
+      expect(state().pageBackgroundBuffers.has('p2')).toBe(false)
+    })
+  }
+})


### PR DESCRIPTION
Closes #23.

## Problem
User reports: in a 2-page template, clicking ✕ on the first tab sends the app back to the onboarding-looking blank state — even though the second page should remain. Most reliable with an image-backed survivor.

## Root cause (two converging bugs)
1. **`useCurrentBackground` gap** — when \`currentPageId === null\`, the resolver only considered the legacy \`backgroundDataUrl\` and solid-colour \`pages[0]\`. An explicit **image** page at index 0 (the usual post-remove state) was never looked up in \`pageBackgroundDataUrls\`, so the canvas drew with no background.
2. **\`handleRemovePage\` stranded \`currentPageId\`** — after \`removePage\` the handler set \`currentPageId\` back to \`null\` even when explicit pages remained, which triggered (1) every time.

## Fix
- Resolver now falls through to \`pages[0]\` image data when no current page is selected.
- Close handler now lands on whichever page ends up at index 0 (or \`null\` only if the template genuinely has zero explicit pages).

## Test matrix
New \`packages/ui/src/store/__tests__/pageCloseMatrix.test.ts\` exercises every two-page background combination × which tab is closed:

| first | second | close | survivor expected |
|-------|--------|-------|-------------------|
| color | color  | 1     | p2 color          |
| color | color  | 2     | p1 color          |
| color | image  | 1     | p2 image          |
| color | image  | 2     | p1 color          |
| image | color  | 1     | p2 color          |
| image | color  | 2     | p1 image          |
| image | image  | 1     | p2 image          |
| image | image  | 2     | p1 image          |

Plus a three-page "close middle" sweep for each mix. All 12 new cases green, 319/319 total.

## Test plan
- [x] \`pnpm --filter template-goblin-ui type-check\` green
- [x] \`pnpm --filter template-goblin-ui lint\` green
- [x] \`pnpm --filter template-goblin-ui test\` — 319/319 passing (12 new cases)
- [ ] Manual verification pending your approval.

Changeset: \`.changeset/page-close-cascade.md\` (patch).