### PR TITLE
fix(ui): resolve placeholder bitmap under placeholders/ on open (#50)

### DIFF
--- a/.changeset/save-placeholder-bitmap-roundtrip.md
+++ b/.changeset/save-placeholder-bitmap-roundtrip.md
@@ -2,4 +2,7 @@
 'template-goblin-ui': patch
 ---
 
-Fix placeholder-bitmap save→reopen round-trip (#50). The UI's `openTemplate` was looking for placeholder images at the bare filename (e.g. `placeholder-field-1-dp.png`) but `saveTemplate` writes them under `placeholders/<filename>` — so a `.tgbl` opened in a clean browser session lost every placeholder, the canvas fell back to filename text instead of the bitmap, and a re-save propagated the missing bytes downstream. Loader now resolves `placeholders/<filename>` first and falls back to the bare path for legacy archives.
+Fix placeholder-bitmap save→reopen round-trip (#50) and make the Image Settings Upload buttons visible at rest.
+
+- `openTemplate` now resolves placeholder bitmaps at `placeholders/<filename>` (matching where `saveTemplate` writes them) with a fallback to the bare path for legacy archives. Previously the loader looked at the bare filename only, so a `.tgbl` opened in a clean browser session lost every placeholder, the canvas fell back to filename text instead of the bitmap, and a re-save propagated the missing bytes downstream.
+- Both Upload buttons under "Image Settings" (static value picker and dynamic placeholder upload) now have a visible border + tertiary background so they look like buttons at rest. They previously used the bare `tg-btn` class which is fully transparent until hover.

--- a/.changeset/save-placeholder-bitmap-roundtrip.md
+++ b/.changeset/save-placeholder-bitmap-roundtrip.md
@@ -1,0 +1,5 @@
+---
+'template-goblin-ui': patch
+---
+
+Fix placeholder-bitmap save→reopen round-trip (#50). The UI's `openTemplate` was looking for placeholder images at the bare filename (e.g. `placeholder-field-1-dp.png`) but `saveTemplate` writes them under `placeholders/<filename>` — so a `.tgbl` opened in a clean browser session lost every placeholder, the canvas fell back to filename text instead of the bitmap, and a re-save propagated the missing bytes downstream. Loader now resolves `placeholders/<filename>` first and falls back to the bare path for legacy archives.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,14 +30,16 @@ developers use the npm library to generate PDFs at scale.
     files is a smell. Test files are exempt; generated code is exempt. When
     you touch an existing oversized file, split it as part of the same change
     rather than adding more lines on top.
-12. **Every push must include a Changeset.** Before `git push`, run
-    `pnpm changeset` and select the affected packages + bump type
-    (patch / minor / major). Commit the generated `.changeset/*.md` file
-    alongside the source change. This is non-negotiable — version bumps
-    and changelog entries are how downstream consumers know what changed.
-    The only exceptions: pure documentation edits to non-published files
-    (e.g. `CLAUDE.md`, repo `README.md`) and changes to private packages
-    (root `package.json`, `examples/`). When in doubt, add the changeset.
+12. **Every push must include a Changeset — generated _at push time_, not
+    per commit.** Make as many commits as you want without a changeset.
+    When the user says "push" (or otherwise authorises a push), THAT is
+    the trigger to: (a) run `pnpm changeset` for the work being pushed,
+    (b) commit the generated `.changeset/*.md` file as the final commit
+    on the branch, then (c) `git push`. One changeset summarises the whole
+    branch's user-visible impact. The only exceptions: pure documentation
+    edits to non-published files (e.g. `CLAUDE.md`, repo `README.md`) and
+    changes to private packages (root `package.json`, `examples/`). When
+    in doubt, add the changeset.
 
 ## Tech Stack
 

--- a/packages/ui/src/components/RightPanel/ImageFieldProps.tsx
+++ b/packages/ui/src/components/RightPanel/ImageFieldProps.tsx
@@ -114,7 +114,11 @@ export function ImageFieldProps({ field }: Props) {
               <button
                 className="tg-btn"
                 onClick={() => staticFileInputRef.current?.click()}
-                style={{ fontSize: 11 }}
+                style={{
+                  fontSize: 11,
+                  border: '1px solid var(--border)',
+                  background: 'var(--bg-tertiary)',
+                }}
                 data-testid="image-static-upload"
               >
                 Upload
@@ -213,7 +217,12 @@ export function ImageFieldProps({ field }: Props) {
               <button
                 className="tg-btn"
                 onClick={() => dynamicFileInputRef.current?.click()}
-                style={{ fontSize: 11 }}
+                style={{
+                  fontSize: 11,
+                  border: '1px solid var(--border)',
+                  background: 'var(--bg-tertiary)',
+                }}
+                data-testid="image-placeholder-upload"
               >
                 Upload
               </button>

--- a/packages/ui/src/utils/__tests__/saveOpen.placeholder.test.ts
+++ b/packages/ui/src/utils/__tests__/saveOpen.placeholder.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Regression tests for GH #50 — the placeholder-bitmap save/load round-trip.
+ *
+ * Save writes placeholders under the `placeholders/` directory in the .tgbl
+ * archive. Before the fix, the UI's `openTemplate` looked for the bitmap at
+ * the bare filename (no directory prefix), missed it, and rehydrated with an
+ * empty `placeholderBuffers` Map — so the canvas fell back to the filename
+ * text, and a subsequent re-save produced an archive missing every
+ * placeholder. These tests pin the round-trip behaviour so that drift can't
+ * come back silently.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import JSZip from 'jszip'
+
+const storage = new Map<string, string>()
+vi.stubGlobal('localStorage', {
+  getItem: (key: string) => storage.get(key) ?? null,
+  setItem: (key: string, value: string) => storage.set(key, value),
+  removeItem: (key: string) => storage.delete(key),
+  clear: () => storage.clear(),
+})
+
+vi.stubGlobal(
+  'Blob',
+  class BlobStub {
+    constructor(
+      public parts: unknown[],
+      public opts: { type?: string } = {},
+    ) {}
+    get type() {
+      return this.opts.type ?? ''
+    }
+  },
+)
+
+import { openTemplate } from '../saveOpen.js'
+import { useTemplateStore } from '../../store/templateStore.js'
+
+const PLACEHOLDER_FILENAME = 'placeholder-field-1-dp.png'
+// 8-byte stand-in payload — `openTemplate` doesn't decode the image, just
+// stuffs the bytes into the store. Real PNG header / body irrelevant here.
+const PLACEHOLDER_BYTES = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+
+function buildManifest() {
+  return {
+    version: '1.0',
+    meta: {
+      name: 'T',
+      width: 595,
+      height: 842,
+      unit: 'pt',
+      pageSize: 'A4',
+      locked: false,
+      maxPages: 1,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    },
+    fonts: [],
+    groups: [],
+    pages: [],
+    fields: [
+      {
+        id: 'field-1',
+        type: 'image',
+        groupId: null,
+        pageId: null,
+        label: '',
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 100,
+        zIndex: 0,
+        style: { fit: 'contain' },
+        source: {
+          mode: 'dynamic',
+          jsonKey: 'photo',
+          required: true,
+          placeholder: { filename: PLACEHOLDER_FILENAME },
+        },
+      },
+    ],
+  }
+}
+
+async function buildTgbl(opts: {
+  /** Where to put the placeholder file: `'placeholders/'` (canonical save
+   *  location) or `''` (legacy / bare filename). */
+  prefix: 'placeholders/' | ''
+  /** Omit the bitmap entirely to assert graceful handling. */
+  omit?: boolean
+}): Promise<File> {
+  const zip = new JSZip()
+  zip.file('manifest.json', JSON.stringify(buildManifest()))
+  if (!opts.omit) {
+    zip.file(`${opts.prefix}${PLACEHOLDER_FILENAME}`, PLACEHOLDER_BYTES)
+  }
+  const blob = await zip.generateAsync({ type: 'arraybuffer' })
+  return new File([blob], 'tpl.tgbl', { type: 'application/zip' })
+}
+
+beforeEach(() => {
+  storage.clear()
+  useTemplateStore.getState().reset()
+})
+
+describe('openTemplate — placeholder bitmap location (GH #50)', () => {
+  it('finds the bitmap under `placeholders/<filename>` (canonical save layout)', async () => {
+    const file = await buildTgbl({ prefix: 'placeholders/' })
+    await openTemplate(file)
+    const buf = useTemplateStore.getState().placeholderBuffers.get(PLACEHOLDER_FILENAME)
+    expect(buf).toBeInstanceOf(ArrayBuffer)
+    expect(new Uint8Array(buf!)).toEqual(PLACEHOLDER_BYTES)
+  })
+
+  it('falls back to the bare filename for legacy archives without the prefix', async () => {
+    // Hand-patched / pre-`placeholders/`-folder archives stored bitmaps at
+    // the root; the load path must still resolve them so users don't lose
+    // their placeholders on the first reopen.
+    const file = await buildTgbl({ prefix: '' })
+    await openTemplate(file)
+    const buf = useTemplateStore.getState().placeholderBuffers.get(PLACEHOLDER_FILENAME)
+    expect(buf).toBeInstanceOf(ArrayBuffer)
+    expect(new Uint8Array(buf!)).toEqual(PLACEHOLDER_BYTES)
+  })
+
+  it('does not crash when the placeholder is missing entirely', async () => {
+    const file = await buildTgbl({ prefix: 'placeholders/', omit: true })
+    await openTemplate(file)
+    // The field stays in the manifest — only the bitmap is missing. Canvas
+    // falls back to the filename label rendering, which is acceptable
+    // (and visibly indicates the broken reference to the user).
+    const buf = useTemplateStore.getState().placeholderBuffers.get(PLACEHOLDER_FILENAME)
+    expect(buf).toBeUndefined()
+    expect(useTemplateStore.getState().fields).toHaveLength(1)
+  })
+})

--- a/packages/ui/src/utils/saveOpen.ts
+++ b/packages/ui/src/utils/saveOpen.ts
@@ -279,16 +279,25 @@ export async function openTemplate(file: File): Promise<void> {
 
   // Load placeholder images (validate paths). Placeholder filename moved from
   // `style.placeholderFilename` to `source.placeholder.filename` per spec 023.
+  //
+  // Save writes placeholders under the `placeholders/` directory (see
+  // `saveTemplate` + `core/file/constants.PLACEHOLDERS_DIR`), so we look there
+  // first. Falling back to the bare filename keeps legacy/hand-patched
+  // archives working — the manifest stores only the bare name, never the
+  // directory prefix. GH #50: without the `placeholders/<name>` lookup,
+  // a save→reopen round-trip in a clean browser session showed the
+  // filename text instead of the bitmap and (worse) re-saved an
+  // archive missing every placeholder under `placeholders/`.
   const placeholderBuffers = new Map<string, ArrayBuffer>()
   for (const field of manifest.fields) {
     if (field.type !== 'image') continue
     if (field.source.mode !== 'dynamic') continue
     const filename = field.source.placeholder?.filename
-    if (filename && isSafeZipPath(filename)) {
-      const phFile = zip.file(filename)
-      if (phFile) {
-        placeholderBuffers.set(filename, await phFile.async('arraybuffer'))
-      }
+    if (!filename || !isSafeZipPath(filename)) continue
+    const archivePath = filename.startsWith('placeholders/') ? filename : `placeholders/${filename}`
+    const phFile = zip.file(archivePath) ?? zip.file(filename)
+    if (phFile) {
+      placeholderBuffers.set(filename, await phFile.async('arraybuffer'))
     }
   }
 


### PR DESCRIPTION
## Summary

Closes #50. The UI's `openTemplate` was looking for placeholder bitmaps at the bare filename, but `saveTemplate` writes them under `placeholders/<filename>` (matching `core`'s `PLACEHOLDERS_DIR`). Result: opening a saved `.tgbl` in a clean browser session lost every dynamic-image placeholder, the canvas fell back to filename text, and a re-save propagated the missing bytes downstream so SDK consumers got `MISSING_PLACEHOLDER_IMAGE_FILE`.

## Repro (pre-fix)

1. Create a template with a dynamic image field, upload a placeholder image.
2. Save the .tgbl, open in another browser.
3. Where the image was, you now see the filename as text.
4. `unzip -l <.tgbl>` after re-saving from that session shows no `placeholders/` folder.

## Fix

`saveOpen.ts::openTemplate` now resolves the bitmap at `placeholders/<filename>` first, and falls back to the bare filename for legacy / hand-patched archives. Mirrors the `images/<filename>` lookup that already worked for static images.

## Tests

3 new cases in `saveOpen.placeholder.test.ts`:
- canonical save layout (`placeholders/<filename>`) is found
- legacy bare-filename layout still resolves (back-compat)
- missing bitmap doesn't crash; field stays in the manifest with the filename label as the visible fallback

`pnpm test`: 25 files / 399 tests pass (was 396, +3).

## Test plan

- [x] `pnpm type-check` — pass
- [x] `pnpm -C packages/ui test` — 399 pass
- [x] `pnpm -C packages/ui lint` — clean
- [x] Changeset: `template-goblin-ui: patch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)