### PR TITLE
🔒 [security fix] Replace insecure randomness for ID generation

### DIFF
--- a/packages/ui/src/components/Canvas/FieldCreationPopup.tsx
+++ b/packages/ui/src/components/Canvas/FieldCreationPopup.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, useCallback } from 'react'
+import { generateSecureId } from '../../utils/id.js'
 import type { FieldType } from '@template-goblin/types'
 import { isSafeKey } from '@template-goblin/types'
 import { CloseIcon } from '../icons/index.js'
@@ -128,7 +129,7 @@ export function FieldCreationPopup({
       reader.readAsDataURL(file)
     })
     const ext = file.name.match(/\.[A-Za-z0-9]+$/)?.[0] ?? '.png'
-    const filename = `static-${Date.now()}${ext}`
+    const filename = generateSecureId('static-') + ext
     setPickedImage({ filename, dataUrl, buffer })
   }
 

--- a/packages/ui/src/components/Canvas/usePageHandlers.ts
+++ b/packages/ui/src/components/Canvas/usePageHandlers.ts
@@ -3,6 +3,7 @@
  * logic extracted from CanvasArea for separation of concerns.
  */
 import { useState, useCallback, useRef } from 'react'
+import { generateSecureId } from '../../utils/id.js'
 import { useTemplateStore } from '../../store/templateStore.js'
 import { useUiStore } from '../../store/uiStore.js'
 import { createDefaultField } from '../../utils/defaults.js'
@@ -12,10 +13,8 @@ import type { FieldCreationDraft, SourceInputs } from './FieldCreationPopup.js'
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
-let pageIdCounter = 0
 function generatePageId(): string {
-  pageIdCounter++
-  return `page-${Date.now()}-${pageIdCounter}`
+  return generateSecureId('page-')
 }
 
 // ─── Hook ────────────────────────────────────────────────────────────────────

--- a/packages/ui/src/components/LeftPanel/FieldList.tsx
+++ b/packages/ui/src/components/LeftPanel/FieldList.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { generateSecureId } from '../../utils/id.js'
 import { useTemplateStore } from '../../store/templateStore.js'
 import { useUiStore } from '../../store/uiStore.js'
 import type { FieldDefinition, GroupDefinition } from '@template-goblin/types'
@@ -142,7 +143,7 @@ export function LeftPanel() {
   function handleNewGroup() {
     const name = prompt('Group name:')
     if (!name || !name.trim()) return
-    const id = `group-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+    const id = generateSecureId('group-')
     addGroup({ id, name: name.trim() })
   }
 

--- a/packages/ui/src/components/Toolbar/fontUpload.ts
+++ b/packages/ui/src/components/Toolbar/fontUpload.ts
@@ -1,4 +1,5 @@
 import { useTemplateStore } from '../../store/templateStore.js'
+import { generateSecureId } from '../../utils/id.js'
 
 /**
  * TTF magic bytes we accept. 0x00010000 is TrueType, 0x74727565 is the legacy
@@ -105,7 +106,7 @@ export async function processFontFiles(files: File[] | FileList): Promise<FontUp
       }
     }
 
-    const id = `font-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+    const id = generateSecureId('font-')
     const name = safeName.replace(/\.ttf$/i, '')
     useTemplateStore.getState().addFont({ id, name, filename: targetFilename }, buffer)
     results.push({ filename: file.name, ok: true })

--- a/packages/ui/src/store/templateStore.ts
+++ b/packages/ui/src/store/templateStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
+import { generateSecureId } from '../utils/id.js'
 import type {
   FieldDefinition,
   TemplateMeta,
@@ -184,11 +185,8 @@ function pushHistory(state: TemplateState): Partial<TemplateState> {
   }
 }
 
-let fieldCounter = 0
-
 function generateId(): string {
-  fieldCounter++
-  return `field-${Date.now()}-${fieldCounter}`
+  return generateSecureId('field-')
 }
 
 /** Convert ArrayBuffer to base64 for JSON serialization */
@@ -596,7 +594,7 @@ export const useTemplateStore = create<TemplateState>()(
             )
           } else {
             const page0: PageDefinition = {
-              id: `page-0-${Date.now()}`,
+              id: generateSecureId('page-0-'),
               index: 0,
               backgroundType: 'color',
               backgroundColor: hex,

--- a/packages/ui/src/utils/__tests__/id.test.ts
+++ b/packages/ui/src/utils/__tests__/id.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi } from 'vitest'
+import { generateSecureId } from '../id.js'
+
+describe('generateSecureId', () => {
+  it('should generate a string starting with the given prefix', () => {
+    const id = generateSecureId('test-')
+    expect(id).toMatch(/^test-/)
+  })
+
+  it('should use crypto.randomUUID', () => {
+    const spy = vi.spyOn(crypto, 'randomUUID')
+    generateSecureId()
+    expect(spy).toHaveBeenCalled()
+  })
+
+  it('should generate unique IDs', () => {
+    const ids = new Set()
+    for (let i = 0; i < 100; i++) {
+      ids.add(generateSecureId())
+    }
+    expect(ids.size).toBe(100)
+  })
+})

--- a/packages/ui/src/utils/id.ts
+++ b/packages/ui/src/utils/id.ts
@@ -1,0 +1,9 @@
+/**
+ * Generates a secure unique identifier using crypto.randomUUID().
+ *
+ * @param prefix Optional prefix to prepend to the ID (e.g., 'font-', 'group-').
+ * @returns A cryptographically secure unique identifier string.
+ */
+export function generateSecureId(prefix = ''): string {
+  return `${prefix}${crypto.randomUUID()}`
+}


### PR DESCRIPTION
🎯 **What:** Replaced insecure ID generation using `Math.random()` and predictable timestamps with `crypto.randomUUID()`.
⚠️ **Risk:** `Math.random()` is not cryptographically secure and its output is predictable. This could potentially allow an attacker to predict generated IDs (for fonts, fields, etc.), leading to potential identifier collisions or information leakage in certain scenarios.
🛡️ **Solution:** Introduced a `generateSecureId` utility that leverages the native Web Crypto API's `crypto.randomUUID()` to generate non-predictable, unique identifiers across the `packages/ui` package. Removed all instances of `Math.random()` and predictable `Date.now()` based ID generation.

---
*PR created automatically by Jules for task [8082877293551475668](https://jules.google.com/task/8082877293551475668) started by @JaiminPatel345*