### PR TITLE
fix(ui): Add Page dialog improvements — inherit skip + match image + neutral labels + stable layout (#47)

### DIFF
--- a/.changeset/add-page-dialog-improvements.md
+++ b/.changeset/add-page-dialog-improvements.md
@@ -1,0 +1,22 @@
+---
+'template-goblin-ui': minor
+---
+
+Add Page dialog UX (#47):
+
+- "Same as previous page" no longer routes through the size step. The
+  new page commits immediately with the previous page's dimensions —
+  consistent with what the option's label implies.
+- The size picker labels are country-neutral: "US Letter" / "US Legal"
+  → "Letter" / "Legal". The underlying `PageSize` keys are unchanged.
+- Picking "Custom" no longer grows the dialog. The width/height inputs
+  reserve their bounding box at all times (visibility-hidden,
+  pointer-events-none, tab-skipped, aria-hidden when not selected) so
+  the parent dialog stays anchored. The dialog also carries an explicit
+  `minWidth` / `minHeight` so step transitions don't reflow the modal
+  either.
+- When the user picks Image upload, the size picker now opens with a
+  "Match image (W × H pt)" radio at the top, pre-selected with the
+  uploaded image's natural pixel dimensions. That's the most sensible
+  default for an image-bg page (no scaling, no crop, native aspect
+  ratio).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,15 @@ developers use the npm library to generate PDFs at scale.
     footer in commit messages or PR bodies, no `Authored-By: claude…`.
     Commit messages stay tool-free and read as if a human wrote them.
     Same rule for PR descriptions.
+14. **Every major version bump must be reflected in git.** When
+    `pnpm changeset version` produces a `MAJOR` bump on any published
+    package (e.g. `template-goblin` 1.x → 2.0.0), the version-bump
+    commit MUST be followed by an annotated git tag matching the new
+    version (`git tag -a v2.0.0 -m "v2.0.0"`) AND a GitHub Release
+    (`gh release create v<n>.0.0 --generate-notes`) so the new major is
+    discoverable from the GitHub UI and from `git tag --list`. Tag
+    AFTER pushing the version commit; never tag a local-only commit.
+    Minor and patch bumps don't require this — tag only on majors.
 
 ## Tech Stack
 

--- a/packages/ui/e2e/add-page-dialog.spec.ts
+++ b/packages/ui/e2e/add-page-dialog.spec.ts
@@ -1,0 +1,244 @@
+/**
+ * E2E for `AddPageDialog` — issue #47 regressions and follow-up UX.
+ *
+ * Covered:
+ *   1. "Same as previous page" → new page added immediately, no size dialog
+ *      shown. Stored width/height match the previous page's dimensions.
+ *   2. "Solid color" → routes through the size step (the issue's primary
+ *      ask: every non-inherit type asks for size).
+ *   3. The size picker shows neither "US Letter" nor "US Legal" — the
+ *      labels are country-neutral now.
+ *   4. Picking "Custom" inside the size picker does NOT grow the dialog
+ *      (width or height) — siblings stay anchored.
+ *   5. The custom width/height inputs are tab-skipped while a preset is
+ *      selected (a11y; their slot exists but is hidden).
+ */
+import type { Page } from '@playwright/test'
+import { test, expect } from '@playwright/test'
+
+async function seed(page: Page): Promise<void> {
+  // Onboard with a single solid-color page so the toolbar (and "+ Add Page"
+  // button) are visible and `previousSize` resolves to a known value.
+  const payload = {
+    state: {
+      meta: {
+        schemaVersion: 1,
+        name: 'add-page-dialog-test',
+        version: '0.0.0',
+        width: 595,
+        height: 842,
+        locked: false,
+      },
+      fields: [],
+      fonts: [],
+      groups: [],
+      pages: [
+        {
+          id: 'p0',
+          index: 0,
+          backgroundType: 'color',
+          backgroundColor: '#ffffff',
+          backgroundFilename: null,
+          width: 595,
+          height: 842,
+          pageSize: 'A4',
+        },
+      ],
+      backgroundDataUrl: null,
+      backgroundBuffer: null,
+      pageBackgroundDataUrls: [],
+      pageBackgroundBuffers: [],
+      fontBuffers: [],
+      placeholderBuffers: [],
+      staticImageBuffers: [],
+      staticImageDataUrls: [],
+    },
+    version: 2,
+  }
+  await page.addInitScript((s: string) => {
+    return new Promise<void>((resolve, reject) => {
+      const req = indexedDB.open('template-goblin', 1)
+      req.onupgradeneeded = () => {
+        const db = req.result
+        if (!db.objectStoreNames.contains('kv')) db.createObjectStore('kv')
+      }
+      req.onsuccess = () => {
+        const db = req.result
+        const tx = db.transaction('kv', 'readwrite')
+        tx.objectStore('kv').put(s, 'template-goblin-template')
+        tx.oncomplete = () => {
+          localStorage.removeItem('template-goblin-ui')
+          resolve()
+        }
+        tx.onerror = () => reject(tx.error)
+      }
+      req.onerror = () => reject(req.error)
+    })
+  }, JSON.stringify(payload))
+}
+
+function fabricCanvas(page: Page) {
+  return page.locator('[data-testid="canvas-stage-wrapper"] canvas').first()
+}
+
+async function openAddPage(page: Page): Promise<void> {
+  // The "+ Add Page" button is in PageBar; click via its aria/text.
+  await page
+    .locator('button', { hasText: /\+ Add Page|Add page/i })
+    .first()
+    .click()
+  await expect(page.locator('.tg-dialog-title', { hasText: 'Add New Page' })).toBeVisible()
+}
+
+interface PersistedState {
+  pages?: Array<{
+    id: string
+    index: number
+    backgroundType: string
+    backgroundColor: string | null
+    width?: number
+    height?: number
+  }>
+}
+
+async function readPages(page: Page): Promise<PersistedState['pages']> {
+  return await page.evaluate(async () => {
+    const db = await new Promise<IDBDatabase>((resolve, reject) => {
+      const req = indexedDB.open('template-goblin', 1)
+      req.onsuccess = () => resolve(req.result)
+      req.onerror = () => reject(req.error)
+    })
+    const raw = await new Promise<string | undefined>((resolve, reject) => {
+      const tx = db.transaction('kv', 'readonly')
+      const req = tx.objectStore('kv').get('template-goblin-template') as IDBRequest<
+        string | undefined
+      >
+      tx.oncomplete = () => resolve(req.result)
+      tx.onerror = () => reject(tx.error)
+    })
+    if (!raw) return undefined
+    const parsed = JSON.parse(raw) as { state?: PersistedState }
+    return parsed.state?.pages
+  })
+}
+
+test.describe('Add Page dialog (#47)', () => {
+  test('Same as previous page commits without showing the size step', async ({ page }) => {
+    await seed(page)
+    await page.goto('/')
+    await expect(fabricCanvas(page)).toBeVisible()
+    await openAddPage(page)
+
+    // Click the inherit option. The dialog should close without ever
+    // rendering the size picker — assert by looking for the "Page size:"
+    // step prompt that the size step renders.
+    const sizeStepProbe = page.locator('text=Page size:')
+    expect(await sizeStepProbe.count()).toBe(0)
+    await page.locator('[data-testid="add-page-inherit"]').click()
+    // Dialog dismissed.
+    await expect(page.locator('.tg-dialog-title', { hasText: 'Add New Page' })).toBeHidden()
+
+    // The new page should carry forward the previous page's dimensions
+    // verbatim — that's the "inherit" contract. `snapshotSameAsPrevious`
+    // in `usePageHandlers` materialises the previous page's background
+    // (color in this seed) directly into the new page, so the stored
+    // `backgroundType` matches the previous page rather than literally
+    // being `'inherit'`. The visible behaviour is identical.
+    const pages = await readPages(page)
+    expect(pages?.length).toBe(2)
+    const newPage = pages?.find((p) => p.index === 1)
+    expect(newPage?.backgroundType).toBe('color')
+    expect(newPage?.backgroundColor).toBe('#ffffff')
+    expect(newPage?.width).toBe(595)
+    expect(newPage?.height).toBe(842)
+  })
+
+  test('Solid color routes through the size step (asks for dimensions)', async ({ page }) => {
+    await seed(page)
+    await page.goto('/')
+    await expect(fabricCanvas(page)).toBeVisible()
+    await openAddPage(page)
+
+    await page.locator('button', { hasText: /Solid color/ }).click()
+    // Color step.
+    await page.locator('button', { hasText: /Next: page size/ }).click()
+    // Size step is visible.
+    await expect(page.locator('text=Page size:')).toBeVisible()
+    // "Same as previous (... × ... pt)" radio is the default for "previous".
+    await expect(page.locator(`text=Same as previous (595 × 842 pt)`)).toBeVisible()
+  })
+
+  test('Size picker labels do not advertise a country (no "US Letter" / "US Legal")', async ({
+    page,
+  }) => {
+    await seed(page)
+    await page.goto('/')
+    await expect(fabricCanvas(page)).toBeVisible()
+    await openAddPage(page)
+    await page.locator('button', { hasText: /Solid color/ }).click()
+    await page.locator('button', { hasText: /Next: page size/ }).click()
+    await expect(page.locator('text=Page size:')).toBeVisible()
+
+    const dialog = page.locator('.tg-dialog')
+    const text = (await dialog.textContent()) ?? ''
+    expect(text).toMatch(/Letter \(/)
+    expect(text).toMatch(/Legal \(/)
+    expect(text).not.toMatch(/US Letter/)
+    expect(text).not.toMatch(/US Legal/)
+  })
+
+  test('selecting Custom does not change the dialog bounding box', async ({ page }) => {
+    await seed(page)
+    await page.goto('/')
+    await expect(fabricCanvas(page)).toBeVisible()
+    await openAddPage(page)
+    await page.locator('button', { hasText: /Solid color/ }).click()
+    await page.locator('button', { hasText: /Next: page size/ }).click()
+    await expect(page.locator('text=Page size:')).toBeVisible()
+
+    const dialog = page.locator('.tg-dialog')
+    const before = await dialog.boundingBox()
+    expect(before).not.toBeNull()
+
+    // Click the Custom radio.
+    await page.locator('label', { hasText: /^Custom$/ }).click()
+
+    // Layout settles; capture again.
+    const after = await dialog.boundingBox()
+    expect(after).not.toBeNull()
+
+    // Width and height should be identical (or within sub-pixel rounding).
+    // Previously the dialog grew by ~70px in height when Custom was
+    // picked; the reserved-slot fix in `PageSizePicker.tsx` keeps the
+    // bounds stable.
+    expect(Math.abs((after!.width ?? 0) - (before!.width ?? 0))).toBeLessThanOrEqual(1)
+    expect(Math.abs((after!.height ?? 0) - (before!.height ?? 0))).toBeLessThanOrEqual(1)
+  })
+
+  test('custom width/height inputs are tab-skipped while a preset is selected', async ({
+    page,
+  }) => {
+    await seed(page)
+    await page.goto('/')
+    await expect(fabricCanvas(page)).toBeVisible()
+    await openAddPage(page)
+    await page.locator('button', { hasText: /Solid color/ }).click()
+    await page.locator('button', { hasText: /Next: page size/ }).click()
+    await expect(page.locator('text=Page size:')).toBeVisible()
+
+    // The custom block is rendered (reserved slot) but `tabIndex={-1}`
+    // when not the selected option, and `aria-hidden="true"`. Both probes:
+    const widthInput = page.locator('input[type="number"]').first()
+    expect(await widthInput.evaluate((el) => (el as HTMLInputElement).tabIndex)).toBe(-1)
+    expect(
+      await widthInput.evaluate((el) => el.closest('[aria-hidden]')?.getAttribute('aria-hidden')),
+    ).toBe('true')
+
+    // After picking Custom, the inputs become tab-reachable.
+    await page.locator('label', { hasText: /^Custom$/ }).click()
+    expect(await widthInput.evaluate((el) => (el as HTMLInputElement).tabIndex)).toBe(0)
+    expect(
+      await widthInput.evaluate((el) => el.closest('[aria-hidden]')?.getAttribute('aria-hidden')),
+    ).toBe('false')
+  })
+})

--- a/packages/ui/e2e/add-page-dialog.spec.ts
+++ b/packages/ui/e2e/add-page-dialog.spec.ts
@@ -215,6 +215,63 @@ test.describe('Add Page dialog (#47)', () => {
     expect(Math.abs((after!.height ?? 0) - (before!.height ?? 0))).toBeLessThanOrEqual(1)
   })
 
+  test('Image upload shows "Match image" as the first option, pre-selected with natural dimensions', async ({
+    page,
+  }) => {
+    await seed(page)
+    await page.goto('/')
+    await expect(fabricCanvas(page)).toBeVisible()
+    await openAddPage(page)
+
+    // 4×4 red PNG — distinct natural dimensions from the seeded page
+    // (595×842 A4) so the "Match image" radio's label is unambiguous.
+    const TINY_PNG_BYTES = Buffer.from(
+      'iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAYAAACp8Z5+AAAAEklEQVR4XmP8z8AARBgAcwBQEgEDA' +
+        'XAGRgwAAAAASUVORK5CYII=',
+      'base64',
+    )
+
+    // Drive the hidden file input scoped inside the dialog (other file
+    // inputs exist on the page — toolbar Open .tgbl, FontManager, etc.).
+    await page
+      .locator('.tg-dialog input[type="file"][accept="image/*"]')
+      .setInputFiles({ name: 'tiny.png', mimeType: 'image/png', buffer: TINY_PNG_BYTES })
+
+    // Size step renders. Match image must be the FIRST radio (above
+    // Same as previous), labelled with the decoded natural size (4×4).
+    await expect(page.locator('text=Page size:')).toBeVisible()
+    const matchLabel = page.locator('label', { hasText: /^Match image \(4 × 4 pt\)/ })
+    await expect(matchLabel).toBeVisible()
+
+    // First radio in the picker = match image. Verify by reading every
+    // visible label's text content in DOM order and checking index 0
+    // mentions "Match image".
+    const labels = await page
+      .locator('.tg-dialog label')
+      .filter({ hasText: /(Match image|Same as previous|A4|A3|A5|Letter|Legal|Custom)/ })
+      .allTextContents()
+    expect(labels[0]).toMatch(/Match image/)
+
+    // Default selection should be Match image.
+    const matchRadio = matchLabel.locator('input[type="radio"]')
+    await expect(matchRadio).toBeChecked()
+
+    // Confirm Add Page → the new page's stored dimensions equal the
+    // image's natural size (4×4 pt), proving the match path resolved
+    // correctly even though preset radios for A4/Letter/etc. are
+    // available alongside.
+    await page.getByRole('button', { name: 'Add Page', exact: true }).click()
+
+    // Image-bg pages persist async (FileReader → addPage). Poll until
+    // the new page lands.
+    await expect.poll(async () => (await readPages(page))?.length ?? 0, { timeout: 5000 }).toBe(2)
+    const pages = await readPages(page)
+    const newPage = pages?.find((p) => p.index === 1)
+    expect(newPage?.width).toBe(4)
+    expect(newPage?.height).toBe(4)
+    expect(newPage?.backgroundType).toBe('image')
+  })
+
   test('custom width/height inputs are tab-skipped while a preset is selected', async ({
     page,
   }) => {

--- a/packages/ui/src/components/Canvas/AddPageDialog.tsx
+++ b/packages/ui/src/components/Canvas/AddPageDialog.tsx
@@ -59,7 +59,15 @@ export function AddPageDialog({
 
   return (
     <div className="tg-dialog-overlay" onClick={onClose}>
-      <div className="tg-dialog" onClick={(e) => e.stopPropagation()}>
+      <div
+        className="tg-dialog"
+        onClick={(e) => e.stopPropagation()}
+        // Lock the dialog width so picking "Custom" inside the size picker
+        // (which adds a two-input row) doesn't widen the modal and shift
+        // every other label sideways. Min-height absorbs the height delta
+        // between the choose / color / size steps for the same reason.
+        style={{ minWidth: 360, minHeight: 320 }}
+      >
         <h3 className="tg-dialog-title">Add New Page</h3>
 
         {step === 'choose' && (
@@ -100,7 +108,16 @@ export function AddPageDialog({
               <button
                 className="tg-btn"
                 style={{ justifyContent: 'flex-start', padding: '10px 14px' }}
-                onClick={() => gotoSize({ kind: 'inherit' })}
+                onClick={() =>
+                  // Inherit means "same as previous page" — including
+                  // dimensions. Skip the size dialog entirely (#47).
+                  onAdd('inherit', {
+                    pageSize: 'custom',
+                    width: previousSize.width,
+                    height: previousSize.height,
+                  })
+                }
+                data-testid="add-page-inherit"
               >
                 <svg
                   width="16"

--- a/packages/ui/src/components/Canvas/AddPageDialog.tsx
+++ b/packages/ui/src/components/Canvas/AddPageDialog.tsx
@@ -37,10 +37,14 @@ export function AddPageDialog({
   const [bgPick, setBgPick] = useState<Step1 | null>(null)
 
   // Step-2 state — default to "match previous" since most sheets in a
-  // multi-page doc keep the same paper size.
+  // multi-page doc keep the same paper size. Image uploads override this
+  // to "match" (the uploaded image's natural dimensions) below.
   const [sizeChoice, setSizeChoice] = useState<PageSizeChoice>('previous')
   const [customWidth, setCustomWidth] = useState(previousSize.width)
   const [customHeight, setCustomHeight] = useState(previousSize.height)
+  // Decoded natural dimensions of the user's uploaded image — drives the
+  // "Match image" radio in the size picker.
+  const [imageNatural, setImageNatural] = useState<{ width: number; height: number } | null>(null)
 
   const fileInputRef = useRef<HTMLInputElement>(null)
 
@@ -49,9 +53,47 @@ export function AddPageDialog({
     setStep('size')
   }
 
+  /**
+   * Decode the uploaded image's natural dimensions in a hidden HTMLImageElement
+   * before transitioning to the size step. We default `sizeChoice` to
+   * 'match' AND pre-fill the custom width/height with those numbers so the
+   * picker opens with the natural size selected and a sensible fallback if
+   * the user switches to Custom.
+   */
+  function pickImage(file: File) {
+    const url = URL.createObjectURL(file)
+    const img = new window.Image()
+    img.onload = () => {
+      const natural = { width: img.naturalWidth, height: img.naturalHeight }
+      setImageNatural(natural)
+      setCustomWidth(natural.width)
+      setCustomHeight(natural.height)
+      setSizeChoice('match')
+      setBgPick({ kind: 'image', bgFile: file })
+      setStep('size')
+      URL.revokeObjectURL(url)
+    }
+    img.onerror = () => {
+      // Fallback: skip the natural-size pre-fill and let the user pick a
+      // preset like every other flow.
+      URL.revokeObjectURL(url)
+      setImageNatural(null)
+      setSizeChoice('previous')
+      setBgPick({ kind: 'image', bgFile: file })
+      setStep('size')
+    }
+    img.src = url
+  }
+
   function commit() {
     if (!bgPick) return
-    const size = resolveChoice(sizeChoice, customWidth, customHeight, previousSize)
+    const size = resolveChoice(
+      sizeChoice,
+      customWidth,
+      customHeight,
+      previousSize,
+      imageNatural ?? undefined,
+    )
     if (bgPick.kind === 'image') onAdd('image', size, undefined, bgPick.bgFile)
     else if (bgPick.kind === 'inherit') onAdd('inherit', size)
     else onAdd('color', size, bgPick.color)
@@ -100,7 +142,7 @@ export function AddPageDialog({
                 hidden
                 onChange={(e) => {
                   const file = e.target.files?.[0]
-                  if (file) gotoSize({ kind: 'image', bgFile: file })
+                  if (file) pickImage(file)
                   e.target.value = ''
                 }}
               />
@@ -197,6 +239,7 @@ export function AddPageDialog({
               value={sizeChoice}
               onChange={setSizeChoice}
               previousSize={previousSize}
+              matchImage={imageNatural ?? undefined}
               customWidth={customWidth}
               customHeight={customHeight}
               setCustomWidth={setCustomWidth}

--- a/packages/ui/src/components/Canvas/PageSizePicker.tsx
+++ b/packages/ui/src/components/Canvas/PageSizePicker.tsx
@@ -10,7 +10,7 @@ import { PAGE_SIZE_PRESETS, type PageSize } from '@template-goblin/types'
  * The component is fully controlled — callers own the `value` and the
  * custom-width/height inputs so the picker has no internal state.
  */
-export type PageSizeChoice = 'previous' | PageSize
+export type PageSizeChoice = 'previous' | 'match' | PageSize
 
 export interface PageSizePickerProps {
   value: PageSizeChoice
@@ -20,6 +20,13 @@ export interface PageSizePickerProps {
   setCustomWidth: (v: number) => void
   setCustomHeight: (v: number) => void
   previousSize?: { width: number; height: number }
+  /**
+   * Natural dimensions of an image the user just uploaded. When supplied,
+   * a "Match image" radio renders FIRST in the list — that's the most
+   * sensible default for an image-bg page (preserves the image's native
+   * aspect ratio, no scaling artefacts on the canvas or in the PDF).
+   */
+  matchImage?: { width: number; height: number }
 }
 
 export function PageSizePicker({
@@ -30,6 +37,7 @@ export function PageSizePicker({
   setCustomWidth,
   setCustomHeight,
   previousSize,
+  matchImage,
 }: PageSizePickerProps) {
   const presets: { key: PageSize; label: string }[] = [
     { key: 'A4', label: 'A4 (595 × 842 pt)' },
@@ -40,6 +48,13 @@ export function PageSizePicker({
   ]
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+      {matchImage && (
+        <Radio
+          checked={value === 'match'}
+          onChange={() => onChange('match')}
+          label={`Match image (${matchImage.width} × ${matchImage.height} pt)`}
+        />
+      )}
       {previousSize && (
         <Radio
           checked={value === 'previous'}
@@ -122,21 +137,26 @@ export function PageSizePicker({
 /**
  * Resolve a PageSizeChoice into concrete (pageSize, width, height). Mirrors
  * `getPageSize` semantics — preset keys consult `PAGE_SIZE_PRESETS`,
- * `'previous'` echoes the supplied previousSize, `'custom'` uses the inputs.
+ * `'previous'` echoes the supplied previousSize, `'match'` echoes the
+ * supplied uploaded-image natural size, `'custom'` uses the inputs.
  */
 export function resolveChoice(
   choice: PageSizeChoice,
   customWidth: number,
   customHeight: number,
   previousSize?: { width: number; height: number },
+  matchImage?: { width: number; height: number },
 ): { pageSize: PageSize; width: number; height: number } {
+  if (choice === 'match' && matchImage) {
+    return { pageSize: 'custom', width: matchImage.width, height: matchImage.height }
+  }
   if (choice === 'previous' && previousSize) {
     return { pageSize: 'custom', width: previousSize.width, height: previousSize.height }
   }
   if (choice === 'custom') {
     return { pageSize: 'custom', width: customWidth, height: customHeight }
   }
-  if (choice === 'previous') {
+  if (choice === 'match' || choice === 'previous') {
     // Fallback: no previous size supplied. Treat as A4.
     return { pageSize: 'A4', ...PAGE_SIZE_PRESETS.A4 }
   }

--- a/packages/ui/src/components/Canvas/PageSizePicker.tsx
+++ b/packages/ui/src/components/Canvas/PageSizePicker.tsx
@@ -35,8 +35,8 @@ export function PageSizePicker({
     { key: 'A4', label: 'A4 (595 × 842 pt)' },
     { key: 'A3', label: 'A3 (842 × 1191 pt)' },
     { key: 'A5', label: 'A5 (420 × 595 pt)' },
-    { key: 'Letter', label: 'US Letter (612 × 792 pt)' },
-    { key: 'Legal', label: 'US Legal (612 × 1008 pt)' },
+    { key: 'Letter', label: 'Letter (612 × 792 pt)' },
+    { key: 'Legal', label: 'Legal (612 × 1008 pt)' },
   ]
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
@@ -56,8 +56,23 @@ export function PageSizePicker({
         />
       ))}
       <Radio checked={value === 'custom'} onChange={() => onChange('custom')} label="Custom" />
-      {value === 'custom' && (
-        <div style={{ display: 'flex', gap: 12, marginTop: 8 }}>
+      {/*
+        Reserve the slot for the custom width/height inputs even when the
+        user has a preset selected, so switching to "Custom" doesn't grow
+        the picker (and therefore the parent dialog) — siblings below stay
+        in place. `visibility: hidden` keeps the bounding box; the inputs
+        skip tab order and pointer events when hidden.
+      */}
+      <div style={{ minHeight: 60, marginTop: 8 }}>
+        <div
+          style={{
+            display: 'flex',
+            gap: 12,
+            visibility: value === 'custom' ? 'visible' : 'hidden',
+            pointerEvents: value === 'custom' ? 'auto' : 'none',
+          }}
+          aria-hidden={value !== 'custom'}
+        >
           <div style={{ flex: 1 }}>
             <label
               style={{
@@ -75,6 +90,7 @@ export function PageSizePicker({
               min={1}
               value={customWidth}
               onChange={(e) => setCustomWidth(Number(e.target.value))}
+              tabIndex={value === 'custom' ? 0 : -1}
             />
           </div>
           <div style={{ flex: 1 }}>
@@ -94,10 +110,11 @@ export function PageSizePicker({
               min={1}
               value={customHeight}
               onChange={(e) => setCustomHeight(Number(e.target.value))}
+              tabIndex={value === 'custom' ? 0 : -1}
             />
           </div>
         </div>
-      )}
+      </div>
     </div>
   )
 }

--- a/packages/ui/src/components/Toolbar/PageSizeDialog.tsx
+++ b/packages/ui/src/components/Toolbar/PageSizeDialog.tsx
@@ -31,8 +31,8 @@ export function PageSizeDialog() {
   const presetOptions: PageSizeOption[] = [
     { label: 'A4 (595 x 842 pt)', pageSize: 'A4', width: 595, height: 842 },
     { label: 'A3 (842 x 1191 pt)', pageSize: 'A3', width: 842, height: 1191 },
-    { label: 'US Letter (612 x 792 pt)', pageSize: 'Letter', width: 612, height: 792 },
-    { label: 'US Legal (612 x 1008 pt)', pageSize: 'Legal', width: 612, height: 1008 },
+    { label: 'Letter (612 x 792 pt)', pageSize: 'Letter', width: 612, height: 792 },
+    { label: 'Legal (612 x 1008 pt)', pageSize: 'Legal', width: 612, height: 1008 },
   ]
 
   function handleApply() {


### PR DESCRIPTION
## Summary

- Closes #47 — every non-inherit background type asks for size; inherit skips the size step.
- Image uploads pre-fill a "Match image" option at the top of the size picker.
- Picking "Custom" no longer grows the dialog (siblings stay anchored).
- Size labels are country-neutral ("US Letter" → "Letter", "US Legal" → "Legal").
- Adds Hard Rule #13's sibling: tag + GitHub Release on every major version bump (Hard Rule #14, doc-only).

## What changed

**`AddPageDialog.tsx`**
- "Same as previous page" commits inherit page directly, no size step.
- Image upload decodes the file's `naturalWidth` / `naturalHeight` in a hidden `HTMLImageElement`, pre-fills `customWidth/Height`, and passes the natural size as `matchImage` to the picker so the radio defaults to "Match image".
- Outer `.tg-dialog` has explicit `minWidth: 360, minHeight: 320` so step transitions don't reflow the modal.

**`PageSizePicker.tsx`**
- New optional `matchImage` prop renders "Match image (W × H pt)" first when supplied. `PageSizeChoice` extended with `'match'`. `resolveChoice` honours it.
- Custom width/height block reserves its slot at all times — `visibility: hidden` + `pointer-events: none` + `tabIndex={-1}` + `aria-hidden="true"` when not the selected option, flipping to visible/interactive on Custom. Layout stable across the click.
- Letter / Legal preset labels no longer carry the "US " prefix. Same for `PageSizeDialog.tsx` (toolbar onboarding flow).

**`CLAUDE.md`**
- Hard Rule #14: every MAJOR version bump from `pnpm changeset version` must be followed by an annotated git tag (`git tag -a v<n>.0.0 -m "v<n>.0.0"`) AND a GitHub Release (`gh release create v<n>.0.0 --generate-notes`). Minor / patch don't need it.

## Test plan

- [x] `pnpm type-check` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 436 unit tests pass (no new unit tests in this PR; coverage is e2e)
- [x] `pnpm build` clean
- [x] `pnpm test:e2e -- add-page-dialog.spec.ts` — 6 tests pass:
  - Same as previous skips the size step; new page carries forward width/height
  - Solid color routes through size step with previous-size default radio
  - Picker contains "Letter (..." / "Legal (..." but NOT "US Letter" / "US Legal"
  - Dialog `boundingBox()` is unchanged across the Custom click (sub-pixel tolerance)
  - Custom inputs are `tabIndex={-1}` + `aria-hidden="true"` until Custom is picked
  - Image upload shows "Match image (4 × 4 pt)" as the first radio, pre-selected; Add Page persists `width=4, height=4, backgroundType='image'`

## Issues filed during the work

- #58 bug+feat — "Change Background" toolbar button broken on update + reuse Add-Page popup. Active.
- #59, #60, #61, #62 — v3 enhancements (page reorder, zoom-input toggle, header/footer, page-number options).