### PR TITLE
🧪 [testing improvement] handle and test AdmZip initialization failures

### DIFF
--- a/packages/core/src/file/read.ts
+++ b/packages/core/src/file/read.ts
@@ -81,7 +81,15 @@ export function readTgblBuffer(path: string): Buffer {
  * @throws TemplateGoblinError MISSING_MANIFEST or INVALID_MANIFEST
  */
 export function parseManifestFromZip(zip: AdmZip): TemplateManifest {
-  const manifestEntry = zip.getEntry(MANIFEST_FILENAME)
+  let manifestEntry: AdmZip.IZipEntry | null
+  try {
+    manifestEntry = zip.getEntry(MANIFEST_FILENAME)
+  } catch (error) {
+    throw new TemplateGoblinError(
+      'INVALID_FORMAT',
+      `Invalid .tgbl file: corrupted ZIP archive (${error instanceof Error ? error.message : 'unknown error'})`,
+    )
+  }
 
   if (!manifestEntry) {
     throw new TemplateGoblinError('MISSING_MANIFEST', 'Invalid .tgbl file: missing manifest.json')
@@ -95,7 +103,15 @@ export function parseManifestFromZip(zip: AdmZip): TemplateManifest {
     )
   }
 
-  const manifestText = manifestEntry.getData().toString('utf-8')
+  let manifestText: string
+  try {
+    manifestText = manifestEntry.getData().toString('utf-8')
+  } catch (error) {
+    throw new TemplateGoblinError(
+      'INVALID_FORMAT',
+      `Invalid .tgbl file: corrupted ZIP archive (${error instanceof Error ? error.message : 'unknown error'})`,
+    )
+  }
 
   try {
     const parsed: unknown = JSON.parse(manifestText)
@@ -342,6 +358,14 @@ function validateManifestStructure(manifest: TemplateManifest): void {
  */
 export async function readManifest(path: string): Promise<TemplateManifest> {
   const buffer = readTgblBuffer(path)
-  const zip = new AdmZip(buffer)
-  return parseManifestFromZip(zip)
+  try {
+    const zip = new AdmZip(buffer)
+    return parseManifestFromZip(zip)
+  } catch (error) {
+    if (error instanceof TemplateGoblinError) throw error
+    throw new TemplateGoblinError(
+      'INVALID_FORMAT',
+      `Invalid .tgbl file: corrupted ZIP archive (${error instanceof Error ? error.message : 'unknown error'})`,
+    )
+  }
 }

--- a/packages/core/src/load.ts
+++ b/packages/core/src/load.ts
@@ -25,7 +25,15 @@ import {
 export async function loadTemplate(path: string): Promise<LoadedTemplate> {
   // REQ: Read and verify ZIP file
   const buffer = readTgblBuffer(path)
-  const zip = new AdmZip(buffer)
+  let zip: AdmZip
+  try {
+    zip = new AdmZip(buffer)
+  } catch (error) {
+    throw new TemplateGoblinError(
+      'INVALID_FORMAT',
+      `Invalid .tgbl file: corrupted ZIP archive (${error instanceof Error ? error.message : 'unknown error'})`,
+    )
+  }
 
   // REQ: Parse and validate manifest
   const manifest = parseManifestFromZip(zip)

--- a/packages/core/tests/file/read.test.ts
+++ b/packages/core/tests/file/read.test.ts
@@ -130,6 +130,23 @@ describe('readTgblBuffer', () => {
       expect((err as TemplateGoblinError).code).toBe('INVALID_FORMAT')
     }
   })
+
+  it('should throw INVALID_FORMAT when file starts with magic bytes but is corrupted', async () => {
+    const filePath = join(tmpDir, 'corrupted.tgbl')
+    // PK magic bytes + garbage
+    writeFileSync(filePath, Buffer.from([0x50, 0x4b, 0x03, 0x04, 0x00, 0x00, 0x00, 0x00]))
+
+    // readTgblBuffer only checks magic bytes, so it should PASS
+    const buffer = readTgblBuffer(filePath)
+    expect(buffer).toBeDefined()
+
+    // readManifest should FAIL because AdmZip will fail to parse it
+    await expect(readManifest(filePath)).rejects.toThrow(TemplateGoblinError)
+    await expect(readManifest(filePath)).rejects.toMatchObject({
+      code: 'INVALID_FORMAT',
+      message: /corrupted ZIP archive/,
+    })
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/core/tests/load.test.ts
+++ b/packages/core/tests/load.test.ts
@@ -124,6 +124,20 @@ describe('loadTemplate', () => {
     })
   })
 
+  it('should throw INVALID_FORMAT when file starts with magic bytes but is corrupted', async () => {
+    // PK magic bytes + garbage
+    const p = writeTmp(
+      'corrupted.tgbl',
+      Buffer.from([0x50, 0x4b, 0x03, 0x04, 0x00, 0x00, 0x00, 0x00]),
+    )
+
+    await expect(loadTemplate(p)).rejects.toThrow(TemplateGoblinError)
+    await expect(loadTemplate(p)).rejects.toMatchObject({
+      code: 'INVALID_FORMAT',
+      message: /corrupted ZIP archive/,
+    })
+  })
+
   // ---- Error: MISSING_MANIFEST ----------------------------------
 
   it('should throw MISSING_MANIFEST when ZIP has no manifest.json', async () => {


### PR DESCRIPTION
🎯 **What:** Added missing error handling and tests for `AdmZip` initialization and entry access failures. Previously, corrupted ZIP files with valid magic bytes would cause unhandled exceptions from the `adm-zip` library.

📊 **Coverage:** 
- Added tests in `packages/core/tests/file/read.test.ts` for `readManifest` with corrupted archives.
- Added tests in `packages/core/tests/load.test.ts` for `loadTemplate` with corrupted archives.
- Improved error handling in `packages/core/src/file/read.ts` (`parseManifestFromZip`, `readManifest`) and `packages/core/src/load.ts` (`loadTemplate`) to wrap library-level errors.

✨ **Result:** Increased reliability when loading templates. Corrupted or invalid archives now consistently return a `TemplateGoblinError` with code `INVALID_FORMAT` instead of crashing with raw library errors. Correctly preserves `MISSING_MANIFEST` and `INVALID_MANIFEST` (JSON/validation) error codes.

---
*PR created automatically by Jules for task [10520561174030778156](https://jules.google.com/task/10520561174030778156) started by @JaiminPatel345*