### PR TITLE
fix(canvas): table column edits sync to canvas + header style + auto-select on focus (#38)

### DIFF
--- a/.changeset/table-column-sync.md
+++ b/.changeset/table-column-sync.md
@@ -1,0 +1,20 @@
+---
+'template-goblin-ui': minor
+---
+
+Table fields now stay in sync with the right-panel properties (#38).
+The canvas draws a column grid (one vertical divider per column boundary,
+scaled proportionally to declared widths) plus a header band with
+per-column labels — adding, editing, removing, or reordering columns
+produces visible feedback on the next reconcile. Header style edits in
+the properties panel — `fontFamily`, `fontSize`, `fontWeight`,
+`fontStyle`, `textDecoration`, `color`, `backgroundColor`, `borderColor`,
+`borderWidth`, `align`, `paddingLeft`, `paddingRight` — flow through to
+the rendered header band. The JSON preview pane was already reactive;
+the canvas catching up closes the sync gap.
+
+Side-panel UX polish: clicking (or tabbing) into any input inside the
+properties / structure panels now auto-selects the existing value, so
+the next keystroke replaces it instead of appending. Click-and-drag
+selections are preserved (only collapsed-caret focuses trigger
+select-all).

--- a/packages/ui/e2e/table-column-sync.spec.ts
+++ b/packages/ui/e2e/table-column-sync.spec.ts
@@ -1,0 +1,243 @@
+/**
+ * E2E for GH #38: adding / removing a column on a table field via the
+ * right-panel must propagate to the canvas. Pre-fix the canvas drew a
+ * single labelled rect for any table regardless of `style.columns`, so
+ * `+ Add Column` updated the store but produced zero visual change.
+ *
+ * The canvas now emits column-divider Lines and per-column header label
+ * Textboxes (see `tableCanvasParts.ts`), so the field group's child count
+ * is a reliable proxy: it grows when a column is added and shrinks when
+ * one is removed.
+ */
+import type { Page } from '@playwright/test'
+import { test, expect } from '@playwright/test'
+
+const BASE_CELL = {
+  fontFamily: 'Helvetica',
+  fontSize: 10,
+  fontWeight: 'normal',
+  fontStyle: 'normal',
+  textDecoration: 'none',
+  color: '#000000',
+  backgroundColor: '#ffffff',
+  borderWidth: 0,
+  borderColor: '#cccccc',
+  paddingTop: 2,
+  paddingBottom: 2,
+  paddingLeft: 4,
+  paddingRight: 4,
+  align: 'left',
+  verticalAlign: 'top',
+}
+
+function tableStyle(columns: Array<{ key: string; label: string; width: number }>) {
+  return {
+    maxRows: 5,
+    maxColumns: 8,
+    multiPage: false,
+    showHeader: true,
+    headerStyle: { ...BASE_CELL, fontWeight: 'bold', backgroundColor: '#eeeeee' },
+    rowStyle: BASE_CELL,
+    oddRowStyle: null,
+    evenRowStyle: null,
+    cellStyle: { overflowMode: 'truncate' },
+    columns: columns.map((c) => ({ ...c, style: null, headerStyle: null })),
+  }
+}
+
+async function seed(page: Page): Promise<void> {
+  const payload = {
+    state: {
+      meta: {
+        schemaVersion: 1,
+        name: 'table-column-sync-test',
+        version: '0.0.0',
+        width: 1000,
+        height: 800,
+        locked: false,
+      },
+      fields: [
+        {
+          id: 'tbl1',
+          type: 'table',
+          label: 'tbl1',
+          groupId: null,
+          pageId: null,
+          x: 100,
+          y: 200,
+          width: 400,
+          height: 200,
+          zIndex: 0,
+          source: { mode: 'dynamic', jsonKey: 'rows', required: true, placeholder: null },
+          style: tableStyle([
+            { key: 'a', label: 'A', width: 100 },
+            { key: 'b', label: 'B', width: 100 },
+          ]),
+        },
+      ],
+      fonts: [],
+      groups: [],
+      pages: [
+        {
+          id: 'p0',
+          index: 0,
+          backgroundType: 'color',
+          backgroundColor: '#ffffff',
+          backgroundFilename: null,
+        },
+      ],
+      backgroundDataUrl: null,
+      backgroundBuffer: null,
+      pageBackgroundDataUrls: [],
+      pageBackgroundBuffers: [],
+      fontBuffers: [],
+      placeholderBuffers: [],
+      staticImageBuffers: [],
+      staticImageDataUrls: [],
+    },
+    version: 2,
+  }
+  await page.addInitScript((s: string) => {
+    return new Promise<void>((resolve, reject) => {
+      const req = indexedDB.open('template-goblin', 1)
+      req.onupgradeneeded = () => {
+        const db = req.result
+        if (!db.objectStoreNames.contains('kv')) db.createObjectStore('kv')
+      }
+      req.onsuccess = () => {
+        const db = req.result
+        const tx = db.transaction('kv', 'readwrite')
+        tx.objectStore('kv').put(s, 'template-goblin-template')
+        tx.oncomplete = () => {
+          localStorage.removeItem('template-goblin-ui')
+          resolve()
+        }
+        tx.onerror = () => reject(tx.error)
+      }
+      req.onerror = () => reject(req.error)
+    })
+  }, JSON.stringify(payload))
+}
+
+function fabricCanvas(page: Page) {
+  return page.locator('[data-testid="canvas-stage-wrapper"] canvas').first()
+}
+
+/**
+ * Count how many Fabric children the table group has on the canvas. The
+ * table group always carries a bgRect; column dividers and header labels
+ * pile on top, so the count grows monotonically with column count.
+ */
+async function readGroupChildCount(page: Page, fieldId: string): Promise<number> {
+  return await page.evaluate((id: string) => {
+    interface FabricLike {
+      getObjects(): Array<{
+        __fieldId?: string
+        getObjects?: () => unknown[]
+      }>
+    }
+    const fc = (window as unknown as { __fabricCanvas?: FabricLike }).__fabricCanvas
+    if (!fc) return 0
+    const g = fc.getObjects().find((o) => o.__fieldId === id)
+    if (!g?.getObjects) return 0
+    return g.getObjects().length
+  }, fieldId)
+}
+
+/** Make the right-panel `LoopFieldProps` panel visible by selecting the field. */
+async function selectField(page: Page, fieldId: string): Promise<void> {
+  await page.evaluate((id: string) => {
+    interface FabricLike {
+      getObjects(): Array<{ __fieldId?: string }>
+      setActiveObject: (o: object) => void
+      requestRenderAll: () => void
+      fire?: (event: string, opts: object) => void
+    }
+    const fc = (window as unknown as { __fabricCanvas?: FabricLike }).__fabricCanvas
+    if (!fc) return
+    const g = fc.getObjects().find((o) => o.__fieldId === id)
+    if (!g) return
+    fc.setActiveObject(g as object)
+    // Fire selection:created so any listeners syncing the right panel run.
+    fc.fire?.('selection:created', { selected: [g] })
+    fc.requestRenderAll()
+  }, fieldId)
+}
+
+test.describe('Table column sync (#38)', () => {
+  test('adding a column via the right panel grows the canvas group child count', async ({
+    page,
+  }) => {
+    await seed(page)
+    await page.goto('/')
+    await expect(fabricCanvas(page)).toBeVisible()
+
+    const baseline = await readGroupChildCount(page, 'tbl1')
+    expect(baseline).toBeGreaterThan(0)
+
+    await selectField(page, 'tbl1')
+    // The right-panel LoopFieldProps mounts when a table field is selected.
+    await expect(page.locator('[data-testid="loop-add-column"]')).toBeVisible()
+
+    await page.locator('[data-testid="loop-add-column"]').click()
+
+    // Reconcile is synchronous on store update; poll to absorb a render
+    // tick and let the e2e be robust under load.
+    await expect
+      .poll(async () => readGroupChildCount(page, 'tbl1'), { timeout: 3000 })
+      .toBeGreaterThan(baseline)
+
+    // Add another — child count should keep growing.
+    const after1 = await readGroupChildCount(page, 'tbl1')
+    await page.locator('[data-testid="loop-add-column"]').click()
+    await expect
+      .poll(async () => readGroupChildCount(page, 'tbl1'), { timeout: 3000 })
+      .toBeGreaterThan(after1)
+  })
+
+  test('removing a column via the right panel shrinks the canvas group child count', async ({
+    page,
+  }) => {
+    await seed(page)
+    await page.goto('/')
+    await expect(fabricCanvas(page)).toBeVisible()
+
+    await selectField(page, 'tbl1')
+    await expect(page.locator('[data-testid="loop-add-column"]')).toBeVisible()
+
+    // Add one so we have 3 columns; then removing one yields a definite
+    // shrink (vs. the seed which has 2 columns + the bgRect — removing
+    // that column might bring the group back to a single rect with no
+    // dividers, which is a valid but less obvious assertion).
+    await page.locator('[data-testid="loop-add-column"]').click()
+    await expect
+      .poll(async () => readGroupChildCount(page, 'tbl1'), { timeout: 3000 })
+      .toBeGreaterThan(0)
+    const beforeRemove = await readGroupChildCount(page, 'tbl1')
+
+    await page.locator('[data-testid="loop-remove-column-2"]').click()
+
+    await expect
+      .poll(async () => readGroupChildCount(page, 'tbl1'), { timeout: 3000 })
+      .toBeLessThan(beforeRemove)
+  })
+
+  test('JSON preview pane reflects the new column key after Add Column', async ({ page }) => {
+    await seed(page)
+    await page.goto('/')
+    await expect(fabricCanvas(page)).toBeVisible()
+    await selectField(page, 'tbl1')
+
+    // The seeded field is `required: true`, so even in the default JSON
+    // preview mode `getTableValue` emits one row carrying every column key
+    // (see `jsonGenerator.ts`). After Add Column the new key (`col3`) must
+    // appear in the rendered preview without any mode toggle.
+    await page.locator('[data-testid="loop-add-column"]').click()
+
+    await expect
+      .poll(async () => (await page.locator('.tg-json-preview').textContent()) ?? '', {
+        timeout: 3000,
+      })
+      .toMatch(/col3/)
+  })
+})

--- a/packages/ui/e2e/table-column-sync.spec.ts
+++ b/packages/ui/e2e/table-column-sync.spec.ts
@@ -240,4 +240,91 @@ test.describe('Table column sync (#38)', () => {
       })
       .toMatch(/col3/)
   })
+
+  test('Header style colour change reflects on the canvas', async ({ page }) => {
+    await seed(page)
+    await page.goto('/')
+    await expect(fabricCanvas(page)).toBeVisible()
+    await selectField(page, 'tbl1')
+    await expect(page.locator('[data-testid="loop-add-column"]')).toBeVisible()
+
+    // Read the colour of the first header-label Textbox before the edit.
+    // The header labels are the children with a `.text` value matching one
+    // of the column labels — A or B from the seed.
+    const readHeaderFill = async (): Promise<string | null> => {
+      return await page.evaluate((id: string) => {
+        interface ChildLike {
+          fill?: string | null
+          text?: string | null
+        }
+        interface FabricLike {
+          getObjects(): Array<{
+            __fieldId?: string
+            getObjects?: () => ChildLike[]
+          }>
+        }
+        const fc = (window as unknown as { __fabricCanvas?: FabricLike }).__fabricCanvas
+        if (!fc) return null
+        const g = fc.getObjects().find((o) => o.__fieldId === id)
+        if (!g?.getObjects) return null
+        const headerLabel = g.getObjects().find((c) => c.text === 'A')
+        return headerLabel?.fill ?? null
+      }, 'tbl1')
+    }
+
+    const before = await readHeaderFill()
+    expect(before).not.toBeNull()
+
+    // Drive the colour change directly through the templateStore so the
+    // test doesn't depend on the visual layout of the right-panel
+    // properties (the colour picker is a native `<input type="color">`,
+    // tricky to operate from Playwright). The store update is exactly
+    // what the user-facing handler does (`updateHeader({ color: '#ff0000' })`).
+    await page.evaluate(() => {
+      interface StoreLike {
+        getState(): {
+          fields: Array<{ id: string; type: string; style: { headerStyle: object } }>
+          updateFieldStyle: (id: string, updates: object) => void
+        }
+      }
+      const w = window as unknown as { __templateStore?: StoreLike }
+      const store = w.__templateStore
+      if (!store) throw new Error('templateStore not exposed; cannot drive headerStyle change')
+      const f = store.getState().fields.find((x) => x.id === 'tbl1')
+      if (!f) throw new Error('tbl1 not found')
+      store.getState().updateFieldStyle('tbl1', {
+        headerStyle: { ...f.style.headerStyle, color: '#ff0000' },
+      })
+    })
+
+    await expect.poll(readHeaderFill, { timeout: 3000 }).toBe('#ff0000')
+  })
+
+  test('focusing a right-panel input auto-selects its full text', async ({ page }) => {
+    await seed(page)
+    await page.goto('/')
+    await expect(fabricCanvas(page)).toBeVisible()
+    await selectField(page, 'tbl1')
+    await expect(page.locator('[data-testid="loop-add-column"]')).toBeVisible()
+
+    // The seeded jsonKey is "rows" (4 chars). After focus + the deferred
+    // select() inside `selectAllOnFocus`, the input's selectionStart
+    // should be 0 and selectionEnd should match the value length.
+    const keyInput = page.locator('[data-testid="loop-jsonkey-input"]')
+    await expect(keyInput).toHaveValue('rows')
+    await keyInput.focus()
+
+    // Wait for the setTimeout(0) in selectAllOnFocus to run.
+    await expect
+      .poll(
+        async () =>
+          await keyInput.evaluate((el: HTMLInputElement) => ({
+            start: el.selectionStart ?? -1,
+            end: el.selectionEnd ?? -1,
+            len: el.value.length,
+          })),
+        { timeout: 2000 },
+      )
+      .toMatchObject({ start: 0, end: 4, len: 4 })
+  })
 })

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -12,10 +12,22 @@ import { ResizeHandle } from './components/ResizeHandle.js'
 import { useKeyboard } from './hooks/useKeyboard.js'
 import { useUiStore } from './store/uiStore.js'
 import { useTemplateStore } from './store/templateStore.js'
+import { useSelectAllOnFocus } from './utils/selectAllOnFocus.js'
 import './App.css'
 
 export function App() {
   useKeyboard()
+  // Auto-select-all on input focus inside the side panels (#38 — UX
+  // follow-up). The properties editor (jsonKey + per-column inputs +
+  // header style controls) lives in `.tg-left-panel`; the structural
+  // tree + JSON preview live in `.tg-right-panel`. Both panels mount
+  // conditionally after onboarding, so we use callback refs (state-
+  // backed) — `useRef` has stable identity and the focus listener would
+  // never re-bind when the panel mounts.
+  const [leftPanelScrollEl, setLeftPanelScrollEl] = useState<HTMLDivElement | null>(null)
+  const [rightPanelScrollEl, setRightPanelScrollEl] = useState<HTMLDivElement | null>(null)
+  useSelectAllOnFocus(leftPanelScrollEl)
+  useSelectAllOnFocus(rightPanelScrollEl)
 
   const theme = useUiStore((s) => s.theme)
   // Onboarding is complete once page 0 has ANY concrete background — either
@@ -50,7 +62,7 @@ export function App() {
                 active selection (GH #19 — content swapped with the right
                 panel). The scrollable content is wrapped so the outer
                 panel's right edge stays free for the resize handle. */}
-            <div className="tg-panel-scroll">
+            <div className="tg-panel-scroll" ref={setLeftPanelScrollEl}>
               <PropertiesPanel />
             </div>
             <ResizeHandle
@@ -96,7 +108,7 @@ export function App() {
                 JSON preview + PDF size estimate (GH #19). Scrollable
                 content wrapped so the outer panel edge stays free for the
                 resize handle. */}
-            <div className="tg-panel-scroll">
+            <div className="tg-panel-scroll" ref={setRightPanelScrollEl}>
               <StructurePanel />
             </div>
           </div>

--- a/packages/ui/src/components/Canvas/__tests__/tableCanvasParts.test.ts
+++ b/packages/ui/src/components/Canvas/__tests__/tableCanvasParts.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest'
+import type { TableColumn } from '@template-goblin/types'
+import {
+  computeColumnBoundaries,
+  computeHeaderHeight,
+  scaledColumnWidths,
+} from '../tableCanvasParts.js'
+
+function col(width: number, key = 'k', label = 'L'): TableColumn {
+  return { key, label, width, style: null, headerStyle: null }
+}
+
+describe('scaledColumnWidths', () => {
+  it('returns [] for zero columns', () => {
+    expect(scaledColumnWidths([], 200)).toEqual([])
+  })
+
+  it('returns [] when totalWidth is non-positive', () => {
+    expect(scaledColumnWidths([col(80), col(120)], 0)).toEqual([])
+    expect(scaledColumnWidths([col(80), col(120)], -10)).toEqual([])
+  })
+
+  it('scales declared widths to fit totalWidth', () => {
+    // declared total = 200, totalWidth = 100 → scale 0.5
+    expect(scaledColumnWidths([col(80), col(120)], 100)).toEqual([40, 60])
+  })
+
+  it('falls back to even split when every declared width is zero', () => {
+    // Treats all-zero as "no declaration" so dividers still appear.
+    expect(scaledColumnWidths([col(0), col(0), col(0)], 120)).toEqual([40, 40, 40])
+  })
+
+  it('treats negative widths as zero', () => {
+    // 100 (only positive) + (-50 → 0) → totalDeclared 100, scale = 200/100 = 2
+    expect(scaledColumnWidths([col(100), col(-50)], 200)).toEqual([200, 0])
+  })
+})
+
+describe('computeColumnBoundaries', () => {
+  it('returns [] for fewer than 2 columns', () => {
+    expect(computeColumnBoundaries([], 200)).toEqual([])
+    expect(computeColumnBoundaries([col(100)], 200)).toEqual([])
+  })
+
+  it('returns [] when totalWidth is non-positive', () => {
+    expect(computeColumnBoundaries([col(50), col(50)], 0)).toEqual([])
+    expect(computeColumnBoundaries([col(50), col(50)], -1)).toEqual([])
+  })
+
+  it('returns N-1 boundaries for N columns', () => {
+    expect(computeColumnBoundaries([col(50), col(50)], 100)).toEqual([50])
+    expect(computeColumnBoundaries([col(50), col(50), col(50)], 150)).toEqual([50, 100])
+    expect(computeColumnBoundaries([col(50), col(50), col(50), col(50)], 200)).toEqual([
+      50, 100, 150,
+    ])
+  })
+
+  it('scales declared widths to fit totalWidth', () => {
+    // declared total = 60, totalWidth = 120 → scale 2 → widths [20, 40, 60]
+    // boundaries are cumulative, excluding the last edge → [20, 60]
+    expect(computeColumnBoundaries([col(10), col(20), col(30)], 120)).toEqual([20, 60])
+  })
+
+  it('uses even split when no column declares a positive width', () => {
+    // Even split fallback should still produce the boundaries.
+    expect(computeColumnBoundaries([col(0), col(0), col(0)], 120)).toEqual([40, 80])
+  })
+})
+
+describe('computeHeaderHeight', () => {
+  it('returns 0 when showHeader is false', () => {
+    expect(computeHeaderHeight(200, false)).toBe(0)
+  })
+
+  it('returns 0 for non-positive totalHeight', () => {
+    expect(computeHeaderHeight(0, true)).toBe(0)
+    expect(computeHeaderHeight(-5, true)).toBe(0)
+  })
+
+  it('returns 22% of totalHeight when that exceeds the floor', () => {
+    // 22% of 200 = 44, well above the 14pt floor.
+    expect(computeHeaderHeight(200, true)).toBe(44)
+  })
+
+  it('clamps up to the 14pt minimum on tiny rects', () => {
+    // 22% of 50 = 11 → bumped up to 14.
+    expect(computeHeaderHeight(50, true)).toBe(14)
+  })
+
+  it('caps at totalHeight when the field is smaller than the minimum', () => {
+    // For a 10pt-tall rect the header would be 14 (floor) but cap to 10
+    // so the divider stays inside the field.
+    expect(computeHeaderHeight(10, true)).toBe(10)
+  })
+})

--- a/packages/ui/src/components/Canvas/fabricUtils.ts
+++ b/packages/ui/src/components/Canvas/fabricUtils.ts
@@ -41,6 +41,7 @@ import type { FieldDefinition } from '@template-goblin/types'
 import { FIELD_COLORS, SELECTED_STROKE_WIDTH } from '../../theme/fieldColors.js'
 import { fieldCanvasLabel } from './fieldLabel.js'
 import { shouldRenderFillRect } from './rectFill.js'
+import { buildTableCanvasParts } from './tableCanvasParts.js'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Coordinate helpers (REQ-036, AC-036)
@@ -735,7 +736,17 @@ export function buildGroupChildren(
     })
   }
 
-  // 3. Auto-fit label (GH #12) — skipped when an image is rendered.
+  // 2.5 Table column dividers + header labels (GH #38). Done before the
+  //     centred body label so a non-empty `style.columns` short-circuits
+  //     it — the column-header labels in the band already convey the
+  //     field's purpose, and a centred field-name label would clash with
+  //     the grid.
+  if (field.type === 'table' && field.style?.columns?.length) {
+    children.push(...buildTableCanvasParts(field, w, h))
+  }
+
+  // 3. Auto-fit label (GH #12) — skipped when an image is rendered, and
+  //    skipped for tables that already drew their column headers above.
   //    Uses a centred `Textbox` (wraps to `labelW`) rather than a plain
   //    `FabricText` with a clipPath.  The previous clipPath approach was
   //    fragile: Fabric positions clipPath relative to the clipped object's
@@ -745,7 +756,9 @@ export function buildGroupChildren(
   //    "max-fit" label that rerenders correctly when the field is
   //    resized (`applyFieldToGroup` rebuilds children on every field
   //    update, so fontSize is recomputed against the new bounds).
-  if (!placeholderResolved) {
+  const skipBodyLabel =
+    placeholderResolved || (field.type === 'table' && (field.style?.columns?.length ?? 0) > 0)
+  if (!skipBodyLabel) {
     const label = fieldCanvasLabel(field)
     if (label) {
       const innerPad = 6

--- a/packages/ui/src/components/Canvas/tableCanvasParts.ts
+++ b/packages/ui/src/components/Canvas/tableCanvasParts.ts
@@ -1,0 +1,146 @@
+/**
+ * Table-specific Fabric children for the canvas (#38).
+ *
+ * The base `buildGroupChildren` in `fabricUtils.ts` handles the bgRect and
+ * (for non-table fields) a centred body label. Tables need column dividers,
+ * a header divider, and per-column header labels so that adding / editing /
+ * removing columns in the right panel produces visible feedback on the
+ * canvas. Without these, the rect rebuild on every field update is a no-op
+ * and the canvas falsely says "nothing changed".
+ *
+ * Pure layout maths live in `computeColumnBoundaries` / `computeHeaderHeight`
+ * so they can be unit-tested without instantiating Fabric.
+ */
+import { Line, Textbox } from 'fabric'
+import type { FabricObject } from 'fabric'
+import type { FieldDefinition, TableColumn } from '@template-goblin/types'
+
+const HEADER_FRACTION = 0.22
+const HEADER_MIN_PT = 14
+const HEADER_MAX_FONT_PT = 12
+const DIVIDER_STROKE = '#0a0a0a'
+const DIVIDER_WIDTH = 0.5
+
+/**
+ * Compute the **scaled** width of each column in points so the cumulative
+ * width fits inside `totalWidth`. Falls back to an even split when no
+ * column declares a positive width — that way dragging the table to a new
+ * size, or seeding malformed columns, still draws visible dividers
+ * instead of collapsing the table to a single rect.
+ */
+export function scaledColumnWidths(columns: TableColumn[], totalWidth: number): number[] {
+  if (columns.length === 0 || totalWidth <= 0) return []
+  const positive = columns.map((c) => (c.width > 0 ? c.width : 0))
+  const totalDeclared = positive.reduce((s, w) => s + w, 0)
+  if (totalDeclared <= 0) {
+    return columns.map(() => totalWidth / columns.length)
+  }
+  const scale = totalWidth / totalDeclared
+  return positive.map((w) => w * scale)
+}
+
+/**
+ * X-coordinates of column dividers — the boundaries BETWEEN columns,
+ * NOT including 0 or `totalWidth`. For N columns this returns N-1 values.
+ * Returns `[]` for fewer than 2 columns or non-positive `totalWidth`.
+ */
+export function computeColumnBoundaries(columns: TableColumn[], totalWidth: number): number[] {
+  if (columns.length < 2 || totalWidth <= 0) return []
+  const ws = scaledColumnWidths(columns, totalWidth)
+  const xs: number[] = []
+  let cum = 0
+  for (let i = 0; i < ws.length - 1; i++) {
+    cum += ws[i] ?? 0
+    xs.push(cum)
+  }
+  return xs
+}
+
+/**
+ * Header band height in points. `0` when the header is hidden or the
+ * field is too small. Caps at `totalHeight` (degenerate templates) so the
+ * divider never sits below the rect.
+ */
+export function computeHeaderHeight(totalHeight: number, showHeader: boolean): number {
+  if (!showHeader || totalHeight <= 0) return 0
+  const ideal = Math.max(HEADER_MIN_PT, totalHeight * HEADER_FRACTION)
+  return Math.min(ideal, totalHeight)
+}
+
+/**
+ * Build the table-specific Fabric children: column dividers, header
+ * divider, and per-column header labels. Returns `[]` for non-table fields
+ * or when the field has no columns (fall through to the centred body label
+ * `buildGroupChildren` already produces).
+ */
+export function buildTableCanvasParts(
+  field: FieldDefinition,
+  width: number,
+  height: number,
+): FabricObject[] {
+  if (field.type !== 'table' || !field.style) return []
+  const columns = field.style.columns ?? []
+  if (columns.length === 0) return []
+  const showHeader = !!field.style.showHeader
+
+  const boundaries = computeColumnBoundaries(columns, width)
+  const headerH = computeHeaderHeight(height, showHeader)
+  const widths = scaledColumnWidths(columns, width)
+  const parts: FabricObject[] = []
+
+  for (const x of boundaries) {
+    parts.push(
+      new Line([x, 0, x, height], {
+        stroke: DIVIDER_STROKE,
+        strokeWidth: DIVIDER_WIDTH,
+        strokeUniform: true,
+        selectable: false,
+        evented: false,
+      }),
+    )
+  }
+
+  if (showHeader && headerH > 0 && headerH < height) {
+    parts.push(
+      new Line([0, headerH, width, headerH], {
+        stroke: DIVIDER_STROKE,
+        strokeWidth: DIVIDER_WIDTH,
+        strokeUniform: true,
+        selectable: false,
+        evented: false,
+      }),
+    )
+  }
+
+  if (showHeader && headerH > 0) {
+    let leftCum = 0
+    const padding = 4
+    for (let i = 0; i < columns.length; i++) {
+      const colWidth = widths[i] ?? 0
+      const labelText = columns[i]?.label || columns[i]?.key || ''
+      if (labelText && colWidth > padding * 2) {
+        const fontSize = Math.max(8, Math.min(HEADER_MAX_FONT_PT, headerH * 0.6))
+        parts.push(
+          new Textbox(labelText, {
+            left: leftCum + colWidth / 2,
+            top: headerH / 2,
+            width: Math.max(1, colWidth - padding),
+            fontSize,
+            fontFamily: 'Helvetica',
+            fontWeight: 'bold',
+            fill: '#0a0a0a',
+            textAlign: 'center',
+            originX: 'center',
+            originY: 'center',
+            selectable: false,
+            evented: false,
+            splitByGrapheme: false,
+          }),
+        )
+      }
+      leftCum += colWidth
+    }
+  }
+
+  return parts
+}

--- a/packages/ui/src/components/Canvas/tableCanvasParts.ts
+++ b/packages/ui/src/components/Canvas/tableCanvasParts.ts
@@ -3,23 +3,29 @@
  *
  * The base `buildGroupChildren` in `fabricUtils.ts` handles the bgRect and
  * (for non-table fields) a centred body label. Tables need column dividers,
- * a header divider, and per-column header labels so that adding / editing /
- * removing columns in the right panel produces visible feedback on the
- * canvas. Without these, the rect rebuild on every field update is a no-op
- * and the canvas falsely says "nothing changed".
+ * a header band, and per-column header labels so that adding / editing /
+ * removing columns — or tweaking the header style — produces visible
+ * feedback on the canvas. Without these, the rect rebuild on every field
+ * update is a no-op and the canvas falsely says "nothing changed".
+ *
+ * Header typography, fill colour, divider colour, alignment, and
+ * horizontal padding are read from `style.headerStyle` so that user edits
+ * in the right panel reflect on canvas (#38, second pass).
  *
  * Pure layout maths live in `computeColumnBoundaries` / `computeHeaderHeight`
  * so they can be unit-tested without instantiating Fabric.
  */
-import { Line, Textbox } from 'fabric'
+import { Rect, Line, Textbox } from 'fabric'
 import type { FabricObject } from 'fabric'
-import type { FieldDefinition, TableColumn } from '@template-goblin/types'
+import type { CellStyle, FieldDefinition, TableColumn } from '@template-goblin/types'
 
 const HEADER_FRACTION = 0.22
 const HEADER_MIN_PT = 14
-const HEADER_MAX_FONT_PT = 12
-const DIVIDER_STROKE = '#0a0a0a'
-const DIVIDER_WIDTH = 0.5
+const HEADER_MAX_FONT_PT = 16
+const DEFAULT_DIVIDER_STROKE = '#0a0a0a'
+const DEFAULT_DIVIDER_WIDTH = 0.5
+const DEFAULT_HEADER_COLOR = '#0a0a0a'
+const DEFAULT_HEADER_FONT_FAMILY = 'Helvetica'
 
 /**
  * Compute the **scaled** width of each column in points so the cumulative
@@ -68,10 +74,10 @@ export function computeHeaderHeight(totalHeight: number, showHeader: boolean): n
 }
 
 /**
- * Build the table-specific Fabric children: column dividers, header
- * divider, and per-column header labels. Returns `[]` for non-table fields
- * or when the field has no columns (fall through to the centred body label
- * `buildGroupChildren` already produces).
+ * Build the table-specific Fabric children: header background, column
+ * dividers, header divider, and per-column header labels. Returns `[]`
+ * for non-table fields or when the field has no columns (fall through to
+ * the centred body label `buildGroupChildren` already produces).
  */
 export function buildTableCanvasParts(
   field: FieldDefinition,
@@ -82,17 +88,45 @@ export function buildTableCanvasParts(
   const columns = field.style.columns ?? []
   if (columns.length === 0) return []
   const showHeader = !!field.style.showHeader
+  const headerStyle = field.style.headerStyle as CellStyle | undefined
 
   const boundaries = computeColumnBoundaries(columns, width)
   const headerH = computeHeaderHeight(height, showHeader)
   const widths = scaledColumnWidths(columns, width)
   const parts: FabricObject[] = []
 
+  // Header background fill — paints a band behind the labels so the
+  // user's chosen `headerStyle.backgroundColor` is visible. Skipped when
+  // the colour is empty/transparent or the header is hidden.
+  const headerBg = headerStyle?.backgroundColor
+  if (showHeader && headerH > 0 && isVisibleColor(headerBg)) {
+    parts.push(
+      new Rect({
+        left: 0,
+        top: 0,
+        width,
+        height: headerH,
+        fill: headerBg,
+        selectable: false,
+        evented: false,
+        originX: 'left',
+        originY: 'top',
+      }),
+    )
+  }
+
+  const headerBorder = headerStyle?.borderColor
+  const dividerStroke = isVisibleColor(headerBorder) ? headerBorder : DEFAULT_DIVIDER_STROKE
+  const dividerWidth =
+    typeof headerStyle?.borderWidth === 'number' && headerStyle.borderWidth > 0
+      ? headerStyle.borderWidth
+      : DEFAULT_DIVIDER_WIDTH
+
   for (const x of boundaries) {
     parts.push(
       new Line([x, 0, x, height], {
-        stroke: DIVIDER_STROKE,
-        strokeWidth: DIVIDER_WIDTH,
+        stroke: dividerStroke,
+        strokeWidth: dividerWidth,
         strokeUniform: true,
         selectable: false,
         evented: false,
@@ -103,8 +137,8 @@ export function buildTableCanvasParts(
   if (showHeader && headerH > 0 && headerH < height) {
     parts.push(
       new Line([0, headerH, width, headerH], {
-        stroke: DIVIDER_STROKE,
-        strokeWidth: DIVIDER_WIDTH,
+        stroke: dividerStroke,
+        strokeWidth: dividerWidth,
         strokeUniform: true,
         selectable: false,
         evented: false,
@@ -113,23 +147,34 @@ export function buildTableCanvasParts(
   }
 
   if (showHeader && headerH > 0) {
+    const padL = Math.max(0, headerStyle?.paddingLeft ?? 0)
+    const padR = Math.max(0, headerStyle?.paddingRight ?? 0)
+    const userFontSize =
+      typeof headerStyle?.fontSize === 'number' && headerStyle.fontSize > 0
+        ? headerStyle.fontSize
+        : null
+    const fontCap = Math.max(8, Math.min(HEADER_MAX_FONT_PT, headerH * 0.6))
+    const fontSize = userFontSize !== null ? Math.min(userFontSize, fontCap) : fontCap
+
     let leftCum = 0
-    const padding = 4
     for (let i = 0; i < columns.length; i++) {
       const colWidth = widths[i] ?? 0
       const labelText = columns[i]?.label || columns[i]?.key || ''
-      if (labelText && colWidth > padding * 2) {
-        const fontSize = Math.max(8, Math.min(HEADER_MAX_FONT_PT, headerH * 0.6))
+      const innerW = Math.max(1, colWidth - padL - padR)
+      if (labelText && colWidth > padL + padR + 2) {
         parts.push(
           new Textbox(labelText, {
-            left: leftCum + colWidth / 2,
+            left: leftCum + padL + innerW / 2,
             top: headerH / 2,
-            width: Math.max(1, colWidth - padding),
+            width: innerW,
             fontSize,
-            fontFamily: 'Helvetica',
-            fontWeight: 'bold',
-            fill: '#0a0a0a',
-            textAlign: 'center',
+            fontFamily: headerStyle?.fontFamily || DEFAULT_HEADER_FONT_FAMILY,
+            fontWeight: headerStyle?.fontWeight || 'bold',
+            fontStyle: headerStyle?.fontStyle || 'normal',
+            underline: headerStyle?.textDecoration === 'underline',
+            linethrough: headerStyle?.textDecoration === 'line-through',
+            fill: headerStyle?.color || DEFAULT_HEADER_COLOR,
+            textAlign: headerStyle?.align || 'center',
             originX: 'center',
             originY: 'center',
             selectable: false,
@@ -143,4 +188,14 @@ export function buildTableCanvasParts(
   }
 
   return parts
+}
+
+/**
+ * Whether a colour value is meaningful to render. Empty / null / `none` /
+ * `transparent` all map to "skip"; everything else is forwarded to Fabric.
+ */
+function isVisibleColor(c: string | null | undefined): c is string {
+  if (!c) return false
+  const s = c.trim().toLowerCase()
+  return s.length > 0 && s !== 'transparent' && s !== 'none'
 }

--- a/packages/ui/src/components/RightPanel/LoopFieldProps.tsx
+++ b/packages/ui/src/components/RightPanel/LoopFieldProps.tsx
@@ -158,6 +158,7 @@ export function LoopFieldProps({ field }: Props) {
               </span>
               <input
                 className="tg-input"
+                data-testid="loop-jsonkey-input"
                 value={displayKey}
                 onChange={(e) => onJsonKeyChange(e.target.value)}
               />

--- a/packages/ui/src/components/RightPanel/LoopFieldProps.tsx
+++ b/packages/ui/src/components/RightPanel/LoopFieldProps.tsx
@@ -273,6 +273,7 @@ export function LoopFieldProps({ field }: Props) {
                   className="tg-btn tg-btn--danger"
                   style={{ fontSize: 10, padding: '2px 6px' }}
                   onClick={() => removeColumn(i)}
+                  data-testid={`loop-remove-column-${i}`}
                 >
                   Remove
                 </button>
@@ -326,6 +327,7 @@ export function LoopFieldProps({ field }: Props) {
           className="tg-btn"
           style={{ width: '100%', justifyContent: 'center', fontSize: 11 }}
           onClick={addColumn}
+          data-testid="loop-add-column"
         >
           + Add Column
         </button>

--- a/packages/ui/src/store/templateStore.ts
+++ b/packages/ui/src/store/templateStore.ts
@@ -981,3 +981,12 @@ export const useTemplateStore = create<TemplateState>()(
     },
   ),
 )
+
+// Expose for Playwright / dev-mode inspection (mirrors `__fabricCanvas` in
+// `useFabricCanvas.ts`). Lets e2e tests drive store updates without
+// reaching into private React internals — used by the table-column-sync
+// spec to flip headerStyle.color and assert the canvas re-renders.
+if (typeof window !== 'undefined' && import.meta.env.DEV) {
+  ;(window as unknown as { __templateStore?: typeof useTemplateStore }).__templateStore =
+    useTemplateStore
+}

--- a/packages/ui/src/utils/selectAllOnFocus.ts
+++ b/packages/ui/src/utils/selectAllOnFocus.ts
@@ -1,0 +1,69 @@
+/**
+ * Auto-select-all when an input inside a scoped container gains focus.
+ *
+ * Wired by `useSelectAllOnFocus(ref)` on the right-panel scroll root in
+ * `App.tsx`. Uses the native `focusin` event (which bubbles, unlike
+ * `focus`) so we catch focus events from any descendant input/textarea.
+ * React's synthetic `onFocus` *does* bubble in modern React, but a native
+ * listener is unambiguous and survives portal/strict-mode quirks — same
+ * UX whether the user clicks or tabs in.
+ *
+ * The `select()` is deferred via `setTimeout(0)` so the click's mouseup
+ * doesn't position the caret over the selection. We also bail when the
+ * input already has a manually-dragged selection (start !== end at
+ * deferred time) — that preserves user-drag selections.
+ *
+ * Skipped element types: `color`, `file`, `range`, `checkbox`, `radio`,
+ * `button`, `submit`, `reset`, `image` — `select()` is meaningless or
+ * actively wrong on these.
+ */
+import { useEffect } from 'react'
+
+const SKIP_INPUT_TYPES = new Set([
+  'color',
+  'file',
+  'range',
+  'checkbox',
+  'radio',
+  'button',
+  'submit',
+  'reset',
+  'image',
+])
+
+function handleFocusIn(target: EventTarget | null): void {
+  if (!(target instanceof HTMLInputElement) && !(target instanceof HTMLTextAreaElement)) {
+    return
+  }
+  if (target instanceof HTMLInputElement && SKIP_INPUT_TYPES.has(target.type)) {
+    return
+  }
+  setTimeout(() => {
+    if (document.activeElement !== target) return
+    if (target.selectionStart !== target.selectionEnd) return
+    try {
+      target.select()
+    } catch {
+      // Some input types (e.g. number on Safari) throw on .select() —
+      // safe to swallow; the user just doesn't get auto-select there.
+    }
+  }, 0)
+}
+
+/**
+ * Attach a `focusin` listener to a scoped element. Pass a state-backed
+ * element (via callback ref) so the effect re-runs when the element
+ * mounts — `useRef` won't trigger this since the ref OBJECT is stable
+ * even when its `.current` populates after first paint, and the right
+ * panel mounts conditionally after onboarding.
+ */
+export function useSelectAllOnFocus(el: HTMLElement | null): void {
+  useEffect(() => {
+    if (!el) return
+    function listener(e: FocusEvent) {
+      handleFocusIn(e.target)
+    }
+    el.addEventListener('focusin', listener)
+    return () => el.removeEventListener('focusin', listener)
+  }, [el])
+}


### PR DESCRIPTION
## Summary

- Closes #38 — adding / editing / removing a column on a table field now produces visible feedback on the canvas. Pre-fix, `style.columns` updated in the store but the canvas drew every table as a single labelled rect, so the per-update rebuild was a visual no-op.
- Header style edits in the properties panel (font, colour, background, borders, padding, alignment) flow through to the rendered header band on canvas.
- UX polish: clicking or tabbing into any input inside the side panels auto-selects its existing value, so the next keystroke replaces it instead of appending.

## What changed

**Canvas rendering** (`tableCanvasParts.ts`, new file)
- Vertical `Line` per inter-column boundary (N-1 for N columns), positioned by cumulative scaled column widths so the grid fits inside the field rect regardless of declared widths.
- Header band: `Rect` filled with `headerStyle.backgroundColor`, horizontal `Line` divider at the band bottom, per-column `Textbox` labels honouring `headerStyle` typography (`fontFamily`, `fontSize` capped at the band's natural max, `fontWeight`, `fontStyle`, underline / linethrough, `color`, `align`, `paddingLeft/Right`).
- Pure layout helpers (`scaledColumnWidths`, `computeColumnBoundaries`, `computeHeaderHeight`) live in the same file and are unit-tested without instantiating Fabric.

**Reconcile path** (`fabricUtils.ts`)
- `buildGroupChildren` calls `buildTableCanvasParts` after the bgRect when the field is a non-empty table, and skips the centred body label for those tables (column-header Textboxes convey the field's purpose; a centred field-name label would clash).
- `+13 lines` on a file already over the 300-line cap. The new logic lives in the new sibling file; this file's growth is just the integration point.

**Side-panel auto-select** (`utils/selectAllOnFocus.ts`, new file)
- `useSelectAllOnFocus(el)` hook attaches a native `focusin` listener to a scoped element. Native (not React's synthetic `onFocus`) because under HMR the React handler dropped events on a div parent — the native listener is unambiguous.
- Wired to **both** `.tg-panel-scroll` roots in `App.tsx` — properties editor (`tg-left-panel`) and structure tree (`tg-right-panel`). Despite the folder name `RightPanel/`, the property-editor inputs live in the LEFT panel since #19 swapped them.
- Callback ref + state, not `useRef` — the right panel mounts conditionally after onboarding, and a ref-object's stable identity meant the focus listener never re-bound.
- `select()` is deferred via `setTimeout(0)` so the click's mouseup doesn't position the caret over the selection. Bails when the input has a manual drag-selection in progress (start !== end at deferred time). Skips non-text input types (color, file, range, checkbox, radio, button, submit, reset, image).

**Test infra**
- `data-testid` on the right-panel Add Column / Remove / JSON-Key buttons.
- `window.__templateStore` exposed in DEV (mirrors the existing `__fabricCanvas`) so e2e can drive store updates without reaching into private React internals.

## Test plan

- [x] `pnpm type-check` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 436 unit tests pass (15 new for `tableCanvasParts` pure helpers)
- [x] `pnpm build` clean
- [x] `pnpm test:e2e -- table-column-sync.spec.ts` — 5 tests pass:
  - Add Column grows the canvas group's child count; second Add grows it again
  - Remove on the third column shrinks the count
  - JSON preview pane picks up the new column key (`col3`) after Add Column
  - `headerStyle.color` change reflects on the canvas Textbox `fill`
  - Focusing a side-panel input auto-selects its full text