### PR TITLE
fix(ui): share preview JSON between right panel and Preview dialog (#78)

### DIFF
--- a/.changeset/shared-preview-json.md
+++ b/.changeset/shared-preview-json.md
@@ -1,0 +1,14 @@
+---
+'template-goblin-ui': patch
+---
+
+The right-panel JSON preview and the Preview dialog now share a single
+edited JSON across both surfaces (#78). Previously the right-panel
+textarea kept the user's edits in local component state, so opening
+Preview re-ran `generateExampleJson` and showed the auto-generated
+example again — the user's edits silently vanished. The text now lives
+in `uiStore.previewJsonText` (transient, not persisted): both
+components read from it, both write to it, and the Preview dialog's
+Reset button clears the pin so both surfaces revert to the
+auto-generated example. The right panel grows a `Reset` button that
+appears once the user has pinned a value.

--- a/packages/ui/src/components/Preview/PreviewDialog.tsx
+++ b/packages/ui/src/components/Preview/PreviewDialog.tsx
@@ -42,13 +42,18 @@ export function PreviewDialog({ onClose }: { onClose: () => void }) {
   const staticImageDataUrls = useTemplateStore((s) => s.staticImageDataUrls)
   const jsonMode = useUiStore((s) => s.jsonPreviewMode)
   const repeatCount = useUiStore((s) => s.maxModeRepeatCount)
+  const previewJsonText = useUiStore((s) => s.previewJsonText)
+  const setPreviewJsonText = useUiStore((s) => s.setPreviewJsonText)
 
   const defaultJsonText = useMemo(
     () => JSON.stringify(generateExampleJson(fields, jsonMode, repeatCount), null, 2),
     [fields, jsonMode, repeatCount],
   )
 
-  const [jsonText, setJsonText] = useState(defaultJsonText)
+  // Initial editor content prefers the user's pinned text from the right
+  // panel (#78) so an edit there flows directly into the dialog without
+  // round-tripping through Reset.
+  const [jsonText, setJsonText] = useState(previewJsonText ?? defaultJsonText)
   const [imageOverrides, setImageOverrides] = useState<Map<string, UploadedImage>>(new Map())
   const [uploadError, setUploadError] = useState<string | null>(null)
   const [renderError, setRenderError] = useState<string | null>(null)
@@ -93,6 +98,19 @@ export function PreviewDialog({ onClose }: { onClose: () => void }) {
     setImageOverrides(new Map())
     setUploadError(null)
     setRenderError(null)
+    // Clear the right-panel pin too — Reset means "go back to fresh
+    // defaults across both surfaces", not just the dialog.
+    setPreviewJsonText(null)
+  }
+
+  /**
+   * Mirror dialog edits into the right-panel store so the two surfaces stay
+   * in sync (#78). `setPreviewJsonText` accepts `null` for "unpinned" but the
+   * dialog never writes `null` from typing — only the explicit Reset does.
+   */
+  function handleJsonChange(text: string) {
+    setJsonText(text)
+    setPreviewJsonText(text)
   }
 
   async function handleUpload(jsonKey: string, file: File) {
@@ -189,7 +207,7 @@ export function PreviewDialog({ onClose }: { onClose: () => void }) {
           id="preview-json-editor"
           data-testid="preview-json-editor"
           value={jsonText}
-          onChange={(e) => setJsonText(e.target.value)}
+          onChange={(e) => handleJsonChange(e.target.value)}
           spellCheck={false}
           style={{
             width: '100%',

--- a/packages/ui/src/components/RightPanel/JsonPreview.tsx
+++ b/packages/ui/src/components/RightPanel/JsonPreview.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback, useEffect } from 'react'
+import { useMemo, useCallback } from 'react'
 import { useTemplateStore } from '../../store/templateStore.js'
 import { useUiStore } from '../../store/uiStore.js'
 import { generateExampleJson } from '../../utils/jsonGenerator.js'
@@ -9,31 +9,39 @@ const MODES: { key: JsonPreviewMode; label: string }[] = [
   { key: 'max', label: 'Max' },
 ]
 
+/**
+ * Right-panel JSON preview. The textarea content lives in
+ * `uiStore.previewJsonText` so an edit here flows straight into the
+ * PreviewDialog (#78). When the store value is `null` the textarea shows
+ * the auto-generated example for the current fields and mode; the moment
+ * the user types, the store value goes non-null and pins the user's text
+ * across mode/field changes. The Reset button clears it back to `null`.
+ */
 export function JsonPreview() {
   const fields = useTemplateStore((s) => s.fields)
   const jsonPreviewMode = useUiStore((s) => s.jsonPreviewMode)
   const setJsonPreviewMode = useUiStore((s) => s.setJsonPreviewMode)
   const maxModeRepeatCount = useUiStore((s) => s.maxModeRepeatCount)
+  const previewJsonText = useUiStore((s) => s.previewJsonText)
+  const setPreviewJsonText = useUiStore((s) => s.setPreviewJsonText)
 
   const generated = useMemo(
     () => generateExampleJson(fields, jsonPreviewMode, maxModeRepeatCount),
     [fields, jsonPreviewMode, maxModeRepeatCount],
   )
+  const generatedText = useMemo(() => JSON.stringify(generated, null, 2), [generated])
 
-  const jsonString = useMemo(() => JSON.stringify(generated, null, 2), [generated])
-
-  const [editedJson, setEditedJson] = useState(jsonString)
-
-  // Re-sync when the generated JSON changes (mode switch, field changes)
-  useEffect(() => {
-    setEditedJson(jsonString)
-  }, [jsonString])
+  // The textarea always shows the user's pinned text when it exists — that
+  // pin is the contract that links this surface to PreviewDialog. Without
+  // a pin we fall back to the freshly-regenerated baseline.
+  const value = previewJsonText ?? generatedText
+  const isPinned = previewJsonText !== null
 
   const handleCopy = useCallback(() => {
-    navigator.clipboard.writeText(editedJson).catch(() => {
+    navigator.clipboard.writeText(value).catch(() => {
       // Fallback: ignore clipboard errors
     })
-  }, [editedJson])
+  }, [value])
 
   return (
     <div className="tg-panel-section">
@@ -48,13 +56,25 @@ export function JsonPreview() {
         <div className="tg-panel-section-title" style={{ marginBottom: 0 }}>
           JSON Preview
         </div>
-        <button
-          className="tg-btn"
-          style={{ fontSize: 10, padding: '2px 8px' }}
-          onClick={handleCopy}
-        >
-          Copy
-        </button>
+        <div style={{ display: 'flex', gap: 4 }}>
+          {isPinned && (
+            <button
+              className="tg-btn"
+              style={{ fontSize: 10, padding: '2px 8px' }}
+              onClick={() => setPreviewJsonText(null)}
+              title="Discard your edits and show the auto-generated example"
+            >
+              Reset
+            </button>
+          )}
+          <button
+            className="tg-btn"
+            style={{ fontSize: 10, padding: '2px 8px' }}
+            onClick={handleCopy}
+          >
+            Copy
+          </button>
+        </div>
       </div>
 
       <div className="tg-json-mode-toggle">
@@ -79,8 +99,8 @@ export function JsonPreview() {
       ) : (
         <textarea
           className="tg-json-preview"
-          value={editedJson}
-          onChange={(e) => setEditedJson(e.target.value)}
+          value={value}
+          onChange={(e) => setPreviewJsonText(e.target.value)}
           style={{
             fontFamily: 'var(--font-mono)',
             fontSize: 11,

--- a/packages/ui/src/store/__tests__/uiStore.test.ts
+++ b/packages/ui/src/store/__tests__/uiStore.test.ts
@@ -273,6 +273,26 @@ describe('uiStore', () => {
     })
   })
 
+  // GH #78 — `previewJsonText` is the shared pin between the right-panel
+  // JsonPreview and the PreviewDialog. Round-tripping null ↔ string lets
+  // either surface drive the other.
+  describe('setPreviewJsonText', () => {
+    it('defaults to null (no pin — both surfaces show auto-generated)', () => {
+      expect(useUiStore.getState().previewJsonText).toBeNull()
+    })
+
+    it('stores the user-pinned text verbatim', () => {
+      useUiStore.getState().setPreviewJsonText('{"texts":{"name":"Jaimin"}}')
+      expect(useUiStore.getState().previewJsonText).toBe('{"texts":{"name":"Jaimin"}}')
+    })
+
+    it('null clears the pin (revert to auto-generated)', () => {
+      useUiStore.getState().setPreviewJsonText('{"texts":{"name":"x"}}')
+      useUiStore.getState().setPreviewJsonText(null)
+      expect(useUiStore.getState().previewJsonText).toBeNull()
+    })
+  })
+
   /* -- Theme -- */
 
   describe('toggleTheme', () => {

--- a/packages/ui/src/store/uiStore.ts
+++ b/packages/ui/src/store/uiStore.ts
@@ -27,6 +27,14 @@ export interface UiState {
   jsonPreviewMode: JsonPreviewMode
   /** Max mode repeat count for text */
   maxModeRepeatCount: number
+  /**
+   * User-edited JSON for the preview pipeline (#78). `null` means "use the
+   * auto-generated example" — both the right-panel JsonPreview textarea and
+   * the PreviewDialog's JSON editor read from this field, so an edit in
+   * either surface flows to the other. Transient (not persisted) — a fresh
+   * session starts unpinned, showing the auto-generated example.
+   */
+  previewJsonText: string | null
   /** Whether the right panel is visible */
   showRightPanel: boolean
   /** Whether the left panel is visible */
@@ -87,6 +95,11 @@ export interface UiState {
   setShowPreview: (show: boolean) => void
   setJsonPreviewMode: (mode: JsonPreviewMode) => void
   setMaxModeRepeatCount: (count: number) => void
+  /**
+   * Set the user-pinned preview JSON. Pass `null` to clear (revert to the
+   * auto-generated example).
+   */
+  setPreviewJsonText: (text: string | null) => void
   setShowRightPanel: (show: boolean) => void
   setShowLeftPanel: (show: boolean) => void
   setShowPageSizeDialog: (show: boolean) => void
@@ -119,6 +132,7 @@ export const useUiStore = create<UiState>()(
       showPreview: false,
       jsonPreviewMode: 'default',
       maxModeRepeatCount: 5,
+      previewJsonText: null,
       showRightPanel: true,
       showLeftPanel: true,
       showPageSizeDialog: false,
@@ -165,6 +179,7 @@ export const useUiStore = create<UiState>()(
       setShowPreview: (show) => set({ showPreview: show }),
       setJsonPreviewMode: (mode) => set({ jsonPreviewMode: mode }),
       setMaxModeRepeatCount: (count) => set({ maxModeRepeatCount: count }),
+      setPreviewJsonText: (text) => set({ previewJsonText: text }),
       setShowRightPanel: (show) => set({ showRightPanel: show }),
       setShowLeftPanel: (show) => set({ showLeftPanel: show }),
       setShowPageSizeDialog: (show) => set({ showPageSizeDialog: show }),


### PR DESCRIPTION
Closes #78.

## Symptom

The right-panel JSON Preview is editable, but the user's edits never reached the Preview dialog. Each time the dialog opened, it re-ran \`generateExampleJson(...)\` and showed the auto-generated example again — three sources of truth (right-panel textarea, auto-gen, dialog editor), only two in sync.

## Fix

Lift the edited JSON into \`uiStore.previewJsonText: string | null\` (\`null\` = unpinned, fall back to auto-generated). Both surfaces read + write the same field.

- \`JsonPreview\` drops local \`useState\`, reads/writes the store. A \`Reset\` button (visible only when pinned) clears back to auto-generated.
- \`PreviewDialog\` seeds its editor from \`previewJsonText ?? defaultJsonText\`. Typing in the dialog mirrors back to the store; the dialog's \`Reset\` clears the store too — both surfaces revert together.
- The store slice is **transient** (not in \`partialize\`) — a fresh session starts unpinned.

## Acceptance

- [x] Right-panel JSON edit → open preview → dialog's JSON editor shows the user's edited text byte-for-byte
- [x] Right-panel unchanged + open preview → dialog still shows the auto-gen example
- [x] Reset (in dialog or right panel) clears the user-pinned text — both surfaces revert
- [x] Mode / fields / repeat changes update the auto-gen baseline only when no pin is set
- [x] Unit test asserts the store-backed text round-trips

## Verification

- \`pnpm type-check\` ✓
- \`pnpm lint\` ✓
- \`pnpm test\` — UI 442/442 (3 new), core 290/290