### PR TITLE
fix(ui): "Change Background" updates the current page + size-step "Same as Current" label (#58)

### DIFF
--- a/.changeset/change-background-dialog.md
+++ b/.changeset/change-background-dialog.md
@@ -1,0 +1,21 @@
+---
+'template-goblin-ui': minor
+---
+
+Change Background button (#58):
+
+- Renamed the toolbar "BG" button to "Change Background" with a tooltip.
+- Clicking it now opens the same modal as "+ Add Page" (image / solid
+  color / inherit) instead of going straight to a file picker. The
+  user can change the current page's background to any of the three
+  kinds, not only an image.
+- Fixed: changing to a new image now actually updates the canvas. The
+  pre-fix path called the legacy `setBackground` action, which writes
+  only `backgroundDataUrl` / `backgroundBuffer`; multi-page templates
+  read per-page bytes from `pageBackgroundDataUrls`, so the canvas
+  silently kept showing the old image. The new handler updates the
+  current page entry via `updatePage` + `setPageBackground`.
+- In Change Background mode, the size step's "Same as previous"
+  radio now reads "Same as Current (W × H pt)" — the radio's value is
+  the current page's size in this flow, so "previous" was the wrong
+  word. The Add Page flow keeps "Same as previous".

--- a/packages/ui/e2e/change-background.spec.ts
+++ b/packages/ui/e2e/change-background.spec.ts
@@ -162,6 +162,25 @@ async function openChangeBgDialog(page: Page): Promise<void> {
 }
 
 test.describe('Change Background dialog (#58)', () => {
+  test('size picker shows "Same as Current" in edit mode (not "Same as previous")', async ({
+    page,
+  }) => {
+    await seed(page, { multiPage: false })
+    await page.goto('/')
+    await expect(fabricCanvas(page)).toBeVisible()
+    await openChangeBgDialog(page)
+
+    // Solid color routes through the size step where the radio renders.
+    await page.locator('button', { hasText: /Solid color/ }).click()
+    await page.locator('button', { hasText: /Next: page size/ }).click()
+    await expect(page.locator('text=Page size:')).toBeVisible()
+
+    const dialog = page.locator('.tg-dialog')
+    const text = (await dialog.textContent()) ?? ''
+    expect(text).toMatch(/Same as Current \(595 × 842 pt\)/)
+    expect(text).not.toMatch(/Same as previous \(/)
+  })
+
   test('toolbar button is labelled "Change Background"', async ({ page }) => {
     await seed(page, { multiPage: false })
     await page.goto('/')
@@ -229,7 +248,7 @@ test.describe('Change Background dialog (#58)', () => {
     expect(updated?.backgroundColor?.toLowerCase()).toBe('#ff8800')
   })
 
-  test('changing to "Same as previous" sets backgroundType to inherit (multi-page)', async ({
+  test('changing the bg to inherit (Same as previous page) flips backgroundType (multi-page)', async ({
     page,
   }) => {
     await seed(page, { multiPage: true })
@@ -239,7 +258,6 @@ test.describe('Change Background dialog (#58)', () => {
     // previous page to inherit from.
     await page.locator('button', { hasText: /^Page 2$/ }).click()
     await openChangeBgDialog(page)
-
     await page.locator('[data-testid="add-page-inherit"]').click()
 
     await expect

--- a/packages/ui/e2e/change-background.spec.ts
+++ b/packages/ui/e2e/change-background.spec.ts
@@ -1,0 +1,252 @@
+/**
+ * E2E for the Change Background dialog (#58).
+ *
+ * Pre-fix: the toolbar "BG" button opened a file picker that updated only
+ * the legacy `backgroundDataUrl`. For multi-page templates the canvas
+ * reads from `pageBackgroundDataUrls.get(pageId)`, so a new image had no
+ * visual effect. Post-fix the button reuses `AddPageDialog` in `mode="edit"`,
+ * offering image / solid color / inherit. The handler updates the CURRENT
+ * page entry via `updatePage` + `setPageBackground`.
+ *
+ * Covered:
+ *   1. Toolbar button is labelled "Change Background" (was "BG").
+ *   2. Image: upload → store and canvas pick up the new bytes.
+ *   3. Solid color: pick a hex → page's `backgroundType` flips to 'color'
+ *      with the chosen colour persisted.
+ *   4. Same as previous: page's `backgroundType` flips to 'inherit'
+ *      (multi-page templates only).
+ */
+import type { Page } from '@playwright/test'
+import { test, expect } from '@playwright/test'
+
+const BLUE_PNG_BASE64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAYAAACp8Z5+AAAAFElEQVR4XmNkYGD4z8DAwMgABFAGA' +
+  'AYbAQEDjC1nAAAAAElFTkSuQmCC'
+
+interface SeedOpts {
+  multiPage: boolean
+}
+
+async function seed(page: Page, { multiPage }: SeedOpts): Promise<void> {
+  const pages: Record<string, unknown>[] = [
+    {
+      id: 'p0',
+      index: 0,
+      backgroundType: 'color',
+      backgroundColor: '#ffffff',
+      backgroundFilename: null,
+      width: 595,
+      height: 842,
+      pageSize: 'A4',
+    },
+  ]
+  if (multiPage) {
+    pages.push({
+      id: 'p1',
+      index: 1,
+      backgroundType: 'color',
+      backgroundColor: '#cce5ff',
+      backgroundFilename: null,
+      width: 595,
+      height: 842,
+      pageSize: 'A4',
+    })
+  }
+  const payload = {
+    state: {
+      meta: {
+        schemaVersion: 1,
+        name: 'change-bg-test',
+        version: '0.0.0',
+        width: 595,
+        height: 842,
+        locked: false,
+      },
+      fields: [],
+      fonts: [],
+      groups: [],
+      pages,
+      backgroundDataUrl: null,
+      backgroundBuffer: null,
+      pageBackgroundDataUrls: [],
+      pageBackgroundBuffers: [],
+      fontBuffers: [],
+      placeholderBuffers: [],
+      staticImageBuffers: [],
+      staticImageDataUrls: [],
+    },
+    version: 2,
+  }
+  await page.addInitScript((s: string) => {
+    return new Promise<void>((resolve, reject) => {
+      const req = indexedDB.open('template-goblin', 1)
+      req.onupgradeneeded = () => {
+        const db = req.result
+        if (!db.objectStoreNames.contains('kv')) db.createObjectStore('kv')
+      }
+      req.onsuccess = () => {
+        const db = req.result
+        const tx = db.transaction('kv', 'readwrite')
+        tx.objectStore('kv').put(s, 'template-goblin-template')
+        tx.oncomplete = () => {
+          localStorage.removeItem('template-goblin-ui')
+          resolve()
+        }
+        tx.onerror = () => reject(tx.error)
+      }
+      req.onerror = () => reject(req.error)
+    })
+  }, JSON.stringify(payload))
+}
+
+function fabricCanvas(page: Page) {
+  return page.locator('[data-testid="canvas-stage-wrapper"] canvas').first()
+}
+
+interface PersistedPage {
+  id: string
+  index: number
+  backgroundType: string
+  backgroundColor: string | null
+  backgroundFilename: string | null
+}
+
+async function readPage(page: Page, pageId: string): Promise<PersistedPage | undefined> {
+  return await page.evaluate(async (id: string) => {
+    const db = await new Promise<IDBDatabase>((resolve, reject) => {
+      const req = indexedDB.open('template-goblin', 1)
+      req.onsuccess = () => resolve(req.result)
+      req.onerror = () => reject(req.error)
+    })
+    const raw = await new Promise<string | undefined>((resolve, reject) => {
+      const tx = db.transaction('kv', 'readonly')
+      const req = tx.objectStore('kv').get('template-goblin-template') as IDBRequest<
+        string | undefined
+      >
+      tx.oncomplete = () => resolve(req.result)
+      tx.onerror = () => reject(tx.error)
+    })
+    if (!raw) return undefined
+    const parsed = JSON.parse(raw) as { state?: { pages?: PersistedPage[] } }
+    return parsed.state?.pages?.find((p) => p.id === id)
+  }, pageId)
+}
+
+async function readPageBackgroundDataUrl(page: Page, pageId: string): Promise<string | null> {
+  return await page.evaluate(async (id: string) => {
+    const db = await new Promise<IDBDatabase>((resolve, reject) => {
+      const req = indexedDB.open('template-goblin', 1)
+      req.onsuccess = () => resolve(req.result)
+      req.onerror = () => reject(req.error)
+    })
+    const raw = await new Promise<string | undefined>((resolve, reject) => {
+      const tx = db.transaction('kv', 'readonly')
+      const req = tx.objectStore('kv').get('template-goblin-template') as IDBRequest<
+        string | undefined
+      >
+      tx.oncomplete = () => resolve(req.result)
+      tx.onerror = () => reject(tx.error)
+    })
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as {
+      state?: { pageBackgroundDataUrls?: Array<[string, string]> }
+    }
+    const entry = parsed.state?.pageBackgroundDataUrls?.find(([k]) => k === id)
+    return entry?.[1] ?? null
+  }, pageId)
+}
+
+async function openChangeBgDialog(page: Page): Promise<void> {
+  await page.locator('[data-testid="toolbar-change-background"]').click()
+  await expect(page.locator('.tg-dialog-title', { hasText: 'Change Background' })).toBeVisible()
+}
+
+test.describe('Change Background dialog (#58)', () => {
+  test('toolbar button is labelled "Change Background"', async ({ page }) => {
+    await seed(page, { multiPage: false })
+    await page.goto('/')
+    await expect(fabricCanvas(page)).toBeVisible()
+    const btn = page.locator('[data-testid="toolbar-change-background"]')
+    await expect(btn).toContainText(/Change Background/i)
+    // The old "BG" label should not appear in the toolbar text.
+    const toolbarText = (await page.locator('.tg-toolbar').textContent()) ?? ''
+    expect(toolbarText).not.toMatch(/^BG$|\bBG\b(?!\.)/)
+  })
+
+  test('changing to a new image updates the canvas and per-page bg map', async ({ page }) => {
+    await seed(page, { multiPage: false })
+    await page.goto('/')
+    await expect(fabricCanvas(page)).toBeVisible()
+    await openChangeBgDialog(page)
+
+    const buffer = Buffer.from(BLUE_PNG_BASE64, 'base64')
+    // The dialog's hidden file input is scoped inside `.tg-dialog`.
+    await page
+      .locator('.tg-dialog input[type="file"][accept="image/*"]')
+      .setInputFiles({ name: 'blue.png', mimeType: 'image/png', buffer })
+
+    // Size step → confirm with Match image (the default for image flow).
+    await page.getByRole('button', { name: 'Apply', exact: true }).click()
+
+    // The async FileReader chain in `handleChangeBackground` lands the
+    // bytes in `pageBackgroundDataUrls`. Poll for the per-page entry.
+    await expect
+      .poll(async () => readPageBackgroundDataUrl(page, 'p0'), { timeout: 5000 })
+      .toMatch(/^data:image\/png;base64,/)
+    const updated = await readPage(page, 'p0')
+    expect(updated?.backgroundType).toBe('image')
+    expect(updated?.width).toBe(4)
+    expect(updated?.height).toBe(4)
+  })
+
+  test('changing to a solid colour flips backgroundType and persists the colour', async ({
+    page,
+  }) => {
+    await seed(page, { multiPage: false })
+    await page.goto('/')
+    await expect(fabricCanvas(page)).toBeVisible()
+    await openChangeBgDialog(page)
+
+    await page.locator('button', { hasText: /Solid color/ }).click()
+
+    // Set a non-default colour. React owns the value via a controlled
+    // input, so we call its native setter and dispatch the `input` event
+    // — Playwright's `fill()` doesn't apply to `<input type="color">`,
+    // and a plain `el.value = X` is overwritten by React's next render.
+    await page.locator('input[type="color"]').evaluate((el: HTMLInputElement) => {
+      const proto = Object.getPrototypeOf(el)
+      const setter = Object.getOwnPropertyDescriptor(proto, 'value')?.set
+      setter?.call(el, '#ff8800')
+      el.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+    await page.locator('button', { hasText: /Next: page size/ }).click()
+    await page.getByRole('button', { name: 'Apply', exact: true }).click()
+
+    await expect
+      .poll(async () => (await readPage(page, 'p0'))?.backgroundType, { timeout: 3000 })
+      .toBe('color')
+    const updated = await readPage(page, 'p0')
+    expect(updated?.backgroundColor?.toLowerCase()).toBe('#ff8800')
+  })
+
+  test('changing to "Same as previous" sets backgroundType to inherit (multi-page)', async ({
+    page,
+  }) => {
+    await seed(page, { multiPage: true })
+    await page.goto('/')
+    await expect(fabricCanvas(page)).toBeVisible()
+    // Switch to Page 2 first — inherit only makes sense when there's a
+    // previous page to inherit from.
+    await page.locator('button', { hasText: /^Page 2$/ }).click()
+    await openChangeBgDialog(page)
+
+    await page.locator('[data-testid="add-page-inherit"]').click()
+
+    await expect
+      .poll(async () => (await readPage(page, 'p1'))?.backgroundType, { timeout: 3000 })
+      .toBe('inherit')
+    const updated = await readPage(page, 'p1')
+    expect(updated?.backgroundColor).toBeNull()
+    expect(updated?.backgroundFilename).toBeNull()
+  })
+})

--- a/packages/ui/src/components/Canvas/AddPageDialog.tsx
+++ b/packages/ui/src/components/Canvas/AddPageDialog.tsx
@@ -252,6 +252,7 @@ export function AddPageDialog({
               value={sizeChoice}
               onChange={setSizeChoice}
               previousSize={previousSize}
+              previousSizeLabel={mode === 'edit' ? 'Same as Current' : 'Same as previous'}
               matchImage={imageNatural ?? undefined}
               customWidth={customWidth}
               customHeight={customHeight}

--- a/packages/ui/src/components/Canvas/AddPageDialog.tsx
+++ b/packages/ui/src/components/Canvas/AddPageDialog.tsx
@@ -22,10 +22,21 @@ export function AddPageDialog({
   onClose,
   onAdd,
   previousSize,
+  mode = 'add',
 }: {
   onClose: () => void
   onAdd: (bgType: PageBackgroundType, size: AddPageSize, bgColor?: string, bgFile?: File) => void
   previousSize: { width: number; height: number }
+  /**
+   * `'add'` (default) — the dialog adds a brand-new page after the current
+   * sheet; the title reads "Add New Page" and the action button reads
+   * "Add Page".
+   * `'edit'` — the dialog changes the *current* page's background; the
+   * title reads "Change Background" and the action button reads "Apply".
+   * `inherit` in this mode means "match the previous page's background"
+   * — the same semantics it has in add mode.
+   */
+  mode?: 'add' | 'edit'
 }) {
   type Step1 =
     | { kind: 'image'; bgFile: File }
@@ -110,7 +121,9 @@ export function AddPageDialog({
         // between the choose / color / size steps for the same reason.
         style={{ minWidth: 360, minHeight: 320 }}
       >
-        <h3 className="tg-dialog-title">Add New Page</h3>
+        <h3 className="tg-dialog-title">
+          {mode === 'edit' ? 'Change Background' : 'Add New Page'}
+        </h3>
 
         {step === 'choose' && (
           <>
@@ -258,8 +271,12 @@ export function AddPageDialog({
               >
                 Back
               </button>
-              <button className="tg-btn tg-btn--primary" onClick={commit}>
-                Add Page
+              <button
+                className="tg-btn tg-btn--primary"
+                onClick={commit}
+                data-testid="add-page-confirm"
+              >
+                {mode === 'edit' ? 'Apply' : 'Add Page'}
               </button>
             </div>
           </div>

--- a/packages/ui/src/components/Canvas/CanvasArea.tsx
+++ b/packages/ui/src/components/Canvas/CanvasArea.tsx
@@ -267,6 +267,21 @@ export function CanvasArea() {
         />
       )}
 
+      {pageHandlers.showChangeBgDialog && (
+        <AddPageDialog
+          mode="edit"
+          onClose={() => pageHandlers.setShowChangeBgDialog(false)}
+          onAdd={pageHandlers.handleChangeBackground}
+          previousSize={(() => {
+            // In edit mode the "previous size" pre-fill is the size of the
+            // page being edited — same logic as add mode.
+            const cur = pages.find((p) => p.id === currentPageId)
+            const last = [...pages].sort((a, b) => b.index - a.index)[0]
+            return getPageSize(cur ?? last ?? null, meta)
+          })()}
+        />
+      )}
+
       {pageHandlers.pendingDraft && (
         <FieldCreationPopup
           draft={pageHandlers.pendingDraft}

--- a/packages/ui/src/components/Canvas/PageSizePicker.tsx
+++ b/packages/ui/src/components/Canvas/PageSizePicker.tsx
@@ -21,6 +21,14 @@ export interface PageSizePickerProps {
   setCustomHeight: (v: number) => void
   previousSize?: { width: number; height: number }
   /**
+   * Wording for the `previousSize` radio. Defaults to "Same as previous"
+   * (right for add-page flows where the user is creating a NEW page after
+   * the current one). The Change Background dialog passes "Same as
+   * Current" because, in edit mode, the radio's `previousSize` IS the
+   * current page's size — "previous" reads wrong there.
+   */
+  previousSizeLabel?: string
+  /**
    * Natural dimensions of an image the user just uploaded. When supplied,
    * a "Match image" radio renders FIRST in the list — that's the most
    * sensible default for an image-bg page (preserves the image's native
@@ -37,6 +45,7 @@ export function PageSizePicker({
   setCustomWidth,
   setCustomHeight,
   previousSize,
+  previousSizeLabel = 'Same as previous',
   matchImage,
 }: PageSizePickerProps) {
   const presets: { key: PageSize; label: string }[] = [
@@ -59,7 +68,7 @@ export function PageSizePicker({
         <Radio
           checked={value === 'previous'}
           onChange={() => onChange('previous')}
-          label={`Same as previous (${previousSize.width} × ${previousSize.height} pt)`}
+          label={`${previousSizeLabel} (${previousSize.width} × ${previousSize.height} pt)`}
         />
       )}
       {presets.map((p) => (

--- a/packages/ui/src/components/Canvas/usePageHandlers.ts
+++ b/packages/ui/src/components/Canvas/usePageHandlers.ts
@@ -24,6 +24,9 @@ function generatePageId(): string {
 export function usePageHandlers() {
   const addPage = useTemplateStore((s) => s.addPage)
   const removePage = useTemplateStore((s) => s.removePage)
+  const updatePage = useTemplateStore((s) => s.updatePage)
+  const setPageBackground = useTemplateStore((s) => s.setPageBackground)
+  const setBackground = useTemplateStore((s) => s.setBackground)
   const reset = useTemplateStore((s) => s.reset)
   const pages = useTemplateStore((s) => s.pages)
   const pageBackgroundDataUrls = useTemplateStore((s) => s.pageBackgroundDataUrls)
@@ -33,8 +36,14 @@ export function usePageHandlers() {
   const setCurrentPage = useUiStore((s) => s.setCurrentPage)
   const setPendingBackground = useUiStore((s) => s.setPendingBackground)
   const setShowPageSizeDialog = useUiStore((s) => s.setShowPageSizeDialog)
+  const currentPageId = useUiStore((s) => s.currentPageId)
 
   const [showAddPageDialog, setShowAddPageDialog] = useState(false)
+  // The Change Background dialog is global (uiStore) so the Toolbar
+  // button — which lives outside CanvasArea — can open it without prop
+  // drilling through the layout tree.
+  const showChangeBgDialog = useUiStore((s) => s.showChangeBgDialog)
+  const setShowChangeBgDialog = useUiStore((s) => s.setShowChangeBgDialog)
   const [isDragOver, setIsDragOver] = useState(false)
   const fileInputRef = useRef<HTMLInputElement>(null)
   const { pendingDraft, setPendingDraft, handlePopupConfirm, handlePopupCancel } =
@@ -164,6 +173,82 @@ export function usePageHandlers() {
     [pages, pageBackgroundDataUrls, pageBackgroundBuffers, addPage, setCurrentPage],
   )
 
+  // ── Change background of the current page (#58) ────────────────────────
+
+  /**
+   * Replace the *current page's* background. Mirrors `handleAddPage`'s
+   * branching on `bgType` but updates the existing page entry instead of
+   * appending a new one. Also updates the legacy `backgroundDataUrl`
+   * fields as a backstop for code paths that still consult them.
+   *
+   * Pre-#58 the BG button hit `setBackground` which writes only the legacy
+   * fields, so multi-page templates (where the canvas reads from
+   * `pageBackgroundDataUrls`) saw no change at all.
+   */
+  const handleChangeBackground = useCallback(
+    (
+      bgType: PageBackgroundType,
+      size: { pageSize: PageSize; width: number; height: number },
+      bgColor?: string,
+      bgFile?: File,
+    ) => {
+      setShowChangeBgDialog(false)
+
+      const allPages = useTemplateStore.getState().pages
+      const targetId =
+        currentPageId !== null && allPages.some((p) => p.id === currentPageId)
+          ? currentPageId
+          : (allPages.find((p) => p.index === 0)?.id ?? null)
+      if (!targetId) return
+
+      const sized = { width: size.width, height: size.height, pageSize: size.pageSize }
+
+      if (bgType === 'inherit') {
+        updatePage(targetId, {
+          backgroundType: 'inherit',
+          backgroundColor: null,
+          backgroundFilename: null,
+          ...sized,
+        })
+        return
+      }
+
+      if (bgType === 'color') {
+        updatePage(targetId, {
+          backgroundType: 'color',
+          backgroundColor: bgColor ?? '#ffffff',
+          backgroundFilename: null,
+          ...sized,
+        })
+        return
+      }
+
+      if (bgType === 'image' && bgFile) {
+        const reader = new FileReader()
+        reader.onload = () => {
+          const dataUrl = reader.result as string
+          const bufReader = new FileReader()
+          bufReader.onload = () => {
+            updatePage(targetId, {
+              backgroundType: 'image',
+              backgroundColor: null,
+              backgroundFilename: `backgrounds/${targetId}.png`,
+              ...sized,
+            })
+            setPageBackground(targetId, dataUrl, bufReader.result as ArrayBuffer)
+            // Backstop: pre-pages-schema saved templates (and the single-page
+            // legacy preview path) still consult `backgroundDataUrl`. Keep
+            // it in sync so neither path renders a stale image.
+            setBackground(dataUrl, bufReader.result as ArrayBuffer)
+          }
+          bufReader.readAsArrayBuffer(bgFile)
+        }
+        reader.readAsDataURL(bgFile)
+      }
+    },
+    [currentPageId, updatePage, setPageBackground, setBackground],
+  )
+
   // ── Remove page ────────────────────────────────────────────────────────
 
   const handleRemovePage = useCallback(
@@ -225,6 +310,8 @@ export function usePageHandlers() {
     // State
     showAddPageDialog,
     setShowAddPageDialog,
+    showChangeBgDialog,
+    setShowChangeBgDialog,
     isDragOver,
     fileInputRef,
     pendingDraft,
@@ -237,6 +324,7 @@ export function usePageHandlers() {
     handleDragLeave,
     handleInputChange,
     handleAddPage,
+    handleChangeBackground,
     handleRemovePage,
   }
 }

--- a/packages/ui/src/components/Toolbar/Toolbar.tsx
+++ b/packages/ui/src/components/Toolbar/Toolbar.tsx
@@ -248,7 +248,12 @@ export function Toolbar() {
           Open
         </button>
         <input ref={fileInputRef} type="file" accept=".tgbl" hidden onChange={handleOpenFile} />
-        <button className="tg-btn" onClick={() => bgInputRef.current?.click()}>
+        <button
+          className="tg-btn"
+          onClick={() => useUiStore.getState().setShowChangeBgDialog(true)}
+          title="Change the current page's background"
+          data-testid="toolbar-change-background"
+        >
           <svg
             width="14"
             height="14"
@@ -261,7 +266,7 @@ export function Toolbar() {
             <circle cx="8.5" cy="8.5" r="1.5" />
             <polyline points="21 15 16 10 5 21" />
           </svg>
-          BG
+          Change Background
         </button>
         <input ref={bgInputRef} type="file" accept="image/*" hidden onChange={handleBgUpload} />
       </div>

--- a/packages/ui/src/store/uiStore.ts
+++ b/packages/ui/src/store/uiStore.ts
@@ -33,6 +33,11 @@ export interface UiState {
   showLeftPanel: boolean
   /** Whether the page size dialog is open */
   showPageSizeDialog: boolean
+  /**
+   * Whether the Change Background dialog is open. Reuses `AddPageDialog`
+   * in `mode="edit"` to update the current page's background (#58).
+   */
+  showChangeBgDialog: boolean
   /** Whether the font manager dialog is open */
   showFontManager: boolean
   /** Pending background image for page size dialog */
@@ -85,6 +90,7 @@ export interface UiState {
   setShowRightPanel: (show: boolean) => void
   setShowLeftPanel: (show: boolean) => void
   setShowPageSizeDialog: (show: boolean) => void
+  setShowChangeBgDialog: (show: boolean) => void
   setShowFontManager: (show: boolean) => void
   setPendingBackground: (bg: UiState['pendingBackground']) => void
   setContextMenu: (menu: UiState['contextMenu']) => void
@@ -116,6 +122,7 @@ export const useUiStore = create<UiState>()(
       showRightPanel: true,
       showLeftPanel: true,
       showPageSizeDialog: false,
+      showChangeBgDialog: false,
       showFontManager: false,
       pendingBackground: null,
       contextMenu: null,
@@ -161,6 +168,7 @@ export const useUiStore = create<UiState>()(
       setShowRightPanel: (show) => set({ showRightPanel: show }),
       setShowLeftPanel: (show) => set({ showLeftPanel: show }),
       setShowPageSizeDialog: (show) => set({ showPageSizeDialog: show }),
+      setShowChangeBgDialog: (show) => set({ showChangeBgDialog: show }),
       setShowFontManager: (show) => set({ showFontManager: show }),
       setPendingBackground: (bg) => set({ pendingBackground: bg }),
       setContextMenu: (menu) => set({ contextMenu: menu }),


### PR DESCRIPTION
## Summary

- Closes #58 — the toolbar "BG" button is renamed to "Change Background", and clicking it now opens the same modal as "+ Add Page" (image / solid color / inherit) instead of going straight to a file picker.
- **Bug fix**: changing to a new image now actually updates the canvas. The pre-fix path called the legacy `setBackground` action which writes only `backgroundDataUrl` / `backgroundBuffer`; multi-page templates read per-page bytes from `pageBackgroundDataUrls`, so the canvas silently kept showing the old image.
- In Change Background mode, the size step's "Same as previous (W × H pt)" radio now reads "Same as Current (W × H pt)" — the radio's value IS the current page's size in this flow, so "previous" was the wrong word. The Add Page flow keeps "Same as previous" (right for both add and edit on the bg-step's inherit button).

## What changed

**`Toolbar.tsx`**
- BG button → "Change Background" + tooltip + `data-testid="toolbar-change-background"`. Click opens `AddPageDialog` in the new `mode="edit"` instead of a bare file picker. Onboarding's "Upload Background" path is unchanged (separate code path, still correct).

**`AddPageDialog.tsx`**
- New `mode: 'add' | 'edit'` prop (default `'add'`, all existing callers preserved). In edit mode the title is "Change Background" and the action button is "Apply".
- Passes `previousSizeLabel` to `PageSizePicker`: "Same as Current" in edit mode, "Same as previous" in add mode (default).

**`PageSizePicker.tsx`**
- New optional `previousSizeLabel` prop, default `"Same as previous"`. The radio's full label becomes `${previousSizeLabel} (W × H pt)`.

**`usePageHandlers.ts`**
- New `handleChangeBackground` mirrors `handleAddPage`'s branching but calls `updatePage` + `setPageBackground` on the **current page** (falls back to `pages[0]` when `currentPageId` is null). Image branch also writes the legacy `backgroundDataUrl` as a backstop for code paths that still consult it.

**`uiStore.ts`**
- New `showChangeBgDialog` flag so the Toolbar (which lives outside `CanvasArea`) can open the dialog without prop drilling. `CanvasArea` mounts a second `<AddPageDialog mode="edit">` instance bound to it.

## Test plan

- [x] `pnpm type-check` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 436 unit tests pass
- [x] `pnpm build` clean
- [x] `pnpm test:e2e -- change-background.spec.ts` — 5 tests pass:
  - Toolbar button is labelled "Change Background" (no "BG")
  - Image upload writes per-page bg + flips backgroundType (poll-based, FileReader is async)
  - Solid colour change persists the picked hex (`#ff8800`) — drives the controlled `<input type="color">` via React's native value setter
  - Same-as-previous on Page 2 sets backgroundType to inherit and clears color/filename
  - Size picker shows "Same as Current (W × H pt)" in edit mode and not "Same as previous ("
- [x] Existing `add-page-dialog.spec.ts` (6 tests) still passes; no regressions in the Add Page flow.

## Issues filed during the work

- #65 bug — table bottom border missing when content overflows the field rect
- #66 bug+feat — canvas needs horizontal + vertical scrollbars
- #64 enhancement, v3 — full UI/UX redesign (palette, primitives, microcopy)