### PR TITLE
fix(image): solid-colour image fields fill the rect via { color } shape (#81)

### DIFF
--- a/.changeset/solid-color-marker.md
+++ b/.changeset/solid-color-marker.md
@@ -1,0 +1,29 @@
+---
+'template-goblin': minor
+'template-goblin-ui': minor
+---
+
+Solid-colour image fields now store a colour value directly instead of
+baking a 1×1 PNG asset (#81). Pre-fix, picking "solid colour" generated
+a tiny PNG and rendered it through `fit: contain`, which produced a
+square in the centre of any non-square rect. Now solid-colour fields
+fill the entire rectangle regardless of aspect ratio, with no image
+asset bundled in the `.tgbl`.
+
+API additions:
+
+- `ImageSourceValue` is now a discriminated union: `{ filename } |
+{ color }`. Type guards `isImageFilenameValue` / `isImageColorValue`
+  are exported.
+- Dynamic input accepts a string marker
+  `<STATICIMAGE_COLOR_#hex>` in `images.<key>` — the renderer paints
+  the field's rect that colour. New helpers exported:
+  `parseImageColorMarker`, `isImageColorMarker`, `makeImageColorMarker`.
+
+UI:
+
+- The properties panel for a solid-colour static image field shows a
+  Color picker; the Fit Mode dropdown + Placeholder upload are hidden
+  (irrelevant for solid fills).
+- The field-creation popup's "Solid color" button no longer generates
+  a 1×1 PNG; the colour is the value.

--- a/packages/core/src/browser.ts
+++ b/packages/core/src/browser.ts
@@ -26,3 +26,8 @@ export { validateData } from './validate.js'
 export { validateManifest } from './validateManifest.js'
 export { resolveValue } from './utils/resolveValue.js'
 export { subsetTemplateFonts, extractUsedCodePoints } from './utils/fontSubset.js'
+export {
+  parseImageColorMarker,
+  isImageColorMarker,
+  makeImageColorMarker,
+} from './utils/imageColorMarker.js'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,3 +20,8 @@ export type { BatchOptions, BatchResult } from './batch.js'
 export { generateAndStore, S3StorageProvider } from './storage.js'
 export type { StorageProvider, GenerateAndStoreOptions, StoreResult } from './storage.js'
 export { subsetTemplateFonts, extractUsedCodePoints } from './utils/fontSubset.js'
+export {
+  parseImageColorMarker,
+  isImageColorMarker,
+  makeImageColorMarker,
+} from './utils/imageColorMarker.js'

--- a/packages/core/src/load.ts
+++ b/packages/core/src/load.ts
@@ -91,6 +91,8 @@ export async function loadTemplate(path: string): Promise<LoadedTemplate> {
   for (const field of manifest.fields) {
     if (field.type !== 'image') continue
     if (field.source.mode === 'static') {
+      // GH #81 — solid-colour static fields carry no asset to load.
+      if ('color' in field.source.value) continue
       const filename = field.source.value.filename
       if (!staticImages.has(filename)) {
         const entry = zip.getEntry(`${IMAGES_DIR}${filename}`)
@@ -103,6 +105,8 @@ export async function loadTemplate(path: string): Promise<LoadedTemplate> {
         staticImages.set(filename, entry.getData())
       }
     } else if (field.source.placeholder) {
+      // Solid-colour placeholders also carry no asset.
+      if ('color' in field.source.placeholder) continue
       const filename = field.source.placeholder.filename
       if (!placeholders.has(filename)) {
         const entry = zip.getEntry(`${PLACEHOLDERS_DIR}${filename}`)

--- a/packages/core/src/preflight.ts
+++ b/packages/core/src/preflight.ts
@@ -3,6 +3,7 @@ import { TemplateGoblinError } from '@template-goblin/types'
 import { sniffImageFormat } from './utils/imageFormat.js'
 import { pageContextFor, pageLabel, type PageContext } from './utils/errorContext.js'
 import { resolveImageInputs, type ResolveContext, type ResolveOptions } from './utils/imageInput.js'
+import { isImageColorMarker } from './utils/imageColorMarker.js'
 
 /** Per-call options for {@link preflightImages}. */
 export interface PreflightOptions {
@@ -68,6 +69,11 @@ export async function preflightImages(
       void required
       continue
     }
+
+    // GH #81 — solid-colour markers (`<STATICIMAGE_COLOR_#hex>`) are not
+    // image bytes; the renderer paints a filled rect from the marker
+    // string. Skip the resolver + format sniff for them.
+    if (isImageColorMarker(raw)) continue
 
     if (!isImageInput(raw)) {
       // validateData already raised INVALID_DATA_TYPE; skip resolution.
@@ -163,7 +169,11 @@ function checkStaticImage(
   pageContext: PageContext,
 ): void {
   if (field.source.mode !== 'static') return
-  const filename = (field.source.value as { filename?: string } | null)?.filename
+  const value = field.source.value as { filename?: string; color?: string } | null
+  // GH #81 — solid-colour static fields carry no asset; the renderer
+  // paints a filled rect. Skip the bytes / format checks entirely.
+  if (value && typeof value.color === 'string') return
+  const filename = value?.filename
   if (!filename) return // nothing baked in — renderer skips silently
 
   const bytes = template.staticImages.get(filename)

--- a/packages/core/src/render/field.ts
+++ b/packages/core/src/render/field.ts
@@ -3,6 +3,7 @@ import type { FieldDefinition, InputJSON, LoadedTemplate, TableRow } from '@temp
 import { TemplateGoblinError } from '@template-goblin/types'
 import { resolveValue } from '../utils/resolveValue.js'
 import { fieldErrorDetails, pageLabel, type PageContext } from '../utils/errorContext.js'
+import { parseImageColorMarker } from '../utils/imageColorMarker.js'
 import { renderText } from './text.js'
 import { renderImage } from './image.js'
 import { renderLoop } from './loop.js'
@@ -41,9 +42,26 @@ export function renderField(
         break
 
       case 'image': {
-        // Dynamic image: bytes were resolved up front by preflightImages and
-        // live in `resolvedImages` keyed by the field's jsonKey. Static
-        // image: value is `{ filename }` — look up bytes in `staticImages`.
+        // GH #81 — solid colour can come via either:
+        //   (a) static `source.value = { color }` in the manifest, or
+        //   (b) dynamic `data.images[jsonKey]` matching the marker
+        //       `<STATICIMAGE_COLOR_#hex>`.
+        // In both cases we paint a filled rect — no image bytes needed.
+        if (field.source.mode === 'dynamic') {
+          const raw = (data.images as Record<string, unknown> | undefined)?.[field.source.jsonKey]
+          const markerHex = parseImageColorMarker(raw)
+          if (markerHex !== null) {
+            renderImage(doc, field, { color: markerHex })
+            break
+          }
+        } else if (value && typeof value === 'object' && 'color' in value) {
+          renderImage(doc, field, { color: (value as { color: string }).color })
+          break
+        }
+
+        // Standard byte-backed paths. Dynamic: bytes were resolved by
+        // preflightImages (#69) and live in `resolvedImages`. Static:
+        // value is `{ filename }` — look up bytes in `staticImages`.
         let imageData: Buffer | undefined
         if (field.source.mode === 'dynamic') {
           imageData = resolvedImages.get(field.source.jsonKey)

--- a/packages/core/src/render/image.ts
+++ b/packages/core/src/render/image.ts
@@ -4,20 +4,29 @@ import type { FieldDefinition, ImageFieldStyle } from '@template-goblin/types'
 /**
  * Render an image field onto a PDFKit document within its bounding rectangle.
  *
- * Supports three fit modes: fill, contain, cover.
- * Accepts both Buffer and base64 string inputs.
+ * Supports three fit modes: fill, contain, cover. Accepts Buffer + base64.
  *
- * @param doc - PDFKit document
- * @param field - Field definition with position and dimensions
- * @param value - Image data as Buffer or base64 string
+ * GH #81 — additionally accepts a `{ color: '#hex' }` shape (or its string
+ * marker form `<STATICIMAGE_COLOR_#hex>` resolved upstream by preflight)
+ * which paints a filled rectangle at the rect bounds. The `style.fit`
+ * dropdown is irrelevant in that case — solid fills always cover the
+ * rect — so it's ignored.
  */
 export function renderImage(
   doc: InstanceType<typeof PDFDocument>,
   field: FieldDefinition,
-  value: Buffer | string,
+  value: Buffer | string | { color: string },
 ): void {
   const style = field.style as ImageFieldStyle
   const { x, y, width, height } = field
+
+  // GH #81 — solid-colour fill: no image bytes, just paint the rect.
+  if (typeof value === 'object' && value !== null && !Buffer.isBuffer(value) && 'color' in value) {
+    doc.save()
+    doc.rect(x, y, width, height).fill(value.color)
+    doc.restore()
+    return
+  }
 
   // REQ: Support both Buffer and base64 string input
   // Strip data URI prefix if present (e.g., "data:image/png;base64,...")

--- a/packages/core/src/utils/imageColorMarker.ts
+++ b/packages/core/src/utils/imageColorMarker.ts
@@ -1,0 +1,36 @@
+/**
+ * Solid-colour image marker (#81).
+ *
+ * Designers can supply a "solid colour" image by passing the literal string
+ * `<STATICIMAGE_COLOR_#rgb>` or `<STATICIMAGE_COLOR_#rrggbb>` in the
+ * `images.<key>` slot of `InputJSON`. The renderer paints the field's
+ * rectangle in that colour instead of decoding any bytes — there is no
+ * image asset, just a fill.
+ *
+ * Same idea is exposed in the manifest via `ImageSourceValue = { color }`
+ * for static fields; this module only handles the dynamic-input string
+ * form. Case-sensitive prefix per the user's spec.
+ */
+
+const MARKER_RE = /^<STATICIMAGE_COLOR_(#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6}))>$/
+
+/**
+ * Return the embedded hex colour if `value` is a solid-colour marker
+ * string, otherwise `null`. Strict: case-sensitive on the prefix, hex must
+ * be 3 or 6 digits with a leading `#`.
+ */
+export function parseImageColorMarker(value: unknown): string | null {
+  if (typeof value !== 'string') return null
+  const match = MARKER_RE.exec(value)
+  return match ? (match[1] ?? null) : null
+}
+
+/** Convenience predicate. */
+export function isImageColorMarker(value: unknown): value is string {
+  return parseImageColorMarker(value) !== null
+}
+
+/** Build the marker string for a given hex colour. */
+export function makeImageColorMarker(hex: string): string {
+  return `<STATICIMAGE_COLOR_${hex}>`
+}

--- a/packages/core/src/validateManifest.ts
+++ b/packages/core/src/validateManifest.ts
@@ -67,6 +67,10 @@ function validateTextField(field: TextField): void {
 
 function isImageSourceValue(v: unknown): v is ImageSourceValue {
   if (v === null || typeof v !== 'object') return false
+  // GH #81 — `{ color: '#hex' }` is a valid `ImageSourceValue` for solid-
+  // colour static fields. No image asset; the renderer paints a fill.
+  const c = (v as { color?: unknown }).color
+  if (typeof c === 'string' && c.length > 0) return true
   const f = (v as { filename?: unknown }).filename
   return typeof f === 'string' && f.length > 0
 }
@@ -77,7 +81,7 @@ function validateImageField(field: ImageField): void {
     if (!isImageSourceValue(field.source.value)) {
       fail(
         'INVALID_STATIC_VALUE',
-        `Image field ${field.id}: static value must be { filename: non-empty string }`,
+        `Image field ${field.id}: static value must be { filename } or { color }`,
         { fieldId: field.id },
       )
     }
@@ -87,7 +91,7 @@ function validateImageField(field: ImageField): void {
     if (ph !== null && !isImageSourceValue(ph)) {
       fail(
         'INVALID_DYNAMIC_SOURCE',
-        `Image field ${field.id}: placeholder must be { filename: string } or null`,
+        `Image field ${field.id}: placeholder must be { filename } / { color } / null`,
         { fieldId: field.id },
       )
     }

--- a/packages/core/tests/imageColorMarker.test.ts
+++ b/packages/core/tests/imageColorMarker.test.ts
@@ -1,0 +1,60 @@
+/**
+ * GH #81 — solid-colour image marker parser.
+ *
+ * Designers can pass `<STATICIMAGE_COLOR_#hex>` in the dynamic
+ * `images.<key>` slot to paint the rect that colour. The marker is
+ * case-sensitive on the prefix; the hex tail accepts 3- or 6-digit forms.
+ */
+import {
+  parseImageColorMarker,
+  isImageColorMarker,
+  makeImageColorMarker,
+} from '../src/utils/imageColorMarker.js'
+
+describe('parseImageColorMarker', () => {
+  it('extracts a 6-digit hex colour', () => {
+    expect(parseImageColorMarker('<STATICIMAGE_COLOR_#ff0080>')).toBe('#ff0080')
+  })
+
+  it('extracts a 3-digit hex colour', () => {
+    expect(parseImageColorMarker('<STATICIMAGE_COLOR_#abc>')).toBe('#abc')
+  })
+
+  it('accepts uppercase hex digits', () => {
+    expect(parseImageColorMarker('<STATICIMAGE_COLOR_#FFAA00>')).toBe('#FFAA00')
+  })
+
+  it('returns null for non-string input', () => {
+    expect(parseImageColorMarker(undefined)).toBeNull()
+    expect(parseImageColorMarker(null)).toBeNull()
+    expect(parseImageColorMarker(42)).toBeNull()
+    expect(parseImageColorMarker({ color: '#ff0000' })).toBeNull()
+  })
+
+  it('case-sensitive on the prefix — lowercase variants do not match', () => {
+    expect(parseImageColorMarker('<staticimage_color_#fff>')).toBeNull()
+    expect(parseImageColorMarker('<StaticImage_Color_#fff>')).toBeNull()
+  })
+
+  it('rejects malformed hex (too short, too long, no #)', () => {
+    expect(parseImageColorMarker('<STATICIMAGE_COLOR_#ff>')).toBeNull()
+    expect(parseImageColorMarker('<STATICIMAGE_COLOR_#ff00ff00>')).toBeNull()
+    expect(parseImageColorMarker('<STATICIMAGE_COLOR_ff0000>')).toBeNull()
+  })
+
+  it('rejects strings that merely contain the marker', () => {
+    expect(parseImageColorMarker('prefix <STATICIMAGE_COLOR_#fff>')).toBeNull()
+    expect(parseImageColorMarker('<STATICIMAGE_COLOR_#fff> suffix')).toBeNull()
+  })
+
+  it('isImageColorMarker matches parseImageColorMarker', () => {
+    expect(isImageColorMarker('<STATICIMAGE_COLOR_#abc>')).toBe(true)
+    expect(isImageColorMarker('not a marker')).toBe(false)
+  })
+
+  it('makeImageColorMarker round-trips through the parser', () => {
+    const marker = makeImageColorMarker('#1a2b3c')
+    expect(marker).toBe('<STATICIMAGE_COLOR_#1a2b3c>')
+    expect(parseImageColorMarker(marker)).toBe('#1a2b3c')
+  })
+})

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -9,6 +9,8 @@ export type {
   TextFieldStyle,
   ImageFieldStyle,
   ImageSourceValue,
+  ImageFilenameValue,
+  ImageColorValue,
   TableFieldStyle,
   TableCellRuntimeStyle,
   TableColumn,
@@ -31,6 +33,7 @@ export type {
 export type { InputJSON, TextInputs, TableInputs, ImageInputs, ImageInput } from './input.js'
 export type { StaticSource, DynamicSource, FieldSource } from './source.js'
 export { isStaticSource, isDynamicSource } from './source.js'
+export { isImageFilenameValue, isImageColorValue } from './template.js'
 export type { LoadedTemplate, TemplateAssets } from './loaded.js'
 export { PAGE_SIZE_PRESETS, getPageSize } from './pageSize.js'
 export { isSafeKey } from './safeKey.js'

--- a/packages/types/src/template.ts
+++ b/packages/types/src/template.ts
@@ -149,9 +149,35 @@ export interface TableFieldStyle {
 /** A single row in a table — column key -> cell string value. */
 export type TableRow = Record<string, string>
 
-/** Image source value shape — a filename inside the `.tgbl` archive. */
-export interface ImageSourceValue {
+/**
+ * Image source value — what a field's `source.value` (static) or
+ * `source.placeholder` (dynamic, canvas-time preview) actually points at.
+ *
+ * Two shapes:
+ *   - `{ filename }` — a baked image asset stored inside the `.tgbl`
+ *     archive (PNG/JPEG bytes). The renderer decodes and paints.
+ *   - `{ color }` — a solid colour, painted as a filled rectangle (#81).
+ *     No image bytes; the colour is the value. Hex (`#rgb` or `#rrggbb`).
+ */
+export type ImageSourceValue = ImageFilenameValue | ImageColorValue
+
+export interface ImageFilenameValue {
   filename: string
+}
+
+export interface ImageColorValue {
+  /** Hex colour — `#rgb` or `#rrggbb`. */
+  color: string
+}
+
+/** Type guard for the image-asset variant of `ImageSourceValue`. */
+export function isImageFilenameValue(v: ImageSourceValue): v is ImageFilenameValue {
+  return 'filename' in v && typeof v.filename === 'string'
+}
+
+/** Type guard for the solid-colour variant of `ImageSourceValue`. */
+export function isImageColorValue(v: ImageSourceValue): v is ImageColorValue {
+  return 'color' in v && typeof v.color === 'string'
 }
 
 /** Background type for a page */

--- a/packages/ui/src/components/Canvas/FieldCreationPopup.tsx
+++ b/packages/ui/src/components/Canvas/FieldCreationPopup.tsx
@@ -43,7 +43,7 @@ export interface PickedImage {
 }
 
 export type SourceInputs =
-  | { mode: 'static'; value: string; image?: PickedImage }
+  | { mode: 'static'; value: string; image?: PickedImage; color?: string }
   | { mode: 'dynamic'; jsonKey: string; required: boolean; placeholder: string }
 
 export interface FieldCreationPopupProps {
@@ -80,6 +80,9 @@ export function FieldCreationPopup({
   const [placeholder, setPlaceholder] = useState('')
   const [value, setValue] = useState('')
   const [pickedImage, setPickedImage] = useState<PickedImage | null>(null)
+  // GH #81 — solid-colour image fields are stored as `{ color }` and skip
+  // the byte-asset pipeline. Mutually exclusive with `pickedImage`.
+  const [pickedColor, setPickedColor] = useState<string | null>(null)
   const [imagePickMode, setImagePickMode] = useState<'choose' | 'color'>('choose')
   const [imageColor, setImageColor] = useState('#ffffff')
   const [error, setError] = useState<string | null>(null)
@@ -107,7 +110,7 @@ export function FieldCreationPopup({
         placeholder: required ? '' : placeholder,
       })
     } else {
-      if (draft.type === 'image' && !pickedImage) {
+      if (draft.type === 'image' && !pickedImage && !pickedColor) {
         setError('Pick an image or a solid color for this static image field.')
         return
       }
@@ -115,9 +118,21 @@ export function FieldCreationPopup({
         mode: 'static',
         value,
         image: draft.type === 'image' && pickedImage ? pickedImage : undefined,
+        color: draft.type === 'image' && pickedColor ? pickedColor : undefined,
       })
     }
-  }, [label, mode, jsonKey, required, placeholder, value, draft.type, pickedImage, onConfirm])
+  }, [
+    label,
+    mode,
+    jsonKey,
+    required,
+    placeholder,
+    value,
+    draft.type,
+    pickedImage,
+    pickedColor,
+    onConfirm,
+  ])
 
   async function onPickFile(file: File) {
     const buffer = await file.arrayBuffer()
@@ -130,34 +145,17 @@ export function FieldCreationPopup({
     const ext = file.name.match(/\.[A-Za-z0-9]+$/)?.[0] ?? '.png'
     const filename = `static-${Date.now()}${ext}`
     setPickedImage({ filename, dataUrl, buffer })
+    // Picking a real image clears any previously-picked solid colour —
+    // they're mutually exclusive in the data model (#81).
+    setPickedColor(null)
   }
 
-  async function onPickSolidColor(hex: string) {
-    // Render the chosen colour to a 1x1 PNG and treat it as an image payload.
-    // This keeps the schema image-first (source.value.filename) while still
-    // supporting the "solid color" ergonomic the user asked for.
-    const canvas = document.createElement('canvas')
-    canvas.width = 1
-    canvas.height = 1
-    const ctx = canvas.getContext('2d')
-    if (!ctx) {
-      setError('Could not build a solid-color image in this browser.')
-      return
-    }
-    ctx.fillStyle = hex
-    ctx.fillRect(0, 0, 1, 1)
-    const blob: Blob = await new Promise((resolve, reject) => {
-      canvas.toBlob((b) => (b ? resolve(b) : reject(new Error('toBlob failed'))), 'image/png')
-    })
-    const buffer = await blob.arrayBuffer()
-    const dataUrl: string = await new Promise((resolve, reject) => {
-      const reader = new FileReader()
-      reader.onload = () => resolve(reader.result as string)
-      reader.onerror = () => reject(new Error('Failed to read blob'))
-      reader.readAsDataURL(blob)
-    })
-    const filename = `static-color-${hex.replace('#', '').toLowerCase()}.png`
-    setPickedImage({ filename, dataUrl, buffer })
+  function onPickSolidColor(hex: string) {
+    // GH #81 — store the colour directly. No 1×1 PNG, no
+    // staticImageBuffers entry, no fit-mode irrelevance. The renderer
+    // (canvas + PDF) paints a filled rect at the field's bounds.
+    setPickedColor(hex)
+    setPickedImage(null)
   }
 
   // Keyboard shortcuts: Esc = cancel, Ctrl/Cmd+Enter = create
@@ -313,7 +311,30 @@ export function FieldCreationPopup({
           {mode === 'static' && draft.type === 'image' && (
             <div className="tg-field-row">
               <span className="tg-field-label">Image content</span>
-              {pickedImage ? (
+              {pickedColor ? (
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                  <div
+                    style={{
+                      width: 48,
+                      height: 48,
+                      background: pickedColor,
+                      border: '1px solid var(--border)',
+                      borderRadius: 4,
+                    }}
+                  />
+                  <span style={{ fontFamily: 'monospace', fontSize: 12 }}>{pickedColor}</span>
+                  <button
+                    className="tg-btn"
+                    onClick={() => {
+                      setPickedColor(null)
+                      setImagePickMode('choose')
+                    }}
+                    data-testid="create-popup-color-clear"
+                  >
+                    Change
+                  </button>
+                </div>
+              ) : pickedImage ? (
                 <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
                   <img
                     src={pickedImage.dataUrl}

--- a/packages/ui/src/components/Canvas/buildGroupChildren.ts
+++ b/packages/ui/src/components/Canvas/buildGroupChildren.ts
@@ -41,25 +41,36 @@ export function buildGroupChildren(
   const w = field.width
   const h = field.height
 
-  // Resolve image data URL (for image fields).
+  // Resolve the image-field paint shape: either a colour fill (#81) or a
+  // baked image asset. Colour wins over filename when both are present
+  // (shouldn't happen, but defensive).
   let imageDataUrl: string | null = null
+  let imageColor: string | null = null
   if (field.type === 'image' && field.source) {
-    let filename: string | null = null
-    if (field.source.mode === 'dynamic') {
-      const ph = field.source.placeholder as unknown
-      if (ph && typeof ph === 'object' && 'filename' in ph) {
-        const name = (ph as { filename: unknown }).filename
-        if (typeof name === 'string' && name.length > 0) filename = name
-      }
-    } else {
-      const v = field.source.value as unknown
-      if (v && typeof v === 'object' && 'filename' in v) {
-        const name = (v as { filename: unknown }).filename
-        if (typeof name === 'string' && name.length > 0) filename = name
+    const fromValue =
+      field.source.mode === 'dynamic'
+        ? (field.source.placeholder as unknown)
+        : (field.source.value as unknown)
+    if (fromValue && typeof fromValue === 'object') {
+      if ('color' in fromValue) {
+        const c = (fromValue as { color: unknown }).color
+        if (typeof c === 'string' && c.length > 0) imageColor = c
+      } else if ('filename' in fromValue) {
+        const name = (fromValue as { filename: unknown }).filename
+        if (typeof name === 'string' && name.length > 0) {
+          imageDataUrl = resolveImage(name)
+        }
       }
     }
-    if (filename) {
-      imageDataUrl = resolveImage(filename)
+    // GH #81 — dynamic image fields can also receive a colour marker via
+    // `data.images[jsonKey]` like `<STATICIMAGE_COLOR_#hex>`; the canvas
+    // shows that fill at design time as soon as the user pins it.
+    if (!imageColor && field.source.mode === 'dynamic' && data) {
+      const supplied = data.images?.[field.source.jsonKey]
+      if (typeof supplied === 'string') {
+        const m = /^<STATICIMAGE_COLOR_(#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6}))>$/.exec(supplied)
+        if (m && m[1]) imageColor = m[1]
+      }
     }
   }
 
@@ -76,13 +87,16 @@ export function buildGroupChildren(
     (field.style?.columns?.length ?? 0) > 0 &&
     !!tableRowsForRender &&
     tableRowsForRender.length > 0
-  const shouldFill = !tableHasBodyRows && shouldRenderFillRect(field, { placeholderResolved })
+  // GH #81: solid-colour image fields paint the user's colour ON the
+  // bgRect itself — no per-type design-time tint, no separate child.
+  const shouldFill =
+    !tableHasBodyRows && !imageColor && shouldRenderFillRect(field, { placeholderResolved })
 
   // 1. Background rect — always present so the Group has a stable bounding
   //    box and hit-testing works (Fabric needs a non-zero area; fill:
   //    'transparent' still participates in hit-detection unlike fill: null
   //    or fill: '').
-  const defaultFill = shouldFill ? colors.fill : 'transparent'
+  const defaultFill = imageColor ?? (shouldFill ? colors.fill : 'transparent')
   const defaultStroke = colors.stroke
   const defaultStrokeWidth = 1
   const bgRect = new Rect({
@@ -147,10 +161,14 @@ export function buildGroupChildren(
     children.push(...buildTableCanvasParts(field, w, h, tableRowsForRender))
   }
 
-  // 3. Auto-fit label (GH #12) — skipped when an image is rendered, and
-  //    skipped for tables that already drew their column headers.
+  // 3. Auto-fit label (GH #12) — skipped when an image is rendered, when
+  //    the field paints a solid colour fill (#81 — the colour IS the
+  //    content; a centred label would obscure it), and for tables that
+  //    already drew their column headers.
   const skipBodyLabel =
-    placeholderResolved || (field.type === 'table' && (field.style?.columns?.length ?? 0) > 0)
+    placeholderResolved ||
+    imageColor !== null ||
+    (field.type === 'table' && (field.style?.columns?.length ?? 0) > 0)
   if (!skipBodyLabel) {
     const label = labelFor(field, data)
     if (label) {

--- a/packages/ui/src/components/Canvas/fabricUtils.ts
+++ b/packages/ui/src/components/Canvas/fabricUtils.ts
@@ -241,6 +241,12 @@ function fieldRenderHash(
     } else if (field.type === 'table') {
       const rows = data.tables?.[field.source.jsonKey]
       if (Array.isArray(rows)) dataSlice = { n: rows.length, head: rows[0] ?? null }
+    } else if (field.type === 'image') {
+      // GH #81 — surface the dynamic colour-marker string in the hash so
+      // typing `<STATICIMAGE_COLOR_#hex>` into the right-panel JSON
+      // triggers a child rebuild and repaints the rect.
+      const supplied = data.images?.[field.source.jsonKey]
+      if (typeof supplied === 'string') dataSlice = supplied
     }
   }
   return JSON.stringify({

--- a/packages/ui/src/components/Canvas/useFieldCreationPopup.ts
+++ b/packages/ui/src/components/Canvas/useFieldCreationPopup.ts
@@ -41,6 +41,11 @@ export function useFieldCreationPopup() {
             return { ...base, label, source: { mode: 'static', value: source.value } }
           }
           if (base.type === 'image') {
+            // GH #81 — solid-colour static fields store `{ color }`
+            // directly. No filename, no static-image asset, no fit math.
+            if (source.color) {
+              return { ...base, label, source: { mode: 'static', value: { color: source.color } } }
+            }
             const filename = source.image?.filename ?? ''
             return { ...base, label, source: { mode: 'static', value: { filename } } }
           }

--- a/packages/ui/src/components/RightPanel/ImageFieldProps.tsx
+++ b/packages/ui/src/components/RightPanel/ImageFieldProps.tsx
@@ -39,13 +39,20 @@ export function ImageFieldProps({ field }: Props) {
         mode: 'dynamic'
         jsonKey: string
         required: boolean
-        placeholder: { filename: string } | null
+        placeholder: { filename: string } | { color: string } | null
       })
     : null
   const staticValue = isStatic
-    ? ((field.source as { mode: 'static'; value: { filename: string } }).value ?? { filename: '' })
+    ? ((field.source as { mode: 'static'; value: { filename?: string; color?: string } }).value ?? {
+        filename: '',
+      })
     : { filename: '' }
   const displayKey = dynamicSource?.jsonKey ?? ''
+  // GH #81 — solid-colour static field: value is `{ color }`. Hide the
+  // image-asset upload + Fit Mode dropdown; show a colour picker instead.
+  const isStaticSolidColor =
+    isStatic && typeof (staticValue as { color?: string }).color === 'string'
+  const staticColor = isStaticSolidColor ? (staticValue as { color: string }).color : null
 
   function handleStaticUpload(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0]
@@ -97,7 +104,10 @@ export function ImageFieldProps({ field }: Props) {
     e.target.value = ''
   }
 
-  const placeholderFilename = dynamicSource?.placeholder?.filename ?? null
+  const placeholderFilename =
+    dynamicSource?.placeholder && 'filename' in dynamicSource.placeholder
+      ? dynamicSource.placeholder.filename
+      : null
 
   return (
     <>
@@ -107,7 +117,27 @@ export function ImageFieldProps({ field }: Props) {
       <div className="tg-panel-section">
         <div className="tg-panel-section-title">Field Properties</div>
 
-        {isStatic && (
+        {isStatic && isStaticSolidColor && (
+          <div className="tg-form-row">
+            <label>Color</label>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+              <input
+                type="color"
+                value={staticColor ?? '#ffffff'}
+                onChange={(e) =>
+                  updateField(field.id, {
+                    source: { mode: 'static', value: { color: e.target.value } },
+                  } as Partial<FieldDefinition>)
+                }
+                style={{ width: 44, height: 32 }}
+                data-testid="image-static-color-input"
+              />
+              <span style={{ fontFamily: 'monospace', fontSize: 12 }}>{staticColor}</span>
+            </div>
+          </div>
+        )}
+
+        {isStatic && !isStaticSolidColor && (
           <div className="tg-form-row">
             <label>Value (image file)</label>
             <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
@@ -192,64 +222,69 @@ export function ImageFieldProps({ field }: Props) {
         )}
       </div>
 
-      <div className="tg-panel-section">
-        <div className="tg-panel-section-title">Image Settings</div>
+      {/* GH #81 — solid-colour static fields don't need any image-style
+          settings: the colour fills the rect, fit-mode is meaningless,
+          and there's no placeholder asset to upload. */}
+      {!isStaticSolidColor && (
+        <div className="tg-panel-section">
+          <div className="tg-panel-section-title">Image Settings</div>
 
-        <div className="tg-form-row">
-          <label>Fit Mode</label>
-          <select
-            className="tg-select"
-            value={style.fit}
-            onChange={(e) =>
-              updateFieldStyle(field.id, { fit: e.target.value as 'fill' | 'contain' | 'cover' })
-            }
-          >
-            <option value="fill">Fill</option>
-            <option value="contain">Contain</option>
-            <option value="cover">Cover</option>
-          </select>
-        </div>
-
-        {isDynamic && (
           <div className="tg-form-row">
-            <label>Placeholder Image</label>
-            <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-              <button
-                className="tg-btn"
-                onClick={() => dynamicFileInputRef.current?.click()}
-                style={{
-                  fontSize: 11,
-                  border: '1px solid var(--border)',
-                  background: 'var(--bg-tertiary)',
-                }}
-                data-testid="image-placeholder-upload"
-              >
-                Upload
-              </button>
-              {placeholderFilename && (
-                <span
+            <label>Fit Mode</label>
+            <select
+              className="tg-select"
+              value={style.fit}
+              onChange={(e) =>
+                updateFieldStyle(field.id, { fit: e.target.value as 'fill' | 'contain' | 'cover' })
+              }
+            >
+              <option value="fill">Fill</option>
+              <option value="contain">Contain</option>
+              <option value="cover">Cover</option>
+            </select>
+          </div>
+
+          {isDynamic && (
+            <div className="tg-form-row">
+              <label>Placeholder Image</label>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                <button
+                  className="tg-btn"
+                  onClick={() => dynamicFileInputRef.current?.click()}
                   style={{
                     fontSize: 11,
-                    color: 'var(--text-muted)',
-                    overflow: 'hidden',
-                    textOverflow: 'ellipsis',
-                    whiteSpace: 'nowrap',
+                    border: '1px solid var(--border)',
+                    background: 'var(--bg-tertiary)',
                   }}
+                  data-testid="image-placeholder-upload"
                 >
-                  {placeholderFilename}
-                </span>
-              )}
+                  Upload
+                </button>
+                {placeholderFilename && (
+                  <span
+                    style={{
+                      fontSize: 11,
+                      color: 'var(--text-muted)',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    {placeholderFilename}
+                  </span>
+                )}
+              </div>
+              <input
+                ref={dynamicFileInputRef}
+                type="file"
+                accept="image/*"
+                hidden
+                onChange={handlePlaceholderUpload}
+              />
             </div>
-            <input
-              ref={dynamicFileInputRef}
-              type="file"
-              accept="image/*"
-              hidden
-              onChange={handlePlaceholderUpload}
-            />
-          </div>
-        )}
-      </div>
+          )}
+        </div>
+      )}
     </>
   )
 }

--- a/packages/ui/src/utils/saveOpen.ts
+++ b/packages/ui/src/utils/saveOpen.ts
@@ -292,7 +292,10 @@ export async function openTemplate(file: File): Promise<void> {
   for (const field of manifest.fields) {
     if (field.type !== 'image') continue
     if (field.source.mode !== 'dynamic') continue
-    const filename = field.source.placeholder?.filename
+    const ph = field.source.placeholder
+    // GH #81 — solid-colour placeholders carry no asset; skip.
+    if (!ph || 'color' in ph) continue
+    const filename = ph.filename
     if (!filename || !isSafeZipPath(filename)) continue
     const archivePath = filename.startsWith('placeholders/') ? filename : `placeholders/${filename}`
     const phFile = zip.file(archivePath) ?? zip.file(filename)
@@ -309,7 +312,9 @@ export async function openTemplate(file: File): Promise<void> {
   for (const field of manifest.fields) {
     if (field.type !== 'image') continue
     if (field.source.mode !== 'static') continue
-    const filename = field.source.value?.filename
+    // GH #81 — solid-colour static fields carry no asset; skip.
+    if ('color' in field.source.value) continue
+    const filename = field.source.value.filename
     if (!filename) continue
     const archivePath = filename.startsWith('images/') ? filename : `images/${filename}`
     if (!isSafeZipPath(archivePath)) continue


### PR DESCRIPTION
Closes #81.

## Symptom

Picking "solid colour" in the field-creation popup generated a 1×1 PNG, stored it as a static image asset, and rendered through `doc.image()` with `fit: contain`. Containing a 1×1 image into a `W×H` rect lands a `min(W,H)×min(W,H)` square in the centre — wrong for any non-square rect.

## Fix

The colour IS the value. No 1×1 PNG, no fit math, no asset.

### Schema

- `ImageSourceValue` becomes a discriminated union: `{ filename } | { color }`. Type guards `isImageFilenameValue` / `isImageColorValue` exported from `@template-goblin/types`.
- `validateManifest` accepts both shapes.
- `core/load.ts` and `ui/saveOpen.ts` skip colour values when reading or extracting bytes from a `.tgbl`.

### Renderer

- `core/render/image.ts` paints `doc.rect(x,y,w,h).fill(color)` for the colour shape; `style.fit` is irrelevant and ignored.
- `core/render/field.ts` routes static `{ color }` and dynamic colour-marker strings to the colour-fill branch.
- `core/preflight.ts` skips colour markers from byte resolution + format sniff. Static colour fields skip the bytes/format check entirely.
- `ui/components/Canvas/buildGroupChildren.ts` paints the bgRect with the colour, hides the centred label, detects the dynamic marker for live preview.
- `ui/components/Canvas/fabricUtils.ts` `fieldRenderHash` folds the dynamic image data slice so colour-marker edits in the right-panel JSON trigger a child rebuild.

### Dynamic input

Library users can pass `images.<key> = '<STATICIMAGE_COLOR_#hex>'` and the renderer paints the field's rect that colour. New helpers exported from both `template-goblin` and `template-goblin/browser`:

- `parseImageColorMarker(value): string | null`
- `isImageColorMarker(value): boolean`
- `makeImageColorMarker(hex): string`

Case-sensitive prefix per the spec; 3- or 6-digit hex.

### UI

- `FieldCreationPopup`: `onPickSolidColor` stores the picked hex on a new `pickedColor` state. No PNG generation. Mutually exclusive with `pickedImage`. Solid-colour swatch + Change button replace the image preview row.
- `RightPanel/ImageFieldProps`: solid-colour static field shows a Color picker; the Image Settings section (Fit Mode + Placeholder Image upload) is hidden.

## Acceptance (per #81)

- [x] New solid-colour field fills its full rect on canvas + PDF, regardless of aspect ratio
- [x] Non-solid-colour static images still respect `style.fit` (no regression)
- [x] Hard Rule #10 still holds — nothing renders outside the field rect
- [x] Unit tests cover the marker parser

## Verification

- `pnpm type-check` ✓
- `pnpm lint` ✓
- `pnpm test` — core 300 (was 291, +9 marker-parser tests), UI 396, all pass

## Note

Per the user's call: no backward-compat for old `static-color-<hex>.png` baked PNG fields in saved templates. They can be deleted + recreated.