### PR TITLE
fix(ui): orphaned-pageId fields stay on Page 1 (#37)

### DIFF
--- a/packages/ui/e2e/page-tabs.spec.ts
+++ b/packages/ui/e2e/page-tabs.spec.ts
@@ -349,6 +349,74 @@ test.describe('Page tabs — switch / add / delete', () => {
     await expect(page.locator('[data-testid="onboarding-upload-image"]')).toBeVisible()
   })
 
+  test('GH #37: orphaned (pageId=null) field renders on Page 1 alongside explicit-id fields', async ({
+    page,
+  }) => {
+    // REGRESSION: solid-color onboarding leaves currentPageId at null even
+    // though pages[0] is explicit. Fields drawn in that window get
+    // pageId=null. After "+ Add Page" the user clicks the Page 1 tab and
+    // currentPageId becomes the explicit id — the orphan disappeared until
+    // this fix made the Page 1 filter inclusive of pageId=null.
+    await seed(
+      page,
+      [
+        {
+          id: 'p0',
+          index: 0,
+          backgroundType: 'color',
+          backgroundColor: '#ffffff',
+          backgroundFilename: null,
+        },
+        {
+          id: 'p1',
+          index: 1,
+          backgroundType: 'color',
+          backgroundColor: '#eeeeee',
+          backgroundFilename: null,
+        },
+      ],
+      [
+        // The bug-shaped orphan: drawn before pages[0] was explicit.
+        { id: 'orphan', pageId: null, x: 50, y: 50, width: 100, height: 50, zIndex: 0 },
+        // A field stamped with the explicit id (the post-fix shape).
+        { id: 'on_p0', pageId: 'p0', x: 200, y: 50, width: 100, height: 50, zIndex: 1 },
+        // A field on Page 2 — must NOT bleed into Page 1.
+        { id: 'on_p1', pageId: 'p1', x: 50, y: 200, width: 100, height: 50, zIndex: 2 },
+      ],
+    )
+    await page.goto('/')
+    await expect(fabricCanvas(page)).toBeVisible()
+
+    async function fieldIdsOnCanvas(): Promise<string[]> {
+      return await page.evaluate(() => {
+        interface FabricLike {
+          getObjects(): Array<{ __fieldId?: string; __isGrid?: boolean }>
+        }
+        const fc = (window as unknown as { __fabricCanvas?: FabricLike }).__fabricCanvas
+        return (fc?.getObjects() ?? [])
+          .filter((o) => o.__fieldId && !o.__isGrid)
+          .map((o) => o.__fieldId as string)
+      })
+    }
+
+    // On first load currentPageId is null (the persisted default); the
+    // Page-1 filter must include both the orphan AND the explicit-id field.
+    await page.waitForTimeout(120)
+    expect((await fieldIdsOnCanvas()).sort()).toEqual(['on_p0', 'orphan'])
+
+    // Switch to Page 2 — only on_p1 should render. orphan must not bleed.
+    await page.locator('button', { hasText: /^Page 2$/ }).click()
+    await page.waitForTimeout(120)
+    expect(await fieldIdsOnCanvas()).toEqual(['on_p1'])
+
+    // Click back to Page 1 — currentPageId is now 'p0' (explicit id).
+    // Both the orphan AND on_p0 must still render. This is the exact
+    // navigation pattern that caused the user-visible "fields deleted" bug.
+    await page.locator('button', { hasText: /^Page 1$/ }).click()
+    await page.waitForTimeout(120)
+    expect((await fieldIdsOnCanvas()).sort()).toEqual(['on_p0', 'orphan'])
+  })
+
   test('closing the LAST page on Cancel keeps everything intact', async ({ page }) => {
     await seed(
       page,

--- a/packages/ui/src/components/Canvas/CanvasArea.tsx
+++ b/packages/ui/src/components/Canvas/CanvasArea.tsx
@@ -135,8 +135,26 @@ export function CanvasArea() {
   const placeholderImages = usePlaceholderImages(fields, placeholderBuffers, staticImageBuffers)
   const resolveImage = useImageResolver(placeholderImages, staticImageDataUrls)
 
+  // Page 1 (index 0) is special: orphaned fields (pageId === null) and fields
+  // tagged with the explicit pages[0] id both belong here. Fields can be
+  // orphaned two ways:
+  //   1. They were drawn while Page 1 was implicit — `currentPageId` was null
+  //      at stamp time so `pageId` is null too. After `+ Add Page` makes
+  //      `pages[0]` explicit, clicking the Page 1 tab moves `currentPageId`
+  //      to the explicit id but the fields keep `pageId: null` — they
+  //      vanish without this inclusive filter (GH #37).
+  //   2. `removePage` deliberately reassigns the deleted page's fields to
+  //      `pageId: null` so they fall back to Page 1.
+  // The `currentPageId === null` case ALSO has to match fields that already
+  // carry the explicit id (the post-fix shape) since onboarding leaves
+  // `currentPageId` at null even after `pages[0]` becomes explicit.
+  // Other pages match strictly on id.
+  const page1Id = pages.find((p) => p.index === 0)?.id ?? null
+  const isOnPage1 = currentPageId === null || currentPageId === page1Id
   const pageFields = fields.filter((f) => {
-    if (currentPageId === null) return f.pageId === null || f.pageId === undefined
+    if (isOnPage1) {
+      return f.pageId === null || f.pageId === undefined || f.pageId === page1Id
+    }
     return f.pageId === currentPageId
   })
 

--- a/packages/ui/src/components/Canvas/useFabricCanvas.ts
+++ b/packages/ui/src/components/Canvas/useFabricCanvas.ts
@@ -377,14 +377,22 @@ function wireMouseEvents(
         }
         const fieldType = toolToType[uiState.activeTool]
         if (fieldType) {
+          // Prefer the explicit page-0 id when `currentPageId` is null but an
+          // explicit Page 1 entry exists (i.e. solid-color onboarding leaves
+          // `currentPageId` at null even though `pages[0]` is now real). Without
+          // this, the field is stamped with `pageId: null` and disappears the
+          // moment the user clicks the Page 1 tab — see GH #37.
+          const ts = useTemplateStore.getState()
+          const explicit = ts.pages.find((p) => p.index === 0)?.id ?? null
+          const stampedPageId = useUiStore.getState().currentPageId ?? explicit
           setPendingDraft({
             type: fieldType,
             x: rx,
             y: ry,
             width: rw,
             height: rh,
-            zIndex: useTemplateStore.getState().fields.length,
-            pageId: useUiStore.getState().currentPageId,
+            zIndex: ts.fields.length,
+            pageId: stampedPageId,
             groupId: null,
           })
         }


### PR DESCRIPTION
## Summary

Fixes #37 — fields drawn on Page 1 disappeared after the user clicked **+ Add Page** and navigated back.

**Root cause:** solid-color onboarding creates \`pages[0]\` with an explicit id but leaves \`currentPageId\` at \`null\`. Fields drawn in that window get stamped \`pageId: null\`. After **+ Add Page**, clicking the Page 1 tab moves \`currentPageId\` to the explicit \`pages[0].id\`, and the strict-equality filter dropped every orphan.

**Fix:**
- Field stamping prefers the explicit \`pages[0].id\` when \`currentPageId\` is null. New fields are no longer orphaned in the first place.
- The Page 1 filter now treats both \`pageId === null\` and \`pageId === pages[0].id\` as belonging to Page 1, regardless of whether \`currentPageId\` is null or the explicit id. Catches existing orphans and the standing \`removePage\` orphaning behaviour.

## Test plan

- [x] e2e regression \`page-tabs.spec.ts\` "GH #37" — seeds the bug-shaped state (orphan + explicit-id field) and asserts both render on Page 1, only Page-2 field renders on Page 2, and both still render after navigating Page 1 → Page 2 → Page 1.
- [x] \`pnpm type-check\` / \`pnpm lint\` / \`pnpm test\` (374 unit pass)
- [x] Targeted e2e: page-tabs + page-close-cascade + onboarding-to-canvas — 16/16 pass
- [x] Master QA approved

🤖 Generated with [Claude Code](https://claude.com/claude-code)