### PR TITLE
fix(ui): dynamic text WYSIWYG — canvas/sidebar/PDF agree (#73)

### DIFF
--- a/.changeset/dynamic-text-wysiwyg.md
+++ b/.changeset/dynamic-text-wysiwyg.md
@@ -1,0 +1,15 @@
+---
+'template-goblin-ui': patch
+---
+
+Dynamic text fields are now WYSIWYG with the PDF (#73). Before, a dynamic
+text field with `fontSize: 12` rendered on the canvas at the auto-fit max
+size (often well above 12pt) while the sidebar showed 12 and the PDF
+printed 12 — three sources of truth, two of them wrong. The canvas and
+HTML preview now render dynamic text at the authored `fontSize`, never
+auto-growing past it. New fields default to `fontSizeDynamic: false` so
+authoring is honest from the first paint; users opt in to runtime
+shrinking when they expect overflow on real data. Editing `fontSize`,
+`maxRows`, or `lineHeight` from the properties panel no longer silently
+resizes the rect for dynamic fields — the author-drawn rectangle is
+preserved. Static text keeps the existing auto-fit-to-content behaviour.

--- a/packages/ui/src/components/Canvas/fabricUtils.ts
+++ b/packages/ui/src/components/Canvas/fabricUtils.ts
@@ -785,14 +785,18 @@ export function buildGroupChildren(
             }>)
           : null
       const fontFamily = textStyle?.fontFamily || 'sans-serif'
-      // For dynamic text with auto-fit on, recompute against the rect; in
-      // every other case honour the user's chosen fontSize but never let it
-      // overflow the rect.
+      // GH #73: only static text fields may auto-grow the label to a max-fit
+      // preview — the literal `source.value` IS what the PDF will print, so
+      // showing it large is honest. Dynamic text fields must be WYSIWYG with
+      // the sidebar's authored `fontSize`: the placeholder is only a stand-in
+      // for variable runtime data, and the PDF generator never grows text
+      // above the authored size, so growing it here would lie to the user.
       const userFontSize =
         typeof textStyle?.fontSize === 'number' && textStyle.fontSize > 0
           ? textStyle.fontSize
           : null
-      const autoFit = textStyle?.fontSizeDynamic === true
+      const isDynamicSource = field.source?.mode === 'dynamic'
+      const autoFit = !isDynamicSource && textStyle?.fontSizeDynamic === true
       const fitted = fitFontSize(label, labelW, labelH, fontFamily)
       const fontSize = autoFit || userFontSize === null ? fitted : Math.min(userFontSize, fitted)
       if (fontSize >= 8) {

--- a/packages/ui/src/components/Canvas/useFabricCanvas.ts
+++ b/packages/ui/src/components/Canvas/useFabricCanvas.ts
@@ -203,15 +203,17 @@ function wireDragResizeEvents(fc: FabricCanvas) {
     store.resizeField(g.__fieldId, patch.width, patch.height)
 
     // Sync fitted fontSize back to the store so the sidebar reflects what
-    // the user actually sees on the canvas. Applies to text fields where
-    // the rendered fontSize is auto-fitted: every static text field
-    // (fixed string, fitted to rect) and dynamic text with auto-fit on.
+    // the user sees on the canvas. Applies ONLY to static text fields with
+    // auto-fit on — those are the only fields whose canvas label legitimately
+    // auto-grows to a max-fit preview. Dynamic text is WYSIWYG with the
+    // authored `fontSize` (GH #73), so the canvas never derives a new size
+    // and we must not overwrite the sidebar value behind the user's back.
     const field = store.fields.find((f) => f.id === g.__fieldId)
     if (!field || field.type !== 'text') return
     const tf = field as TextField
     const isStatic = tf.source?.mode === 'static'
     const autoFit = tf.style.fontSizeDynamic === true
-    if (!isStatic && !autoFit) return
+    if (!isStatic || !autoFit) return
     const label = fieldCanvasLabel(tf)
     if (!label) return
     const innerPad = 6

--- a/packages/ui/src/components/RightPanel/TextFieldProps.tsx
+++ b/packages/ui/src/components/RightPanel/TextFieldProps.tsx
@@ -141,21 +141,28 @@ export function TextFieldProps({ field }: Props) {
     } as Partial<FieldDefinition>)
   }
 
+  // GH #73: typography changes auto-resize the rect ONLY for static text —
+  // the literal value is known at design time so growing the rect to fit is
+  // reasonable. Dynamic text fields hold an author-drawn rect that's the
+  // contract for runtime data, and changing fontSize/maxRows/lineHeight
+  // would silently move the rect out from under the author's hands.
   function onMaxRowsChange(maxRows: number) {
     updateFieldStyle(field.id, { maxRows })
-    // Recalculate height: maxRows * fontSize * lineHeight
+    if (!isStatic) return
     const newHeight = maxRows * style.fontSize * style.lineHeight
     resizeField(field.id, field.width, newHeight)
   }
 
   function onLineHeightChange(lineHeight: number) {
     updateFieldStyle(field.id, { lineHeight })
+    if (!isStatic) return
     const newHeight = style.maxRows * style.fontSize * lineHeight
     resizeField(field.id, field.width, newHeight)
   }
 
   function onFontSizeChange(fontSize: number) {
     updateFieldStyle(field.id, { fontSize })
+    if (!isStatic) return
     const newHeight = style.maxRows * fontSize * style.lineHeight
     resizeField(field.id, field.width, newHeight)
   }

--- a/packages/ui/src/utils/__tests__/defaults.test.ts
+++ b/packages/ui/src/utils/__tests__/defaults.test.ts
@@ -132,6 +132,13 @@ describe('defaultTextStyle', () => {
   it('maxRows is >= 1 (spec 010 edge case: min 1)', () => {
     expect(defaultTextStyle().maxRows).toBeGreaterThanOrEqual(1)
   })
+
+  // GH #73 — fontSizeDynamic defaults to false so the authored fontSize is
+  // WYSIWYG with the canvas and the PDF. Users opt in to runtime shrinking
+  // when they actually expect overflow on dynamic data.
+  it('fontSizeDynamic defaults to false (GH #73 WYSIWYG)', () => {
+    expect(defaultTextStyle().fontSizeDynamic).toBe(false)
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/ui/src/utils/__tests__/previewGenerator.test.ts
+++ b/packages/ui/src/utils/__tests__/previewGenerator.test.ts
@@ -437,6 +437,49 @@ describe('generatePreviewHtml', () => {
     })
   })
 
+  // GH #73 — for dynamic text the canvas, sidebar, and preview/PDF must all
+  // agree on the rendered fontSize. The HTML preview is the testable proxy
+  // for the canvas's rendered size: they share the effective-fontSize logic,
+  // and both must emit the user's authored value when the rect accommodates
+  // it. The pre-#73 bug grew the placeholder text past the authored size.
+  describe('GH #73 — dynamic text WYSIWYG', () => {
+    it('dynamic text with fontSizeDynamic=false renders at the authored fontSize', async () => {
+      const f = textField('name')
+      ;(f.style as TextFieldStyle).fontSize = 12
+      ;(f.style as TextFieldStyle).fontSizeDynamic = false
+      f.width = 400
+      f.height = 200
+      const blob = await generatePreviewHtml([f], defaultMeta, [], {
+        texts: { name: 'Jane' },
+        tables: {},
+        images: {},
+      })
+      const html = await blob.text()
+      expect(html).toContain('font-size:12pt')
+    })
+
+    it('dynamic text with fontSizeDynamic=true does NOT auto-grow above the authored fontSize', async () => {
+      // The PDF generator only ever shrinks (never grows), so the preview
+      // must too. Authored size is the ceiling regardless of the flag.
+      const f = textField('name')
+      ;(f.style as TextFieldStyle).fontSize = 12
+      ;(f.style as TextFieldStyle).fontSizeDynamic = true
+      f.width = 400
+      f.height = 200
+      const blob = await generatePreviewHtml([f], defaultMeta, [], {
+        texts: { name: 'Jane' },
+        tables: {},
+        images: {},
+      })
+      const html = await blob.text()
+      const m = html.match(/font-size:(\d+(?:\.\d+)?)pt/)
+      expect(m).not.toBeNull()
+      const size = m ? parseFloat(m[1]!) : 0
+      expect(size).toBeLessThanOrEqual(12)
+      expect(size).toBeGreaterThan(0)
+    })
+  })
+
   // GH #49 — multi-page preview: one <section> per page, fields routed by pageId.
   describe('GH #49 — multi-page rendering', () => {
     it('emits one <section class="page"> per supplied page', async () => {

--- a/packages/ui/src/utils/defaults.ts
+++ b/packages/ui/src/utils/defaults.ts
@@ -49,7 +49,9 @@ export function defaultTextStyle(): TextFieldStyle {
     fontId: null,
     fontFamily: 'Helvetica',
     fontSize: 12,
-    fontSizeDynamic: true,
+    // GH #73: default OFF so authored fontSize is WYSIWYG with canvas + PDF.
+    // Users opt in to dynamic shrinking when they expect overflow at runtime.
+    fontSizeDynamic: false,
     fontSizeMin: 11,
     lineHeight: 1.2,
     fontWeight: 'normal',

--- a/packages/ui/src/utils/previewFieldRenderers.ts
+++ b/packages/ui/src/utils/previewFieldRenderers.ts
@@ -25,9 +25,13 @@ export function renderTextHtml(field: TextField, value: string): string {
   const labelW = Math.max(1, field.width - innerPad * 2)
   const labelH = Math.max(1, field.height - innerPad * 2)
   const fitted = fitFontSize(value, labelW, labelH, fontFamily, s.lineHeight || 1.2)
-  // `fontSizeDynamic` is a hint that the canvas was already auto-fitting,
-  // so the right size to print is the fitted one regardless.
-  const fontSize = s.fontSizeDynamic ? fitted : Math.min(declared, fitted)
+  // GH #73: only static text may use the canvas's max-fit preview — the
+  // literal `source.value` is what the PDF will print so growing it is
+  // honest. Dynamic text is WYSIWYG with the authored `fontSize`; the PDF
+  // generator only ever shrinks (never grows), so the preview must too.
+  const isDynamicSource = field.source?.mode === 'dynamic'
+  const useAutoFit = !isDynamicSource && s.fontSizeDynamic
+  const fontSize = useAutoFit ? fitted : Math.min(declared, fitted)
 
   const truncate = s.overflowMode === 'truncate'
   const cls = `f${truncate ? ' f-truncate' : ''}`


### PR DESCRIPTION
Closes #73.

## Symptom

Dynamic text field with `fontSize: 12` rendered on the canvas at the auto-fit max size (often 24+pt for a small placeholder in a large rect), while the sidebar showed 12 and the PDF generator (which only ever shrinks) printed 12. Three sources of truth, two of them wrong — every preview became suspect.

Companion bug discovered during fix: editing `fontSize` / `maxRows` / `lineHeight` from the properties panel auto-resized the rect for dynamic fields, silently mutating the author-drawn rectangle.

## Fix

Single source of truth: the sidebar's `fontSize` is what the canvas, HTML preview, and PDF all render. The canvas may auto-grow only for **static** text (the literal value is known at design time, so showing it large is honest).

- `defaults.ts` — new fields default to `fontSizeDynamic: false`
- `fabricUtils.ts` (canvas) — dynamic source clamps to `min(authored, fitted)`, never auto-grows
- `useFabricCanvas.ts` (`object:modified`) — only writes back fitted size for `static && fontSizeDynamic`
- `previewFieldRenderers.ts` (HTML preview) — mirrors canvas semantics
- `TextFieldProps.tsx` — typography handlers no longer auto-resize the rect for dynamic fields

## Acceptance (per #73)

- [x] Dynamic text: canvas font size === sidebar font size === PDF font size
- [x] Static text + auto-fit on: canvas shows max-fit preview
- [x] Static text + auto-fit off: matches sidebar
- [x] Editing `fontSize` in the sidebar updates the canvas in the same tick (no stale render)
- [x] Unit test asserts the values match for a dynamic field

## Verification

- `pnpm type-check` ✓
- `pnpm lint` ✓
- `pnpm test` — 439/439 ✓ (3 new tests for #73)