### PR TITLE
fix(ui): dynamic image placeholder no longer stuck as filename text (#34)

### DIFF
--- a/packages/ui/src/components/Canvas/fabricUtils.ts
+++ b/packages/ui/src/components/Canvas/fabricUtils.ts
@@ -235,14 +235,39 @@ export function createFieldGroup(field: FieldDefinition, resolveImage: ImageReso
  * hash matches we short-circuit the expensive rebuild and just move the
  * group, which avoids the white-flash users saw on every drag/release where
  * the image placeholder briefly replaced the loaded bitmap.
+ *
+ * For image fields we also fold in whether the placeholder bitmap has
+ * resolved yet — `usePlaceholderImages` loads bitmaps async, so the very
+ * first reconcile sees `resolveImage(filename) === null` and renders the
+ * filename as a text label. Without this bit, the next reconcile (after
+ * the bitmap finishes loading) would short-circuit and keep showing text.
  */
-function fieldRenderHash(field: FieldDefinition): string {
+function fieldRenderHash(field: FieldDefinition, resolveImage: ImageResolver): string {
+  let imageResolved = false
+  if (field.type === 'image' && field.source) {
+    let filename: string | null = null
+    if (field.source.mode === 'dynamic') {
+      const ph = field.source.placeholder as unknown
+      if (ph && typeof ph === 'object' && 'filename' in ph) {
+        const name = (ph as { filename: unknown }).filename
+        if (typeof name === 'string' && name.length > 0) filename = name
+      }
+    } else {
+      const v = field.source.value as unknown
+      if (v && typeof v === 'object' && 'filename' in v) {
+        const name = (v as { filename: unknown }).filename
+        if (typeof name === 'string' && name.length > 0) filename = name
+      }
+    }
+    if (filename) imageResolved = resolveImage(filename) !== null
+  }
   return JSON.stringify({
     t: field.type,
     w: field.width,
     h: field.height,
     s: field.style,
     src: field.source,
+    imgR: imageResolved,
   })
 }
 
@@ -255,7 +280,7 @@ export function applyFieldToGroup(
   // Skip the children rebuild (which on image fields would briefly drop
   // back to the alpha-0.05 placeholder rect while the bitmap re-decodes,
   // visible as a "white flash" on mouseup of every drag).
-  const newHash = fieldRenderHash(field)
+  const newHash = fieldRenderHash(field, resolveImage)
   if (group.__fieldHash === newHash && group.getObjects().length > 0) {
     group.set({
       left: field.x,


### PR DESCRIPTION
## Summary

- Fixes #34 — dynamic image fields rendered the placeholder filename as a text label until the user resized them.
- Render-hash now folds in whether \`resolveImage(filename)\` returned a bitmap, so the second reconcile (after \`usePlaceholderImages\` finishes its async decode) always rebuilds.
- The d8a7caa drag fast-path keeps working: the resolver is monotonic null→resolved per filename, so \`imgR\` flips exactly once per image — drag/resize after that still short-circuits.

## Test plan

- [x] \`pnpm type-check\` — pass
- [x] \`pnpm lint\` — pass
- [x] \`pnpm --filter template-goblin-ui test\` — 374/374 pass
- [x] Playwright \`image-field.spec.ts\` + \`sync-and-mode-toggle.spec.ts\` — 11/11 pass
- [x] Master QA — PR-ready

## Follow-up (not blocking)

- Add an e2e regression test that seeds a dynamic image via \`placeholderBuffers\` (not \`staticImageDataUrls\`) and asserts the group contains a FabricImage child after the async decode. Existing \`seedImageField\` helper bypasses the async path so #34 wasn't caught.

🤖 Generated with [Claude Code](https://claude.com/claude-code)