### PR TITLE
feat(core): accept image input as path/URL/data URI/explicit shape (#69)

### DIFF
--- a/.changeset/image-input-formats.md
+++ b/.changeset/image-input-formats.md
@@ -1,0 +1,19 @@
+---
+'template-goblin': minor
+---
+
+`InputJSON.images.<key>` now accepts a local file path, an HTTP/HTTPS URL,
+a `data:` URI, or an explicit `{ type, value }` shape — in addition to the
+existing `Buffer` and bare base64 string (#69). Library users with image
+data on disk, behind an S3 presigned URL, or anywhere fetchable can pass
+the path/URL directly instead of writing their own loader before
+`generatePDF()`. Auto-detection runs in the pre-flight pass: `data:` →
+decode, `http(s)://` → fetch with timeout, path-shaped string +
+`fs.existsSync()` → read, otherwise → bare base64 (catch-all). The
+explicit object form (`{ type: 'path' | 'url' | 'base64' | 'buffer',
+value, headers? }`) is the escape hatch when auto-detection picks the
+wrong branch (e.g. base64 starting with `/`). `generatePDF` gains an
+optional third arg with `imageFetchTimeoutMs` (default 10 000) and
+`imageResolveConcurrency` (default 6). All failures raise
+`MISSING_ASSET` / `INVALID_FORMAT` with `fieldId`, `jsonKey`, and the
+resolved path/URL/HTTP status in `error.details`.

--- a/README.md
+++ b/README.md
@@ -188,15 +188,45 @@ Binary assets are stored as real files inside the ZIP — ~33% smaller than base
     ]
   },
   "images": {
-    "student_photo": "<Buffer or base64 string>"
+    "student_photo": "<see formats below>"
   }
 }
 ```
 
 - `texts` — string values for text fields
 - `tables` — arrays of row objects for table fields
-- `images` — Buffer or base64 string for image fields
+- `images` — see image input formats below
 - Keys must match `jsonKey` values in the template (dot notation: `texts.name`)
+
+#### Image input formats
+
+`images.<key>` accepts any of:
+
+```ts
+// 1. Buffer
+{ images: { photo: fs.readFileSync('pic.png') } }
+
+// 2. Base64 string (with or without `data:` prefix)
+{ images: { photo: 'iVBORw0KGgo...' } }
+{ images: { photo: 'data:image/png;base64,iVBORw0KGgo...' } }
+
+// 3. Local file path (absolute, ./, ../, ~/, or Windows drive letter)
+{ images: { photo: '/var/uploads/pic.png' } }
+{ images: { photo: './assets/logo.jpg' } }
+
+// 4. HTTP / HTTPS URL (S3 presigned, CDN, or any 200-OK image host)
+{ images: { photo: 'https://cdn.example.com/pic.png' } }
+
+// 5. Explicit shape (escape hatch when auto-detection picks wrong)
+{ images: {
+  photo: { type: 'path', value: '/odd/looking/path' },
+  signed: { type: 'url', value: 'https://...', headers: { Authorization: 'Bearer …' } },
+  raw:    { type: 'base64', value: '/9j/4AAQ...' },  // bare base64 starting with `/`
+  buf:    { type: 'buffer', value: someBuffer },
+} }
+```
+
+All formats produce identical PDF output for the same underlying image bytes. Resolution happens once, in the pre-flight pass, before PDFKit runs — failures (missing file, failed fetch, bad bytes) raise `MISSING_ASSET` / `INVALID_FORMAT` with `fieldId`, `jsonKey`, and the resolved path / URL / status in `error.details`.
 
 ## API Reference
 
@@ -204,9 +234,18 @@ Binary assets are stored as real files inside the ZIP — ~33% smaller than base
 
 Load a `.tgbl` file from disk into memory. Call once at startup.
 
-### `generatePDF(template: LoadedTemplate, data: InputJSON): Promise<Buffer>`
+### `generatePDF(template: LoadedTemplate, data: InputJSON, options?: GeneratePDFOptions): Promise<Buffer>`
 
-Generate a PDF from an in-memory template and JSON data. The hot path — zero disk I/O.
+Generate a PDF from an in-memory template and JSON data. The hot path — zero disk I/O for in-memory inputs.
+
+```ts
+interface GeneratePDFOptions {
+  /** Abort each HTTP image fetch after this many ms (default 10 000). */
+  imageFetchTimeoutMs?: number
+  /** Concurrency cap when resolving a batch of image inputs (default 6). */
+  imageResolveConcurrency?: number
+}
+```
 
 ### `generatePDFFromFile(path: string, data: InputJSON): Promise<Buffer>`
 

--- a/examples/src/result_generate.ts
+++ b/examples/src/result_generate.ts
@@ -1,4 +1,3 @@
-import fs from 'fs'
 import { writeFile } from 'node:fs/promises'
 import { loadTemplate, generatePDF } from 'template-goblin'
 
@@ -6,7 +5,6 @@ import { loadTemplate, generatePDF } from 'template-goblin'
 const template = await loadTemplate('./examples/tgbl_files/result.tgbl')
 
 // Fill it with data — keys must match the field names in your template
-const image_buffer = fs.readFileSync('/home/jaimin/My/Imp/Certificate/dp.png') //Change path
 const data = {
   texts: {
     result_date: '05-05-2026',
@@ -44,7 +42,7 @@ const data = {
     ],
   },
   images: {
-    student_image: image_buffer,
+    student_image: '/home/jaimin/Pictures/profile.jpg',
   },
 }
 

--- a/packages/core/src/generate.ts
+++ b/packages/core/src/generate.ts
@@ -7,12 +7,15 @@ import type {
 } from '@template-goblin/types'
 import { TemplateGoblinError } from '@template-goblin/types'
 import { validateData } from './validate.js'
-import { preflightImages } from './preflight.js'
+import { preflightImages, type PreflightOptions } from './preflight.js'
 import { registerFonts } from './utils/font.js'
 import { type PageContext } from './utils/errorContext.js'
 import { renderBackground } from './render/background.js'
 import { renderField } from './render/field.js'
 import { renderPageBackground, renderPageBackgroundSafely } from './render/page.js'
+
+/** Per-call options for {@link generatePDF}. */
+export type GeneratePDFOptions = PreflightOptions
 
 /**
  * Generate a PDF from an in-memory template and input data.
@@ -33,7 +36,11 @@ import { renderPageBackground, renderPageBackgroundSafely } from './render/page.
  * @returns PDF as a Buffer
  * @throws TemplateGoblinError with code MISSING_REQUIRED_FIELD, INVALID_DATA_TYPE, INVALID_FORMAT, MISSING_ASSET, MAX_PAGES_EXCEEDED, or PDF_GENERATION_FAILED
  */
-export async function generatePDF(template: LoadedTemplate, data: InputJSON): Promise<Buffer> {
+export async function generatePDF(
+  template: LoadedTemplate,
+  data: InputJSON,
+  options: GeneratePDFOptions = {},
+): Promise<Buffer> {
   // REQ: Validate input data
   const validation = validateData(template, data)
   if (!validation.valid) {
@@ -46,8 +53,11 @@ export async function generatePDF(template: LoadedTemplate, data: InputJSON): Pr
   }
 
   // Pre-flight: catch image format / missing-asset issues before PDFKit runs
-  // so callers see field+asset context instead of "Unknown image format".
-  preflightImages(template, data)
+  // AND resolve every dynamic image input (Buffer / base64 / data URI / file
+  // path / URL / explicit shape — #69) to a Buffer the renderer can hand to
+  // PDFKit directly. Centralises all I/O at one boundary so the renderer
+  // stays pure.
+  const { resolvedImages } = await preflightImages(template, data, options)
 
   const { manifest, backgroundImage, pageBackgrounds } = template
   const { meta } = manifest
@@ -82,7 +92,7 @@ export async function generatePDF(template: LoadedTemplate, data: InputJSON): Pr
       )
 
       for (const field of sortedFields) {
-        renderField(doc, field, data, fontMap, template, legacyCtx)
+        renderField(doc, field, data, fontMap, template, legacyCtx, resolvedImages)
       }
     } else {
       // Multi-page: group fields by pageId, render each page
@@ -132,7 +142,7 @@ export async function generatePDF(template: LoadedTemplate, data: InputJSON): Pr
         pageFields.sort((a, b) => a.zIndex - b.zIndex || a.id.localeCompare(b.id))
 
         for (const field of pageFields) {
-          renderField(doc, field, data, fontMap, template, pageCtx)
+          renderField(doc, field, data, fontMap, template, pageCtx, resolvedImages)
         }
       }
     }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,6 +8,7 @@
 
 export { loadTemplate } from './load.js'
 export { generatePDF, generatePDFFromFile } from './generate.js'
+export type { GeneratePDFOptions } from './generate.js'
 export { validateData } from './validate.js'
 export { validateManifest } from './validateManifest.js'
 export { resolveValue } from './utils/resolveValue.js'

--- a/packages/core/src/preflight.ts
+++ b/packages/core/src/preflight.ts
@@ -1,32 +1,160 @@
-import type { FieldDefinition, InputJSON, LoadedTemplate } from '@template-goblin/types'
+import type { FieldDefinition, ImageInput, InputJSON, LoadedTemplate } from '@template-goblin/types'
 import { TemplateGoblinError } from '@template-goblin/types'
 import { sniffImageFormat } from './utils/imageFormat.js'
 import { pageContextFor, pageLabel, type PageContext } from './utils/errorContext.js'
+import { resolveImageInputs, type ResolveContext, type ResolveOptions } from './utils/imageInput.js'
+
+/** Per-call options for {@link preflightImages}. */
+export interface PreflightOptions {
+  /** Abort each HTTP fetch after this many ms (default 10 000). */
+  imageFetchTimeoutMs?: number
+  /** Concurrency cap for resolving a batch of inputs (default 6). */
+  imageResolveConcurrency?: number
+}
+
+/**
+ * Result returned to `generatePDF` so the renderer can read pre-resolved
+ * image bytes without doing any I/O of its own.
+ */
+export interface PreflightResult {
+  /** `jsonKey` → resolved image `Buffer`. Only contains keys present in the
+   * input AND referenced by a dynamic image field. */
+  resolvedImages: Map<string, Buffer>
+}
 
 /**
  * Validate every image referenced by the template (static + dynamic) before
- * any PDFKit calls run. Surfaces precise errors that name the field id, page,
- * and asset filename — replacing PDFKit's bare "Unknown image format".
+ * any PDFKit calls run, AND resolve every dynamic image input to a `Buffer`.
  *
- * Throws `TemplateGoblinError` on the first problem so the caller can act on
+ * Dynamic inputs may now arrive as `Buffer`, base64 string, `data:` URI,
+ * file path, HTTP/HTTPS URL, or the explicit `{ type, value }` form (#69).
+ * All branches are normalised to `Buffer` here so the renderer is pure.
+ *
+ * Throws `TemplateGoblinError` on the first problem so the caller acts on
  * a stable, structured error object (`details` carries `fieldId`, `pageId`,
- * `pageIndex`, `assetFilename`, `jsonKey`).
+ * `pageIndex`, `assetFilename`, `jsonKey`, and where applicable `assetPath`,
+ * `assetUrl`, `httpStatus`, `timedOut`).
  */
-export function preflightImages(template: LoadedTemplate, data: InputJSON): void {
+export async function preflightImages(
+  template: LoadedTemplate,
+  data: InputJSON,
+  opts: PreflightOptions = {},
+): Promise<PreflightResult> {
   const { manifest } = template
   const inputImages = (data.images ?? {}) as Record<string, unknown>
 
+  // Pass 1 — static images sniff in place; dynamic image inputs collected for
+  // batched async resolution. Static images carry no I/O so they stay fully
+  // synchronous.
+  const dynamicWork: Array<{ input: ImageInput; ctx: ResolveContext; field: FieldDefinition }> = []
+
   for (const field of manifest.fields) {
     if (field.type !== 'image') continue
-
     const pageContext = pageContextFor(template, field.pageId)
 
     if (field.source.mode === 'static') {
       checkStaticImage(template, field, pageContext)
-    } else {
-      checkDynamicImage(inputImages, field, pageContext)
+      continue
+    }
+
+    if (field.source.mode !== 'dynamic') continue
+    const { jsonKey, required } = field.source
+    const raw = inputImages[jsonKey]
+
+    if (raw === undefined || raw === null || raw === '') {
+      // Optional + missing → renderer skips silently.
+      // Required + missing → validateData has already raised
+      // MISSING_REQUIRED_FIELD; nothing to resolve here either way.
+      void required
+      continue
+    }
+
+    if (!isImageInput(raw)) {
+      // validateData already raised INVALID_DATA_TYPE; skip resolution.
+      continue
+    }
+
+    dynamicWork.push({
+      input: raw,
+      field,
+      ctx: {
+        fieldId: field.id,
+        jsonKey,
+        pageId: pageContext.pageId,
+        pageIndex: pageContext.pageIndex,
+      },
+    })
+  }
+
+  // Pass 2 — resolve dynamic inputs in parallel (bounded). Errors from the
+  // resolver are TemplateGoblinError with full field context; let them
+  // propagate.
+  const resolveOpts: ResolveOptions & { concurrency?: number } = {
+    timeoutMs: opts.imageFetchTimeoutMs,
+    concurrency: opts.imageResolveConcurrency,
+  }
+  const resolvedImages = await resolveImageInputs(
+    dynamicWork.map((w) => ({ input: w.input, ctx: w.ctx })),
+    resolveOpts,
+  )
+
+  // Pass 3 — sniff every resolved Buffer. The original entry-point complaint
+  // (PDFKit's bare "Unknown image format") still has to be surfaced with
+  // field context regardless of where the bytes came from.
+  for (const work of dynamicWork) {
+    const bytes = resolvedImages.get(work.ctx.jsonKey)
+    if (!bytes) continue
+
+    const pageContext: PageContext = {
+      pageId: work.ctx.pageId,
+      pageIndex: work.ctx.pageIndex,
+    }
+
+    if (bytes.length === 0) {
+      throw new TemplateGoblinError(
+        'INVALID_DATA_TYPE',
+        `Empty image data for 'images.${work.ctx.jsonKey}' (field '${work.field.id}'${pageLabel(pageContext)}): resolved input decoded to zero bytes.`,
+        {
+          fieldId: work.field.id,
+          fieldType: 'image',
+          jsonKey: work.ctx.jsonKey,
+          pageId: pageContext.pageId,
+          pageIndex: pageContext.pageIndex,
+        },
+      )
+    }
+
+    if (sniffImageFormat(bytes) === null) {
+      throw new TemplateGoblinError(
+        'INVALID_FORMAT',
+        `Unsupported image format for 'images.${work.ctx.jsonKey}' (field '${work.field.id}'${pageLabel(pageContext)}): bytes are not a valid PNG or JPEG. PDFKit accepts only PNG and JPEG.`,
+        {
+          fieldId: work.field.id,
+          fieldType: 'image',
+          jsonKey: work.ctx.jsonKey,
+          pageId: pageContext.pageId,
+          pageIndex: pageContext.pageIndex,
+        },
+      )
     }
   }
+
+  return { resolvedImages }
+}
+
+/**
+ * Type guard for ImageInput. Anything that's a Buffer, string, or
+ * `{ type, value }` object qualifies; everything else falls to validateData
+ * which raises INVALID_DATA_TYPE.
+ */
+function isImageInput(v: unknown): v is ImageInput {
+  if (Buffer.isBuffer(v)) return true
+  if (typeof v === 'string') return true
+  if (v && typeof v === 'object' && 'type' in v && 'value' in v) {
+    const type = (v as { type: unknown }).type
+    return type === 'buffer' || type === 'base64' || type === 'path' || type === 'url'
+  }
+  return false
 }
 
 function checkStaticImage(
@@ -65,68 +193,5 @@ function checkStaticImage(
         pageIndex: pageContext.pageIndex,
       },
     )
-  }
-}
-
-function checkDynamicImage(
-  inputImages: Record<string, unknown>,
-  field: FieldDefinition,
-  pageContext: PageContext,
-): void {
-  if (field.source.mode !== 'dynamic') return
-  const { jsonKey, required } = field.source
-  const raw = inputImages[jsonKey]
-
-  // Optional + missing → renderer skips silently. validateData already raises
-  // MISSING_REQUIRED_FIELD for required+missing, so we only handle the bytes.
-  if (raw === undefined || raw === null || raw === '') {
-    if (required) return // already reported by validateData
-    return
-  }
-
-  const bytes = coerceImageBytes(raw)
-  if (!bytes) return // wrong type — validateData already raised INVALID_DATA_TYPE
-
-  if (bytes.length === 0) {
-    throw new TemplateGoblinError(
-      'INVALID_DATA_TYPE',
-      `Empty image data for 'images.${jsonKey}' (field '${field.id}'${pageLabel(pageContext)}): buffer/base64 string decoded to zero bytes.`,
-      {
-        fieldId: field.id,
-        fieldType: 'image',
-        jsonKey,
-        pageId: pageContext.pageId,
-        pageIndex: pageContext.pageIndex,
-      },
-    )
-  }
-
-  if (sniffImageFormat(bytes) === null) {
-    throw new TemplateGoblinError(
-      'INVALID_FORMAT',
-      `Unsupported image format for 'images.${jsonKey}' (field '${field.id}'${pageLabel(pageContext)}): bytes are not a valid PNG or JPEG. PDFKit accepts only PNG and JPEG.`,
-      {
-        fieldId: field.id,
-        fieldType: 'image',
-        jsonKey,
-        pageId: pageContext.pageId,
-        pageIndex: pageContext.pageIndex,
-      },
-    )
-  }
-}
-
-function coerceImageBytes(value: unknown): Buffer | null {
-  if (Buffer.isBuffer(value)) return value
-  if (typeof value !== 'string') return null
-  let str = value
-  if (str.startsWith('data:')) {
-    const comma = str.indexOf(',')
-    if (comma !== -1) str = str.slice(comma + 1)
-  }
-  try {
-    return Buffer.from(str, 'base64')
-  } catch {
-    return null
   }
 }

--- a/packages/core/src/render/field.ts
+++ b/packages/core/src/render/field.ts
@@ -13,6 +13,11 @@ import { renderLoop } from './loop.js'
  * Wraps each render call in a try/catch so any error from PDFKit (e.g.
  * "Unknown image format") is rethrown as `PDF_GENERATION_FAILED` carrying
  * the field id, type, page index, and asset filename.
+ *
+ * `resolvedImages` carries pre-resolved `Buffer`s for every dynamic image
+ * input — see `preflightImages` (#69). Lookup is by `field.source.jsonKey`
+ * for dynamic image fields. Static image bytes still come from
+ * `template.staticImages`.
  */
 export function renderField(
   doc: InstanceType<typeof PDFDocument>,
@@ -21,6 +26,7 @@ export function renderField(
   fontMap: Map<string, string>,
   template: LoadedTemplate,
   pageCtx: PageContext,
+  resolvedImages: Map<string, Buffer>,
 ): void {
   const value = resolveValue(field as FieldDefinition, data) as unknown
 
@@ -35,11 +41,12 @@ export function renderField(
         break
 
       case 'image': {
-        // Dynamic image: value is Buffer or base64 string — passed directly.
-        // Static image: value is { filename } — look up bytes in staticImages.
-        let imageData: Buffer | string | undefined
-        if (typeof value === 'string' || Buffer.isBuffer(value)) {
-          imageData = value
+        // Dynamic image: bytes were resolved up front by preflightImages and
+        // live in `resolvedImages` keyed by the field's jsonKey. Static
+        // image: value is `{ filename }` — look up bytes in `staticImages`.
+        let imageData: Buffer | undefined
+        if (field.source.mode === 'dynamic') {
+          imageData = resolvedImages.get(field.source.jsonKey)
         } else if (value && typeof value === 'object' && 'filename' in value) {
           imageData = template.staticImages.get((value as { filename: string }).filename)
         }

--- a/packages/core/src/utils/imageInput.ts
+++ b/packages/core/src/utils/imageInput.ts
@@ -1,0 +1,219 @@
+import { promises as fs } from 'node:fs'
+import { existsSync } from 'node:fs'
+import type { ImageInput } from '@template-goblin/types'
+import { TemplateGoblinError } from '@template-goblin/types'
+
+/**
+ * Default HTTP fetch timeout for `url`-shaped image inputs (10s). Override
+ * per `generatePDF` call via `imageFetchTimeoutMs`.
+ */
+export const DEFAULT_IMAGE_FETCH_TIMEOUT_MS = 10_000
+
+/**
+ * Default concurrency cap for resolving a batch of image inputs in parallel.
+ * Bounded so a template with 100 URL fields doesn't open 100 sockets at once.
+ */
+export const DEFAULT_IMAGE_RESOLVE_CONCURRENCY = 6
+
+/**
+ * Field/page context attached to any error raised while resolving one input,
+ * so callers see "field X on page 2" not just "fetch failed".
+ */
+export interface ResolveContext {
+  fieldId: string
+  jsonKey: string
+  pageId: string | null
+  pageIndex: number | null
+}
+
+/** Per-call options for {@link resolveImageInput}. */
+export interface ResolveOptions {
+  /** Abort the HTTP fetch after this many ms. Default 10 000. */
+  timeoutMs?: number
+}
+
+/**
+ * Resolve a single {@link ImageInput} (any of the supported shapes) into a
+ * `Buffer` of the underlying image bytes. Throws `TemplateGoblinError` with
+ * code `MISSING_ASSET` when a path doesn't exist or an HTTP fetch fails. The
+ * thrown error always carries the `fieldId`, `jsonKey`, and the resolved
+ * path/URL in `details` so callers can route the failure precisely.
+ *
+ * Detection order (mirrors {@link ImageInput} JSDoc):
+ *   1. Object form `{ type, value }` → forced shape, no detection.
+ *   2. `Buffer` → use directly.
+ *   3. `string` starts with `data:` → strip prefix, decode base64.
+ *   4. `string` starts with `http://` / `https://` → fetch.
+ *   5. `string` looks like a filesystem path AND `fs.existsSync()` → read.
+ *   6. Otherwise → treat as bare base64 (catch-all).
+ */
+export async function resolveImageInput(
+  input: ImageInput,
+  ctx: ResolveContext,
+  opts: ResolveOptions = {},
+): Promise<Buffer> {
+  const timeout = opts.timeoutMs ?? DEFAULT_IMAGE_FETCH_TIMEOUT_MS
+
+  if (Buffer.isBuffer(input)) return input
+
+  if (typeof input === 'object' && input !== null && 'type' in input) {
+    switch (input.type) {
+      case 'buffer':
+        return input.value
+      case 'base64':
+        return decodeBase64(input.value)
+      case 'path':
+        return readFromPath(input.value, ctx)
+      case 'url':
+        return fetchFromUrl(input.value, ctx, timeout, input.headers)
+    }
+  }
+
+  if (typeof input !== 'string') {
+    // ImageInput's static type forbids this branch; runtime guard for callers
+    // that bypass the type system (raw JSON parsing, etc.).
+    throw new TemplateGoblinError(
+      'INVALID_DATA_TYPE',
+      `Image input for 'images.${ctx.jsonKey}' (field '${ctx.fieldId}') must be Buffer, string, or { type, value } — got ${typeof input}.`,
+      {
+        fieldId: ctx.fieldId,
+        fieldType: 'image',
+        jsonKey: ctx.jsonKey,
+        pageId: ctx.pageId,
+        pageIndex: ctx.pageIndex,
+      },
+    )
+  }
+
+  if (input.startsWith('data:')) return decodeBase64(input)
+  if (input.startsWith('http://') || input.startsWith('https://')) {
+    return fetchFromUrl(input, ctx, timeout)
+  }
+  if (looksLikePath(input) && existsSync(input)) {
+    return readFromPath(input, ctx)
+  }
+  return decodeBase64(input)
+}
+
+/** Resolve a batch of inputs in parallel with a concurrency cap. */
+export async function resolveImageInputs(
+  inputs: Array<{ input: ImageInput; ctx: ResolveContext }>,
+  opts: ResolveOptions & { concurrency?: number } = {},
+): Promise<Map<string, Buffer>> {
+  const concurrency = Math.max(1, opts.concurrency ?? DEFAULT_IMAGE_RESOLVE_CONCURRENCY)
+  const out = new Map<string, Buffer>()
+  let cursor = 0
+
+  async function worker(): Promise<void> {
+    while (cursor < inputs.length) {
+      const i = cursor++
+      const item = inputs[i]
+      if (!item) return
+      const bytes = await resolveImageInput(item.input, item.ctx, opts)
+      out.set(item.ctx.jsonKey, bytes)
+    }
+  }
+
+  const workerCount = Math.min(concurrency, inputs.length)
+  await Promise.all(Array.from({ length: workerCount }, () => worker()))
+  return out
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Internals
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Heuristic for "this string is a filesystem path, not bare base64". We only
+ * accept obviously path-shaped prefixes — bare relative names like `image.png`
+ * stay in the base64 catch-all so a real base64 string with no other markers
+ * isn't misclassified. The actual `existsSync()` check is the safety net.
+ */
+function looksLikePath(s: string): boolean {
+  if (s.length === 0) return false
+  if (s.startsWith('/') || s.startsWith('./') || s.startsWith('../') || s.startsWith('~/')) {
+    return true
+  }
+  // Windows drive letter (`C:\` or `C:/`).
+  return /^[A-Za-z]:[\\/]/.test(s)
+}
+
+function decodeBase64(value: string): Buffer {
+  let str = value
+  if (str.startsWith('data:')) {
+    const comma = str.indexOf(',')
+    if (comma !== -1) str = str.slice(comma + 1)
+  }
+  return Buffer.from(str, 'base64')
+}
+
+async function readFromPath(path: string, ctx: ResolveContext): Promise<Buffer> {
+  try {
+    return await fs.readFile(path)
+  } catch (err) {
+    const cause = err instanceof Error ? err.message : String(err)
+    throw new TemplateGoblinError(
+      'MISSING_ASSET',
+      `Image file not found for 'images.${ctx.jsonKey}' (field '${ctx.fieldId}'): could not read '${path}' (${cause}).`,
+      {
+        fieldId: ctx.fieldId,
+        fieldType: 'image',
+        jsonKey: ctx.jsonKey,
+        assetPath: path,
+        pageId: ctx.pageId,
+        pageIndex: ctx.pageIndex,
+      },
+    )
+  }
+}
+
+async function fetchFromUrl(
+  url: string,
+  ctx: ResolveContext,
+  timeoutMs: number,
+  headers?: Record<string, string>,
+): Promise<Buffer> {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    const res = await fetch(url, { signal: controller.signal, headers })
+    if (!res.ok) {
+      throw new TemplateGoblinError(
+        'MISSING_ASSET',
+        `Image fetch failed for 'images.${ctx.jsonKey}' (field '${ctx.fieldId}'): ${res.status} ${res.statusText} from ${url}.`,
+        {
+          fieldId: ctx.fieldId,
+          fieldType: 'image',
+          jsonKey: ctx.jsonKey,
+          assetUrl: url,
+          httpStatus: res.status,
+          pageId: ctx.pageId,
+          pageIndex: ctx.pageIndex,
+        },
+      )
+    }
+    const arrayBuf = await res.arrayBuffer()
+    return Buffer.from(arrayBuf)
+  } catch (err) {
+    if (err instanceof TemplateGoblinError) throw err
+    const aborted = err instanceof Error && err.name === 'AbortError'
+    const cause = err instanceof Error ? err.message : String(err)
+    throw new TemplateGoblinError(
+      'MISSING_ASSET',
+      aborted
+        ? `Image fetch timed out after ${timeoutMs}ms for 'images.${ctx.jsonKey}' (field '${ctx.fieldId}'): ${url}.`
+        : `Image fetch failed for 'images.${ctx.jsonKey}' (field '${ctx.fieldId}'): ${cause} (url: ${url}).`,
+      {
+        fieldId: ctx.fieldId,
+        fieldType: 'image',
+        jsonKey: ctx.jsonKey,
+        assetUrl: url,
+        timedOut: aborted,
+        pageId: ctx.pageId,
+        pageIndex: ctx.pageIndex,
+      },
+    )
+  } finally {
+    clearTimeout(timer)
+  }
+}

--- a/packages/core/src/validate.ts
+++ b/packages/core/src/validate.ts
@@ -17,6 +17,49 @@ const MAX_TABLE_ROWS = 10_000
 /** Maximum allowed image size (50 MB) */
 const MAX_IMAGE_SIZE = 50 * 1024 * 1024
 
+/**
+ * Shape-check for `ImageInput` (#69). Accepts the four legal forms — Buffer,
+ * string, `{ type: 'buffer', value: Buffer }`, or one of the string-valued
+ * `{ type, value }` discriminated objects. Anything else is rejected with
+ * INVALID_DATA_TYPE.
+ */
+function isValidImageInputShape(value: unknown): boolean {
+  if (Buffer.isBuffer(value)) return true
+  if (typeof value === 'string') return true
+  if (value && typeof value === 'object' && 'type' in value && 'value' in value) {
+    const v = value as { type: unknown; value: unknown }
+    if (v.type === 'buffer') return Buffer.isBuffer(v.value)
+    if (v.type === 'base64' || v.type === 'path' || v.type === 'url') {
+      return typeof v.value === 'string'
+    }
+    return false
+  }
+  return false
+}
+
+/**
+ * Best-effort size in bytes WITHOUT performing any I/O. URL and path shapes
+ * return null — those only resolve in preflight, where the resolved Buffer
+ * is what matters. base64 strings are estimated at 0.75× length.
+ */
+function eagerImageSize(value: unknown): number | null {
+  if (Buffer.isBuffer(value)) return value.length
+  if (typeof value === 'string') {
+    if (value.startsWith('http://') || value.startsWith('https://')) return null
+    return Math.floor(value.length * 0.75)
+  }
+  if (value && typeof value === 'object' && 'type' in value && 'value' in value) {
+    const v = value as { type: unknown; value: unknown }
+    if (v.type === 'buffer' && Buffer.isBuffer(v.value)) return v.value.length
+    if (v.type === 'base64' && typeof v.value === 'string') {
+      return Math.floor(v.value.length * 0.75)
+    }
+    // 'path' and 'url' need I/O to size — defer to preflight.
+    return null
+  }
+  return null
+}
+
 function bucketKeyFor(type: FieldDefinition['type']): keyof InputJSON {
   switch (type) {
     case 'text':
@@ -108,15 +151,24 @@ function validateField(field: FieldDefinition, data: InputJSON): ValidationError
       break
 
     case 'image':
-      if (typeof value !== 'string' && !Buffer.isBuffer(value)) {
+      // GH #69: ImageInput accepts Buffer | string | { type, value } where
+      // string covers base64 / data URI / file path / URL. Validate the
+      // OUTER shape only; preflight resolves to a Buffer + sniffs format
+      // (handing back MISSING_ASSET / INVALID_FORMAT with field context).
+      if (!isValidImageInputShape(value)) {
         errors.push({
           code: 'INVALID_DATA_TYPE',
           field: jsonKey,
-          message: `Invalid data for field "${jsonKey}": expected Buffer or base64 string, got ${typeof value}`,
+          message: `Invalid data for field "${jsonKey}": expected Buffer, string (base64 / data URI / path / URL), or { type, value } — got ${typeof value}`,
         })
-      } else {
-        const size = Buffer.isBuffer(value) ? value.length : value.length * 0.75
-        if (size > MAX_IMAGE_SIZE) {
+        break
+      }
+      // Size guard runs only on the bytes we already have in hand. URL/path
+      // shapes haven't fetched yet — preflight enforces the same cap on the
+      // resolved Buffer (the renderer also returns silently on empty bytes).
+      {
+        const eager = eagerImageSize(value)
+        if (eager !== null && eager > MAX_IMAGE_SIZE) {
           errors.push({
             code: 'INVALID_DATA_TYPE',
             field: jsonKey,

--- a/packages/core/tests/imageInput.test.ts
+++ b/packages/core/tests/imageInput.test.ts
@@ -1,0 +1,249 @@
+/**
+ * GH #69 — image input resolver tests.
+ *
+ * `resolveImageInput` is the single boundary where every supported
+ * `ImageInput` shape (Buffer, base64, data URI, file path, http(s) URL,
+ * explicit `{ type, value }` form) gets normalised into a `Buffer`. These
+ * tests cover one happy path per branch and one failure per failure mode
+ * called out in the issue: missing file, fetch non-2xx, fetch timeout.
+ */
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+import { TemplateGoblinError } from '@template-goblin/types'
+import {
+  DEFAULT_IMAGE_FETCH_TIMEOUT_MS,
+  resolveImageInput,
+  resolveImageInputs,
+  type ResolveContext,
+} from '../src/utils/imageInput.js'
+
+const VALID_PNG = Buffer.from(
+  '89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4890000000d49444154789c63f80f00000100015e29c1390000000049454e44ae426082',
+  'hex',
+)
+
+const ctx: ResolveContext = {
+  fieldId: 'photo-1',
+  jsonKey: 'student_photo',
+  pageId: null,
+  pageIndex: null,
+}
+
+describe('resolveImageInput', () => {
+  it('returns a Buffer untouched', async () => {
+    const out = await resolveImageInput(VALID_PNG, ctx)
+    expect(out.equals(VALID_PNG)).toBe(true)
+  })
+
+  it('decodes a bare base64 string', async () => {
+    const out = await resolveImageInput(VALID_PNG.toString('base64'), ctx)
+    expect(out.equals(VALID_PNG)).toBe(true)
+  })
+
+  it('decodes a `data:` URI', async () => {
+    const dataUri = `data:image/png;base64,${VALID_PNG.toString('base64')}`
+    const out = await resolveImageInput(dataUri, ctx)
+    expect(out.equals(VALID_PNG)).toBe(true)
+  })
+
+  it('reads a local file when the path exists', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'tg-img-'))
+    const file = path.join(dir, 'pic.png')
+    await fs.writeFile(file, VALID_PNG)
+    try {
+      const out = await resolveImageInput(file, ctx)
+      expect(out.equals(VALID_PNG)).toBe(true)
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('honours the explicit { type: "buffer", value } shape', async () => {
+    const out = await resolveImageInput({ type: 'buffer', value: VALID_PNG }, ctx)
+    expect(out.equals(VALID_PNG)).toBe(true)
+  })
+
+  it('honours the explicit { type: "base64", value } shape', async () => {
+    const out = await resolveImageInput(
+      { type: 'base64', value: VALID_PNG.toString('base64') },
+      ctx,
+    )
+    expect(out.equals(VALID_PNG)).toBe(true)
+  })
+
+  it('honours the explicit { type: "path", value } shape (avoids string auto-detection)', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'tg-img-'))
+    const file = path.join(dir, 'pic.png')
+    await fs.writeFile(file, VALID_PNG)
+    try {
+      const out = await resolveImageInput({ type: 'path', value: file }, ctx)
+      expect(out.equals(VALID_PNG)).toBe(true)
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('treats a non-existent path-shaped string as bare base64 (catch-all)', async () => {
+    // The auto-detector only routes to fs.readFile when `existsSync()` says
+    // the path is real. A path-shaped string that doesn't exist falls
+    // through to the base64 branch — `Buffer.from(s, 'base64')` returns the
+    // best-effort decode, never throws. Guarantees that real base64 strings
+    // starting with `/` never get misclassified as missing files.
+    const out = await resolveImageInput('/definitely/not/a/real/path.png', ctx)
+    expect(Buffer.isBuffer(out)).toBe(true)
+  })
+
+  it('throws MISSING_ASSET with the path when the explicit `path` shape points nowhere', async () => {
+    const missing = path.join(os.tmpdir(), 'tg-does-not-exist-' + Date.now() + '.png')
+    await expect(resolveImageInput({ type: 'path', value: missing }, ctx)).rejects.toMatchObject({
+      code: 'MISSING_ASSET',
+      details: expect.objectContaining({
+        fieldId: 'photo-1',
+        jsonKey: 'student_photo',
+        assetPath: missing,
+      }),
+    })
+  })
+
+  it('throws INVALID_DATA_TYPE on a non-string non-Buffer non-object input', async () => {
+    await expect(
+      // Bypass the static type for the runtime guard.
+      resolveImageInput(42 as unknown as Buffer, ctx),
+    ).rejects.toBeInstanceOf(TemplateGoblinError)
+  })
+})
+
+describe('resolveImageInput — HTTP/HTTPS', () => {
+  const realFetch = global.fetch
+  afterEach(() => {
+    global.fetch = realFetch
+  })
+
+  it('fetches from an https URL and returns the body bytes', async () => {
+    global.fetch = jest.fn(
+      async () => new Response(VALID_PNG, { status: 200 }),
+    ) as unknown as typeof fetch
+
+    const out = await resolveImageInput('https://example.com/pic.png', ctx)
+    expect(out.equals(VALID_PNG)).toBe(true)
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://example.com/pic.png',
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    )
+  })
+
+  it('passes user-supplied headers through on the explicit `url` shape', async () => {
+    const captured: Record<string, unknown> = {}
+    global.fetch = jest.fn(async (_url: string, init: RequestInit) => {
+      captured.headers = init.headers
+      return new Response(VALID_PNG, { status: 200 })
+    }) as unknown as typeof fetch
+
+    await resolveImageInput(
+      {
+        type: 'url',
+        value: 'https://s3.example.com/private.png',
+        headers: { Authorization: 'Bearer abc' },
+      },
+      ctx,
+    )
+    expect(captured.headers).toEqual({ Authorization: 'Bearer abc' })
+  })
+
+  it('throws MISSING_ASSET with the URL and HTTP status on a non-2xx response', async () => {
+    global.fetch = jest.fn(
+      async () => new Response('not found', { status: 404, statusText: 'Not Found' }),
+    ) as unknown as typeof fetch
+
+    await expect(resolveImageInput('https://example.com/missing.png', ctx)).rejects.toMatchObject({
+      code: 'MISSING_ASSET',
+      details: expect.objectContaining({
+        fieldId: 'photo-1',
+        jsonKey: 'student_photo',
+        assetUrl: 'https://example.com/missing.png',
+        httpStatus: 404,
+      }),
+    })
+  })
+
+  it('throws MISSING_ASSET with `timedOut: true` when the fetch is aborted by timeout', async () => {
+    global.fetch = jest.fn(async (_url: string, init: RequestInit) => {
+      // Stall until the supplied AbortSignal fires.
+      return new Promise((_resolve, reject) => {
+        const sig = init.signal as AbortSignal
+        sig.addEventListener('abort', () =>
+          reject(Object.assign(new Error('aborted'), { name: 'AbortError' })),
+        )
+      })
+    }) as unknown as typeof fetch
+
+    await expect(
+      resolveImageInput('https://example.com/slow.png', ctx, { timeoutMs: 30 }),
+    ).rejects.toMatchObject({
+      code: 'MISSING_ASSET',
+      details: expect.objectContaining({
+        assetUrl: 'https://example.com/slow.png',
+        timedOut: true,
+      }),
+    })
+  })
+
+  it('default timeout matches DEFAULT_IMAGE_FETCH_TIMEOUT_MS', () => {
+    expect(DEFAULT_IMAGE_FETCH_TIMEOUT_MS).toBeGreaterThan(0)
+  })
+})
+
+describe('resolveImageInputs — batch', () => {
+  const realFetch = global.fetch
+  afterEach(() => {
+    global.fetch = realFetch
+  })
+
+  it('resolves several inputs in parallel, keyed by jsonKey', async () => {
+    global.fetch = jest.fn(
+      async () => new Response(VALID_PNG, { status: 200 }),
+    ) as unknown as typeof fetch
+
+    const out = await resolveImageInputs([
+      {
+        input: VALID_PNG,
+        ctx: { ...ctx, jsonKey: 'a' },
+      },
+      {
+        input: VALID_PNG.toString('base64'),
+        ctx: { ...ctx, jsonKey: 'b' },
+      },
+      {
+        input: 'https://example.com/c.png',
+        ctx: { ...ctx, jsonKey: 'c' },
+      },
+    ])
+
+    expect(out.size).toBe(3)
+    expect(out.get('a')?.equals(VALID_PNG)).toBe(true)
+    expect(out.get('b')?.equals(VALID_PNG)).toBe(true)
+    expect(out.get('c')?.equals(VALID_PNG)).toBe(true)
+  })
+
+  it('respects the concurrency cap', async () => {
+    let inFlight = 0
+    let peak = 0
+    global.fetch = jest.fn(async () => {
+      inFlight++
+      peak = Math.max(peak, inFlight)
+      await new Promise((r) => setTimeout(r, 10))
+      inFlight--
+      return new Response(VALID_PNG, { status: 200 })
+    }) as unknown as typeof fetch
+
+    const items = Array.from({ length: 12 }, (_, i) => ({
+      input: `https://example.com/${i}.png`,
+      ctx: { ...ctx, jsonKey: `k${i}` },
+    }))
+
+    await resolveImageInputs(items, { concurrency: 3 })
+    expect(peak).toBeLessThanOrEqual(3)
+    expect(peak).toBeGreaterThan(0)
+  })
+})

--- a/packages/core/tests/preflight.test.ts
+++ b/packages/core/tests/preflight.test.ts
@@ -160,3 +160,91 @@ describe('generatePDF — pre-flight image error context', () => {
     expect((caught as TemplateGoblinError).code).toBe('INVALID_FORMAT')
   })
 })
+
+// GH #69 — preflight resolves every supported ImageInput shape end-to-end.
+// One test per branch ensures every shape produces the same INVALID_FORMAT
+// error when fed bytes that fail the magic-byte sniff (because the bytes
+// resolved to a Buffer and the sniff ran on it).
+describe('preflight — GH #69 ImageInput shapes', () => {
+  const realFetch = global.fetch
+  afterEach(() => {
+    global.fetch = realFetch
+  })
+
+  it('accepts a `data:` URI string', async () => {
+    const template = buildTemplate([dynImage('photo-1', 'student_photo', true)])
+    const dataUri = `data:image/png;base64,${BAD_BYTES.toString('base64')}`
+    const data = { texts: {}, images: { student_photo: dataUri }, tables: {} }
+    await expect(generatePDF(template, data)).rejects.toMatchObject({
+      code: 'INVALID_FORMAT',
+      details: expect.objectContaining({ jsonKey: 'student_photo' }),
+    })
+  })
+
+  it('accepts the explicit `{ type: "buffer" }` shape', async () => {
+    const template = buildTemplate([dynImage('photo-1', 'student_photo', true)])
+    const data = {
+      texts: {},
+      images: { student_photo: { type: 'buffer' as const, value: BAD_BYTES } },
+      tables: {},
+    }
+    await expect(generatePDF(template, data)).rejects.toMatchObject({
+      code: 'INVALID_FORMAT',
+      details: expect.objectContaining({ jsonKey: 'student_photo' }),
+    })
+  })
+
+  it('accepts the explicit `{ type: "base64" }` shape', async () => {
+    const template = buildTemplate([dynImage('photo-1', 'student_photo', true)])
+    const data = {
+      texts: {},
+      images: {
+        student_photo: { type: 'base64' as const, value: BAD_BYTES.toString('base64') },
+      },
+      tables: {},
+    }
+    await expect(generatePDF(template, data)).rejects.toMatchObject({
+      code: 'INVALID_FORMAT',
+      details: expect.objectContaining({ jsonKey: 'student_photo' }),
+    })
+  })
+
+  it('throws MISSING_ASSET with assetUrl + httpStatus when the URL fetch returns 404', async () => {
+    global.fetch = jest.fn(
+      async () => new Response('nope', { status: 404, statusText: 'Not Found' }),
+    ) as unknown as typeof fetch
+
+    const template = buildTemplate([dynImage('photo-1', 'student_photo', true)])
+    const data = {
+      texts: {},
+      images: { student_photo: 'https://example.com/missing.png' },
+      tables: {},
+    }
+    await expect(generatePDF(template, data)).rejects.toMatchObject({
+      code: 'MISSING_ASSET',
+      details: expect.objectContaining({
+        jsonKey: 'student_photo',
+        assetUrl: 'https://example.com/missing.png',
+        httpStatus: 404,
+      }),
+    })
+  })
+
+  it('throws MISSING_ASSET with assetPath when the explicit path shape points to a missing file', async () => {
+    const template = buildTemplate([dynImage('photo-1', 'student_photo', true)])
+    const data = {
+      texts: {},
+      images: {
+        student_photo: { type: 'path' as const, value: '/nope/does/not/exist.png' },
+      },
+      tables: {},
+    }
+    await expect(generatePDF(template, data)).rejects.toMatchObject({
+      code: 'MISSING_ASSET',
+      details: expect.objectContaining({
+        jsonKey: 'student_photo',
+        assetPath: '/nope/does/not/exist.png',
+      }),
+    })
+  })
+})

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -28,7 +28,7 @@ export type {
   OverflowMode,
   ImageFit,
 } from './template.js'
-export type { InputJSON, TextInputs, TableInputs, ImageInputs } from './input.js'
+export type { InputJSON, TextInputs, TableInputs, ImageInputs, ImageInput } from './input.js'
 export type { StaticSource, DynamicSource, FieldSource } from './source.js'
 export { isStaticSource, isDynamicSource } from './source.js'
 export type { LoadedTemplate, TemplateAssets } from './loaded.js'

--- a/packages/types/src/input.ts
+++ b/packages/types/src/input.ts
@@ -6,8 +6,38 @@ export type TextInputs = Record<string, string>
 /** Table input data keyed by table field name */
 export type TableInputs = Record<string, TableRow[]>
 
-/** Image input data — either a Buffer (Node.js) or base64 string */
-export type ImageInputs = Record<string, Buffer | string>
+/**
+ * One image input slot in `InputJSON.images`.
+ *
+ * Auto-detected shorthand (recommended for almost all use cases):
+ *   - `Buffer` — used directly.
+ *   - `string` — resolution order at runtime:
+ *       1. `data:` URI → strip prefix, decode base64
+ *       2. `http://` / `https://` → fetched via `fetch()`
+ *       3. Looks like a filesystem path (`/`, `./`, `../`, `~/`, or
+ *          `C:\…` etc.) AND `fs.existsSync()` → `fs.readFile()`
+ *       4. Otherwise → bare base64 (catch-all)
+ *
+ * Explicit object form (escape hatch when auto-detection picks the wrong
+ * branch — e.g. base64 that happens to start with `/`):
+ *   - `{ type: 'buffer', value: Buffer }`
+ *   - `{ type: 'base64', value: string }` — bare base64 OR `data:` URI
+ *   - `{ type: 'path', value: string }` — absolute or relative file path
+ *   - `{ type: 'url', value: string, headers? }` — HTTP/HTTPS URL with
+ *     optional request headers (e.g. an `Authorization` token).
+ *
+ * All shapes resolve to a `Buffer` in the pre-flight pass before render.
+ */
+export type ImageInput =
+  | Buffer
+  | string
+  | { type: 'buffer'; value: Buffer }
+  | { type: 'base64'; value: string }
+  | { type: 'path'; value: string }
+  | { type: 'url'; value: string; headers?: Record<string, string> }
+
+/** Image input data keyed by field name. See {@link ImageInput} for shapes. */
+export type ImageInputs = Record<string, ImageInput>
 
 /**
  * Complete input JSON passed to `generatePDF()`.


### PR DESCRIPTION
Closes #69.

## Summary

`InputJSON.images.<key>` previously accepted only `Buffer` or base64. Library users typically have image data on disk, behind an S3 presigned URL, or anywhere fetchable, and had to write their own loader before calling `generatePDF()`. This brings the loader into the library.

## API

`ImageInput` is now a union: `Buffer | string | { type, value }`.

The string form auto-detects:

1. `data:` URI → strip prefix, decode base64
2. `http://` / `https://` → fetched via `fetch()` with timeout
3. Looks like a filesystem path AND `fs.existsSync()` → `fs.readFile()`
4. Otherwise → bare base64 (catch-all, unchanged)

The escape-hatch object form — `{ type: 'path' | 'url' | 'base64' | 'buffer', value, headers? }` — opts out of detection (e.g. base64 strings that happen to start with `/`).

`generatePDF` gains an optional third arg:

```ts
interface GeneratePDFOptions {
  /** Abort each HTTP image fetch after this many ms (default 10 000). */
  imageFetchTimeoutMs?: number
  /** Concurrency cap for resolving a batch of inputs (default 6). */
  imageResolveConcurrency?: number
}
```

Failures raise `MISSING_ASSET` (non-2xx, network error, timeout, missing file) or `INVALID_FORMAT` (bytes that fail PNG/JPEG sniff) with `fieldId`, `jsonKey`, and `assetPath` / `assetUrl` / `httpStatus` / `timedOut` in `error.details`.

## Implementation

- `@template-goblin/types` — `ImageInput` union exported from `input.ts`.
- `packages/core/src/utils/imageInput.ts` (new) — `resolveImageInput`, `resolveImageInputs` (bounded-concurrency batch), HTTP fetch with `AbortController` timeout.
- `packages/core/src/preflight.ts` — async; collects every dynamic image input, resolves to `Map<jsonKey, Buffer>`, sniffs format on the resolved bytes.
- `packages/core/src/generate.ts` — `await preflightImages`; passes the resolved map to `renderField`; accepts `GeneratePDFOptions`.
- `packages/core/src/render/field.ts` — dynamic image fields read bytes from the resolved map (renderer is now Buffer-only).
- `packages/core/src/validate.ts` — shape-check accepts every legal form; size guard runs only on shapes whose bytes are in hand.
- `examples/src/result_generate.ts` — switched the demo to a path string to exercise the new feature.

## Tests

- `tests/imageInput.test.ts` — one happy path per branch (Buffer / base64 / data URI / file path / explicit shapes), one failure per failure mode (missing path, HTTP 404, fetch timeout), batch concurrency cap, header pass-through.
- `tests/preflight.test.ts` — new GH #69 describe block covers the end-to-end path through `generatePDF`.

## Verification

- `pnpm type-check` ✓
- `pnpm lint` ✓
- `pnpm test` — core 290/290, ui 439/439 ✓
- Master QA: SHIP

## Acceptance (per #69)

- [x] `images.<key>` accepts `Buffer`, base64, `data:` URI, file path, http(s) URL, and the explicit `{ type, value }` form
- [x] All formats produce identical PDF output for the same underlying bytes
- [x] Failure cases surface `MISSING_ASSET` / `INVALID_FORMAT` with field id, JSON key, and the path/URL in `details`
- [x] HTTP fetches respect a configurable timeout and run with bounded concurrency
- [x] Unit tests cover each input branch and each failure path
- [x] README updated with an example of each format