### PR TITLE
fix(canvas): persist zoom across refresh, drop racing dimension writers (#84)

### DIFF
--- a/.changeset/zoom-on-refresh.md
+++ b/.changeset/zoom-on-refresh.md
@@ -2,4 +2,9 @@
 'template-goblin-ui': patch
 ---
 
-Drop the ResizeObserver-driven auto-fit zoom on the canvas. With #84's "default 100%" rule, the observer's "snap zoom back to fit when current ≤ fit" behaviour fought the goal: during page refresh the layout settled in stages, the observer fired with a transient container size and snapped zoom to fit, leaving the canvas no longer overflowing the viewport — so no scrollbars appeared even when the page was bigger than the visible area. The canvas now stays at `meta × zoom` regardless of container resizes; users can manually zoom out via the controls if they want a fit-to-viewport view.
+Fix canvas zoom / scrollbar behaviour on page refresh and persist the user's zoom level across reloads (#84 follow-up).
+
+- Drop the ResizeObserver-driven auto-fit zoom — with #84's "default 100%" rule, the observer's "snap back to fit when current ≤ fit" behaviour was hiding the page's natural overflow on refresh, so scrollbars never appeared even when the page was bigger than the viewport.
+- Drop the zoom-sync effect's `fc.getZoom() === store.zoom` early-return — on a fresh refresh both read 1 by default, so the equality skipped the very `setDimensions(meta × 1)` call that gives the canvas its real size. The effect now resyncs `meta × zoom` on every dep change unconditionally.
+- Persist `zoom` in `uiStore` and skip the GH #84 reset on the very first valid post-hydration run, so reloading the editor restores the canvas at whatever zoom you were last viewing instead of snapping to 100%.
+- Remove `useFabricCanvas`'s post-mount `requestAnimationFrame` block; canvas dimension / zoom is now fully owned by the zoom-sync effect, so there's no second writer to fight the persisted zoom on mount.

--- a/.changeset/zoom-on-refresh.md
+++ b/.changeset/zoom-on-refresh.md
@@ -1,0 +1,5 @@
+---
+'template-goblin-ui': patch
+---
+
+Drop the ResizeObserver-driven auto-fit zoom on the canvas. With #84's "default 100%" rule, the observer's "snap zoom back to fit when current ≤ fit" behaviour fought the goal: during page refresh the layout settled in stages, the observer fired with a transient container size and snapped zoom to fit, leaving the canvas no longer overflowing the viewport — so no scrollbars appeared even when the page was bigger than the visible area. The canvas now stays at `meta × zoom` regardless of container resizes; users can manually zoom out via the controls if they want a fit-to-viewport view.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,10 @@ developers use the npm library to generate PDFs at scale.
     (e) `gh pr merge --merge --delete-branch`,
     (f) `git checkout main && git pull --ff-only` (per Rule #17),
     (g) `gh issue list --state open` and present the open issues
-    back to the user.
+    back to the user as a list of `#<number> — <title>` entries
+    (the title is the load-bearing part — never present bare
+    numbers, the user shouldn't have to look up what each issue
+    is about).
     The single instruction is the authorisation for the whole
     sequence — do NOT pause between steps for permission. This
     supersedes Rule #15's "do exactly what is asked" for these

--- a/packages/ui/src/components/Canvas/CanvasArea.tsx
+++ b/packages/ui/src/components/Canvas/CanvasArea.tsx
@@ -9,7 +9,7 @@
  *   - OnboardingPicker → empty-state onboarding
  *   - AddPageDialog    → add-page dialog
  */
-import React, { useRef, useCallback, useState } from 'react'
+import React, { useRef, useCallback } from 'react'
 import { getPageSize } from '@template-goblin/types'
 import { useTemplateStore } from '../../store/templateStore.js'
 import { useUiStore } from '../../store/uiStore.js'
@@ -54,11 +54,6 @@ export function CanvasArea() {
 
   // ── Refs ───────────────────────────────────────────────────────────────
   const containerRef = useRef<HTMLDivElement | null>(null)
-  // State mirror of containerRef.current — effects that must react to the
-  // container element changing (e.g. the ResizeObserver setup) depend on
-  // this. Without it, the observer stays attached to the onboarding picker
-  // after the canvas subtree mounts (GH #17).
-  const [containerEl, setContainerEl] = useState<HTMLDivElement | null>(null)
 
   // ── Custom hooks ───────────────────────────────────────────────────────
   const pageHandlers = usePageHandlers()
@@ -125,7 +120,6 @@ export function CanvasArea() {
   useFabricSync({
     fabricRef,
     fabricInstance,
-    containerEl,
     pageFields,
     bgImage,
     currentBgColor,
@@ -143,7 +137,6 @@ export function CanvasArea() {
   // ── Container ref callback (for OnboardingPicker compatibility) ────────
   const setContainerRef = useCallback((el: HTMLDivElement | null) => {
     containerRef.current = el
-    setContainerEl(el)
   }, [])
 
   // ═══════════════════════════════════════════════════════════════════════

--- a/packages/ui/src/components/Canvas/useFabricCanvas.ts
+++ b/packages/ui/src/components/Canvas/useFabricCanvas.ts
@@ -9,8 +9,6 @@ import { useRef, useCallback, useState } from 'react'
 import { Canvas as FabricCanvas } from 'fabric'
 import type { Rect as FabricRect } from 'fabric'
 import type { FieldCreationDraft } from './FieldCreationPopup.js'
-import { useTemplateStore } from '../../store/templateStore.js'
-import { useUiStore } from '../../store/uiStore.js'
 import { wireSelectionEvents } from './wireSelectionEvents.js'
 import { wireDragResizeEvents } from './wireDragResizeEvents.js'
 import { wireMouseEvents } from './wireMouseEvents.js'
@@ -111,36 +109,11 @@ export function useFabricCanvas(
       )
       wireWheelEvents(fc)
 
-      // GH #84: default zoom is 100% on canvas creation. The canvas is
-      // sized to the raw page dimensions; the container's `overflow: auto`
-      // scrolls when the page is larger than the viewport. Users can zoom
-      // out via the ZoomControls if they want a fit-to-viewport view.
-      const { width: pageW, height: pageH } = useTemplateStore.getState().meta
-      if (import.meta.env.DEV) {
-        // eslint-disable-next-line no-console
-        console.log('[#84 setCanvasEl]', {
-          ctorW: w,
-          ctorH: h,
-          metaW: pageW,
-          metaH: pageH,
-          willResize: pageW > 0 && pageH > 0,
-        })
-      }
-      if (pageW > 0 && pageH > 0) {
-        requestAnimationFrame(() => {
-          fc.setDimensions({ width: pageW, height: pageH })
-          fc.setViewportTransform([1, 0, 0, 1, 0, 0])
-          useUiStore.getState().setZoom(1)
-          if (import.meta.env.DEV) {
-            // eslint-disable-next-line no-console
-            console.log('[#84 setCanvasEl rAF]', {
-              fcZoom: fc.getZoom(),
-              fcW: fc.width,
-              fcH: fc.height,
-            })
-          }
-        })
-      }
+      // Canvas dimensions / zoom are fully owned by useFabricSync's
+      // zoom-sync effect — it fires on mount (fabricInstance changing
+      // null → fc) and on every zoom / meta change, sizing the wrapper
+      // to `meta * store.zoom`. Doing a setDimensions or setZoom here
+      // would stomp the persisted zoom restored by the store on refresh.
     },
     [setPendingDraft, containerRef],
   )

--- a/packages/ui/src/components/Canvas/useFabricCanvas.ts
+++ b/packages/ui/src/components/Canvas/useFabricCanvas.ts
@@ -116,11 +116,29 @@ export function useFabricCanvas(
       // scrolls when the page is larger than the viewport. Users can zoom
       // out via the ZoomControls if they want a fit-to-viewport view.
       const { width: pageW, height: pageH } = useTemplateStore.getState().meta
+      if (import.meta.env.DEV) {
+        // eslint-disable-next-line no-console
+        console.log('[#84 setCanvasEl]', {
+          ctorW: w,
+          ctorH: h,
+          metaW: pageW,
+          metaH: pageH,
+          willResize: pageW > 0 && pageH > 0,
+        })
+      }
       if (pageW > 0 && pageH > 0) {
         requestAnimationFrame(() => {
           fc.setDimensions({ width: pageW, height: pageH })
           fc.setViewportTransform([1, 0, 0, 1, 0, 0])
           useUiStore.getState().setZoom(1)
+          if (import.meta.env.DEV) {
+            // eslint-disable-next-line no-console
+            console.log('[#84 setCanvasEl rAF]', {
+              fcZoom: fc.getZoom(),
+              fcW: fc.width,
+              fcH: fc.height,
+            })
+          }
         })
       }
     },

--- a/packages/ui/src/components/Canvas/useFabricSync.ts
+++ b/packages/ui/src/components/Canvas/useFabricSync.ts
@@ -22,7 +22,6 @@ import {
   createFieldGroup,
   applyFieldToGroup,
   buildGridLines,
-  fitZoomLevel,
   type ImageResolver,
 } from './fabricUtils.js'
 import { usePageBoundsEnforcement } from './usePageBoundsEnforcement.js'
@@ -41,13 +40,6 @@ export interface SyncDeps {
    * don't trigger dep re-fires (GH #17).
    */
   fabricInstance: FabricCanvas | null
-  /**
-   * State mirror of the canvas container element. Effects that must
-   * re-attach to a new container element (e.g. the ResizeObserver) depend
-   * on this so the observer doesn't stay bound to the unmounted onboarding
-   * picker on the first visit (GH #17).
-   */
-  containerEl: HTMLDivElement | null
   pageFields: FieldDefinition[]
   bgImage: HTMLImageElement | null
   currentBgColor: string | null
@@ -86,7 +78,6 @@ export function useFabricSync(deps: SyncDeps) {
   const {
     fabricRef,
     fabricInstance,
-    containerEl,
     pageFields,
     bgImage,
     currentBgColor,
@@ -253,42 +244,6 @@ export function useFabricSync(deps: SyncDeps) {
     fc.requestRenderAll()
     useUiStore.getState().setZoom(1)
   }, [fabricRef, fabricInstance, currentPageId, meta.width, meta.height])
-
-  // ═══════════════ Resize observer (GH #17, #66) ═════════════════════════
-  // Pre-#66 the observer resized the Fabric canvas to match the container
-  // and recentred the page via `viewportTransform`. Now the canvas is
-  // sized to `page * zoom` (independent of the container) and centring is
-  // CSS flex; on a container-size change the only thing that needs to
-  // update is the auto-fit zoom — useFabricSync's auto-fit-zoom-on-meta
-  // effect already handles meta changes, but a window resize doesn't
-  // touch meta so we recompute zoom here when the user is at (or below)
-  // the previous fit level. Above fit-zoom we leave the user's zoom
-  // alone — they're explicitly zoomed in and a window resize shouldn't
-  // throw away their context.
-  //
-  // Depend on `containerEl` (state mirror) — refs have stable identity
-  // so the old implementation stayed bound to the onboarding picker's
-  // <div> after the canvas subtree mounted on the first visit.
-  useEffect(() => {
-    if (!containerEl || !fabricInstance) return
-
-    const observer = new ResizeObserver(() => {
-      const fc = fabricRef.current
-      if (!fc) return
-      if (meta.width <= 0 || meta.height <= 0) return
-      const w = containerEl.clientWidth
-      const h = containerEl.clientHeight
-      const fit = fitZoomLevel(meta.width, meta.height, w, h, 40)
-      const current = fc.getZoom()
-      if (current <= fit + 0.001) {
-        useUiStore.getState().setZoom(fit)
-      }
-      // Otherwise (current > fit, user zoomed in) leave zoom alone; the
-      // canvas keeps its `page * current` size and scrollbars adjust.
-    })
-    observer.observe(containerEl)
-    return () => observer.disconnect()
-  }, [fabricRef, fabricInstance, containerEl, meta.width, meta.height])
 
   // ═══════════════ Cursor sync (REQ-043) ═════════════════════════════════
   useEffect(() => {

--- a/packages/ui/src/components/Canvas/useFabricSync.ts
+++ b/packages/ui/src/components/Canvas/useFabricSync.ts
@@ -8,7 +8,7 @@
  *   - `useFabricImages` — bg / placeholder / static image loading.
  *   - `usePageBoundsEnforcement` — clipPath + outline rect + clamp handlers.
  */
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import {
   type Canvas as FabricCanvas,
   FabricImage,
@@ -214,10 +214,15 @@ export function useFabricSync(deps: SyncDeps) {
   // level. The viewportTransform is identity-with-zoom (no centring
   // translate) — the container's flex centring places smaller-than-
   // viewport canvases instead.
+  //
+  // No early-return on `fc.getZoom() === zoom`: on refresh the canvas is
+  // created at container size with fabric's default zoom = 1 and the
+  // store's default zoom is also 1, so the equality would skip the very
+  // resize that gives the page its real `meta * 1` dimensions. Always
+  // sync on every dep change — setDimensions is idempotent and cheap.
   useEffect(() => {
     const fc = fabricRef.current
     if (!fc || meta.width <= 0 || meta.height <= 0) return
-    if (Math.abs(fc.getZoom() - zoom) < 0.001) return
 
     fc.setDimensions({ width: meta.width * zoom, height: meta.height * zoom })
     fc.setViewportTransform([zoom, 0, 0, zoom, 0, 0])
@@ -230,46 +235,20 @@ export function useFabricSync(deps: SyncDeps) {
   // `currentPageId` is depended on explicitly so same-sized page switches
   // — where `meta.width`/`meta.height` don't change — still reset.
   //
-  // Resize the canvas synchronously here AND update store.zoom — delegating
-  // the resize to the zoom-sync effect is fragile: if the previous page
-  // left fabric's zoom already at 1 but with stale dimensions, the zoom-
-  // sync's `fc.getZoom() === zoom` early-return skips the setDimensions
-  // call, leaving the canvas painting at the old page's `meta * zoom` while
-  // the indicator reads 100%.
+  // The first valid run (canvas mounted + meta hydrated) is the post-
+  // refresh restore: the user is reopening the view they left, so we
+  // preserve the persisted zoom and just let the zoom-sync effect resize
+  // the canvas to `meta * persistedZoom`. Every subsequent currentPageId
+  // / meta change does reset to 1×.
+  const resetInitialisedRef = useRef(false)
   useEffect(() => {
     const fc = fabricRef.current
-    if (!fc || meta.width <= 0 || meta.height <= 0) {
-      if (import.meta.env.DEV) {
-        // eslint-disable-next-line no-console
-        console.log('[#84 reset SKIP]', { fc: !!fc, meta })
-      }
+    if (!fc || meta.width <= 0 || meta.height <= 0) return
+    if (!resetInitialisedRef.current) {
+      resetInitialisedRef.current = true
       return
     }
-    const wrapper = (fc as unknown as { wrapperEl?: HTMLElement }).wrapperEl
-    if (import.meta.env.DEV) {
-      // eslint-disable-next-line no-console
-      console.log('[#84 reset BEFORE]', {
-        pageId: currentPageId,
-        meta: { w: meta.width, h: meta.height },
-        fc: { zoom: fc.getZoom(), w: fc.width, h: fc.height },
-        wrapperStyle: wrapper && { w: wrapper.style.width, h: wrapper.style.height },
-      })
-    }
-    fc.setDimensions({ width: meta.width, height: meta.height })
-    fc.setViewportTransform([1, 0, 0, 1, 0, 0])
-    fc.requestRenderAll()
     useUiStore.getState().setZoom(1)
-    if (import.meta.env.DEV) {
-      // eslint-disable-next-line no-console
-      console.log('[#84 reset AFTER]', {
-        fc: { zoom: fc.getZoom(), w: fc.width, h: fc.height },
-        wrapperStyle: wrapper && { w: wrapper.style.width, h: wrapper.style.height },
-        wrapperRect: wrapper && {
-          ow: wrapper.offsetWidth,
-          oh: wrapper.offsetHeight,
-        },
-      })
-    }
   }, [fabricRef, fabricInstance, currentPageId, meta.width, meta.height])
 
   // ═══════════════ Cursor sync (REQ-043) ═════════════════════════════════

--- a/packages/ui/src/components/Canvas/useFabricSync.ts
+++ b/packages/ui/src/components/Canvas/useFabricSync.ts
@@ -238,11 +238,38 @@ export function useFabricSync(deps: SyncDeps) {
   // the indicator reads 100%.
   useEffect(() => {
     const fc = fabricRef.current
-    if (!fc || meta.width <= 0 || meta.height <= 0) return
+    if (!fc || meta.width <= 0 || meta.height <= 0) {
+      if (import.meta.env.DEV) {
+        // eslint-disable-next-line no-console
+        console.log('[#84 reset SKIP]', { fc: !!fc, meta })
+      }
+      return
+    }
+    const wrapper = (fc as unknown as { wrapperEl?: HTMLElement }).wrapperEl
+    if (import.meta.env.DEV) {
+      // eslint-disable-next-line no-console
+      console.log('[#84 reset BEFORE]', {
+        pageId: currentPageId,
+        meta: { w: meta.width, h: meta.height },
+        fc: { zoom: fc.getZoom(), w: fc.width, h: fc.height },
+        wrapperStyle: wrapper && { w: wrapper.style.width, h: wrapper.style.height },
+      })
+    }
     fc.setDimensions({ width: meta.width, height: meta.height })
     fc.setViewportTransform([1, 0, 0, 1, 0, 0])
     fc.requestRenderAll()
     useUiStore.getState().setZoom(1)
+    if (import.meta.env.DEV) {
+      // eslint-disable-next-line no-console
+      console.log('[#84 reset AFTER]', {
+        fc: { zoom: fc.getZoom(), w: fc.width, h: fc.height },
+        wrapperStyle: wrapper && { w: wrapper.style.width, h: wrapper.style.height },
+        wrapperRect: wrapper && {
+          ow: wrapper.offsetWidth,
+          oh: wrapper.offsetHeight,
+        },
+      })
+    }
   }, [fabricRef, fabricInstance, currentPageId, meta.width, meta.height])
 
   // ═══════════════ Cursor sync (REQ-043) ═════════════════════════════════

--- a/packages/ui/src/store/uiStore.ts
+++ b/packages/ui/src/store/uiStore.ts
@@ -202,6 +202,9 @@ export const useUiStore = create<UiState>()(
         showLeftPanel: state.showLeftPanel,
         showRightPanel: state.showRightPanel,
         currentPageId: state.currentPageId,
+        // GH #84 follow-up: preserve zoom across refresh so the canvas
+        // restores at whatever level the user was last looking at.
+        zoom: state.zoom,
       }),
       // v1 → v2: removed the 'min' jsonPreviewMode value.
       // v2 → v3: removed jsonPreviewMode entirely (#90 collapsed Default/Max


### PR DESCRIPTION
## Summary
Refresh now restores the canvas at the user's last zoom instead of snapping to 100%. Three stacked bugs were preventing this:

1. **Zoom-sync's `fc.getZoom() === store.zoom` early-return** — on a fresh refresh both read 1 by default, so the very call that grows the canvas from container-size to meta-size was skipped, leaving the page painted small with no scrollbars even when bigger than the viewport. Removed the early-return.
2. **`useFabricCanvas` post-mount rAF** — hardcoded `setZoom(1)` + `setDimensions(meta × 1)`. With persisted zoom in play, this stomped the restored value on every mount. Removed; canvas sizing is now fully owned by the zoom-sync effect.
3. **GH #84 reset effect on first run** — its deps go 0 → real on hydration, which it treated as a "page change" and reset to 1×. Now primes a ref on the first valid run and exits; subsequent `currentPageId` / `meta` changes still reset to 1× per #84 add-page / page-switch behaviour.

Also added `zoom` to `uiStore.partialize` so the level persists alongside the other UI prefs.

Earlier on this branch: dropped the ResizeObserver auto-fit (was snapping zoom back to fit during refresh layout settling).

## Test plan
- [x] \`pnpm type-check\` clean
- [x] \`pnpm lint\` clean
- [x] \`pnpm --filter template-goblin-ui test\` — 398/398 pass
- [x] User confirmed: refresh now preserves zoom; new-page / page-switch still reset to 100%.