### PR TITLE
feat(ui): Format button on right-panel JSON Preview (#85)

### DIFF
--- a/.changeset/format-json-button.md
+++ b/.changeset/format-json-button.md
@@ -1,0 +1,5 @@
+---
+'template-goblin-ui': minor
+---
+
+Add a "Format" button to the right-panel JSON Preview header (#85). One click pretty-prints the textarea content with 2-space indentation; `Cmd/Ctrl+Shift+F` does the same from inside the textarea. Invalid JSON surfaces a brief inline error below the textarea (auto-clears after ~3 s) and leaves the user's edits untouched. Clicking Format on the unpinned auto-generated baseline is a no-op so the preview keeps tracking subsequent field-add / field-edit events on the canvas. Multi-line textareas in the right panel no longer auto-select-all on focus, so users can click in to edit one value without the buffer being wiped on the next keystroke.

--- a/packages/ui/e2e/json-preview.spec.ts
+++ b/packages/ui/e2e/json-preview.spec.ts
@@ -1,0 +1,304 @@
+/**
+ * E2E for the right-panel JSON Preview (#85).
+ *
+ * Covers the Format button, the Cmd/Ctrl+Shift+F shortcut, the inline
+ * error path on invalid JSON, the click-doesn't-select-all behaviour
+ * (pre-fix the right-panel auto-select-on-focus wiped the textarea on
+ * the first keystroke), and the regression case where Format on the
+ * unpinned auto-generated text used to pin the snapshot and freeze it
+ * from tracking subsequent field edits.
+ */
+import type { Page } from '@playwright/test'
+import { test, expect } from '@playwright/test'
+
+const BASE_CELL = {
+  fontFamily: 'Helvetica',
+  fontSize: 10,
+  fontWeight: 'normal',
+  fontStyle: 'normal',
+  textDecoration: 'none',
+  color: '#000000',
+  backgroundColor: '#ffffff',
+  borderWidth: 0,
+  borderColor: '#cccccc',
+  paddingTop: 2,
+  paddingBottom: 2,
+  paddingLeft: 4,
+  paddingRight: 4,
+  align: 'left',
+  verticalAlign: 'top',
+}
+
+const TEXT_STYLE = {
+  fontId: null,
+  fontFamily: 'Helvetica',
+  fontSize: 12,
+  fontSizeMin: 8,
+  lineHeight: 1.2,
+  fontWeight: 'normal',
+  fontStyle: 'normal',
+  textDecoration: 'none',
+  color: '#000000',
+  align: 'left',
+  verticalAlign: 'top',
+  maxRows: 2,
+  overflowMode: 'truncate',
+  snapToGrid: false,
+}
+
+function tableStyle(columns: Array<{ key: string; label: string; width: number }>) {
+  return {
+    maxRows: 5,
+    maxColumns: 8,
+    multiPage: false,
+    showHeader: true,
+    headerStyle: { ...BASE_CELL, fontWeight: 'bold', backgroundColor: '#eeeeee' },
+    rowStyle: BASE_CELL,
+    oddRowStyle: null,
+    evenRowStyle: null,
+    cellStyle: { overflowMode: 'truncate' },
+    columns: columns.map((c) => ({ ...c, style: null, headerStyle: null })),
+  }
+}
+
+async function seed(page: Page): Promise<void> {
+  const payload = {
+    state: {
+      meta: {
+        schemaVersion: 1,
+        name: 'json-preview-test',
+        version: '0.0.0',
+        width: 600,
+        height: 500,
+        locked: false,
+      },
+      fields: [
+        {
+          id: 'greeting',
+          type: 'text',
+          label: 'greeting',
+          groupId: null,
+          pageId: 'p0',
+          x: 50,
+          y: 50,
+          width: 400,
+          height: 80,
+          zIndex: 0,
+          source: { mode: 'dynamic', jsonKey: 'greeting', required: false, placeholder: 'Hi' },
+          style: TEXT_STYLE,
+        },
+        {
+          id: 'tbl1',
+          type: 'table',
+          label: 'tbl1',
+          groupId: null,
+          pageId: 'p0',
+          x: 50,
+          y: 200,
+          width: 400,
+          height: 200,
+          zIndex: 1,
+          source: { mode: 'dynamic', jsonKey: 'rows', required: true, placeholder: null },
+          style: tableStyle([
+            { key: 'a', label: 'A', width: 100 },
+            { key: 'b', label: 'B', width: 100 },
+          ]),
+        },
+      ],
+      fonts: [],
+      groups: [],
+      pages: [
+        {
+          id: 'p0',
+          index: 0,
+          backgroundType: 'color',
+          backgroundColor: '#ffffff',
+          backgroundFilename: null,
+        },
+      ],
+      backgroundDataUrl: null,
+      backgroundBuffer: null,
+      pageBackgroundDataUrls: [],
+      pageBackgroundBuffers: [],
+      fontBuffers: [],
+      placeholderBuffers: [],
+      staticImageBuffers: [],
+      staticImageDataUrls: [],
+    },
+    version: 2,
+  }
+  await page.addInitScript((s: string) => {
+    return new Promise<void>((resolve, reject) => {
+      const req = indexedDB.open('template-goblin', 1)
+      req.onupgradeneeded = () => {
+        const db = req.result
+        if (!db.objectStoreNames.contains('kv')) db.createObjectStore('kv')
+      }
+      req.onsuccess = () => {
+        const db = req.result
+        const tx = db.transaction('kv', 'readwrite')
+        tx.objectStore('kv').put(s, 'template-goblin-template')
+        tx.oncomplete = () => {
+          localStorage.removeItem('template-goblin-ui')
+          resolve()
+        }
+        tx.onerror = () => reject(tx.error)
+      }
+      req.onerror = () => reject(req.error)
+    })
+  }, JSON.stringify(payload))
+}
+
+function textarea(page: Page) {
+  return page.locator('[data-testid="json-preview-textarea"]')
+}
+
+function formatBtn(page: Page) {
+  return page.locator('[data-testid="json-preview-format"]')
+}
+
+function resetBtn(page: Page) {
+  return page.locator('[data-testid="json-preview-reset"]')
+}
+
+function formatError(page: Page) {
+  return page.locator('[data-testid="json-preview-format-error"]')
+}
+
+async function selectField(page: Page, fieldId: string): Promise<void> {
+  await page.evaluate((id: string) => {
+    interface FabricLike {
+      getObjects(): Array<{ __fieldId?: string }>
+      setActiveObject: (o: object) => void
+      requestRenderAll: () => void
+      fire?: (event: string, opts: object) => void
+    }
+    const fc = (window as unknown as { __fabricCanvas?: FabricLike }).__fabricCanvas
+    if (!fc) return
+    const g = fc.getObjects().find((o) => o.__fieldId === id)
+    if (!g) return
+    fc.setActiveObject(g as object)
+    fc.fire?.('selection:created', { selected: [g] })
+    fc.requestRenderAll()
+  }, fieldId)
+}
+
+test.describe('JSON Preview (#85)', () => {
+  test.beforeEach(async ({ page }) => {
+    await seed(page)
+    await page.goto('/')
+    await expect(textarea(page)).toBeVisible()
+  })
+
+  test('auto-generated text is already 2-space formatted on load', async ({ page }) => {
+    const value = await textarea(page).inputValue()
+    expect(value).toContain('"greeting"')
+    expect(value).toMatch(/\n {2}"/)
+  })
+
+  test('Format on a pinned-edited textarea pretty-prints the user input', async ({ page }) => {
+    // Type a minified object — onChange pins it.
+    await textarea(page).fill('{"texts":{"greeting":"hello"},"tables":{"rows":[]}}')
+    await formatBtn(page).click()
+    const formatted = await textarea(page).inputValue()
+    expect(formatted).toBe(
+      '{\n  "texts": {\n    "greeting": "hello"\n  },\n  "tables": {\n    "rows": []\n  }\n}',
+    )
+    // Reset button should now be visible — the textarea is pinned.
+    await expect(resetBtn(page)).toBeVisible()
+  })
+
+  test('Format is a no-op when the textarea is showing the auto-generated baseline', async ({
+    page,
+  }) => {
+    // Reset is hidden because nothing is pinned.
+    await expect(resetBtn(page)).toHaveCount(0)
+    const before = await textarea(page).inputValue()
+    await formatBtn(page).click()
+    const after = await textarea(page).inputValue()
+    expect(after).toBe(before)
+    // Still not pinned — Reset stays hidden.
+    await expect(resetBtn(page)).toHaveCount(0)
+  })
+
+  test('adding a table column updates the auto-generated preview AFTER Format was clicked', async ({
+    page,
+  }) => {
+    // Repro of the bug user reported on #85: Format used to pin the
+    // snapshot, freezing the preview from tracking subsequent edits.
+    await formatBtn(page).click()
+    await selectField(page, 'tbl1')
+    await expect(page.locator('[data-testid="loop-add-column"]')).toBeVisible()
+
+    const before = await textarea(page).inputValue()
+    await page.locator('[data-testid="loop-add-column"]').click()
+
+    // The auto-generated JSON should grow to reflect the new column key —
+    // the default table row stamps every column key with an example value.
+    await expect.poll(async () => textarea(page).inputValue(), { timeout: 3000 }).not.toBe(before)
+  })
+
+  test('Format on invalid JSON surfaces an inline error and leaves text unchanged', async ({
+    page,
+  }) => {
+    const broken = '{not valid json'
+    await textarea(page).fill(broken)
+    await formatBtn(page).click()
+    await expect(formatError(page)).toBeVisible()
+    await expect(formatError(page)).toContainText(/Invalid JSON/i)
+    expect(await textarea(page).inputValue()).toBe(broken)
+  })
+
+  test('inline error auto-clears within ~3 seconds', async ({ page }) => {
+    await textarea(page).fill('{not valid json')
+    await formatBtn(page).click()
+    await expect(formatError(page)).toBeVisible()
+    await expect(formatError(page)).toHaveCount(0, { timeout: 5000 })
+  })
+
+  test('Cmd/Ctrl+Shift+F inside the textarea formats the JSON', async ({ page }) => {
+    await textarea(page).fill('{"texts":{"greeting":"x"}}')
+    await textarea(page).focus()
+    // Use Control+Shift+F — Playwright honours it on all platforms.
+    await page.keyboard.press('Control+Shift+F')
+    const formatted = await textarea(page).inputValue()
+    expect(formatted).toBe('{\n  "texts": {\n    "greeting": "x"\n  }\n}')
+  })
+
+  test('clicking inside the textarea does NOT select the whole content', async ({ page }) => {
+    // Pre-fix: the right-panel select-all-on-focus would select the
+    // entire textarea on click, so the next keystroke would wipe the
+    // user's JSON. Now textareas are skipped.
+    const ta = textarea(page)
+    await ta.click()
+    const selection = await ta.evaluate((el) => {
+      const t = el as HTMLTextAreaElement
+      return { start: t.selectionStart, end: t.selectionEnd, len: t.value.length }
+    })
+    // A click should leave a zero-width selection (caret) somewhere
+    // inside the buffer, NOT a full-content range.
+    expect(selection.end - selection.start).toBe(0)
+    expect(selection.end).toBeLessThan(selection.len)
+  })
+
+  test('Reset clears the pin and returns to auto-generated text', async ({ page }) => {
+    await textarea(page).fill('{"custom":"value"}')
+    await expect(resetBtn(page)).toBeVisible()
+    await resetBtn(page).click()
+    await expect(resetBtn(page)).toHaveCount(0)
+    const value = await textarea(page).inputValue()
+    expect(value).toContain('"greeting"')
+  })
+
+  test('subsequent successful Format clears a previously-shown error', async ({ page }) => {
+    await textarea(page).fill('{not valid json')
+    await formatBtn(page).click()
+    await expect(formatError(page)).toBeVisible()
+    // Fix it and re-format — the error should disappear immediately,
+    // not wait for the 3s timer.
+    await textarea(page).fill('{"a":1}')
+    await formatBtn(page).click()
+    await expect(formatError(page)).toHaveCount(0)
+    expect(await textarea(page).inputValue()).toBe('{\n  "a": 1\n}')
+  })
+})

--- a/packages/ui/src/components/RightPanel/JsonPreview.tsx
+++ b/packages/ui/src/components/RightPanel/JsonPreview.tsx
@@ -1,7 +1,8 @@
-import { useMemo, useCallback } from 'react'
+import { useMemo, useCallback, useState, useEffect, useRef } from 'react'
 import { useTemplateStore } from '../../store/templateStore.js'
 import { useUiStore } from '../../store/uiStore.js'
 import { generateExampleJson } from '../../utils/jsonGenerator.js'
+import { formatJsonString } from './formatJson.js'
 
 /**
  * Right-panel JSON preview (#90).
@@ -49,6 +50,51 @@ export function JsonPreview() {
     setPreviewJsonText(JSON.stringify(max, null, 2))
   }, [fields, maxModeRepeatCount, setPreviewJsonText])
 
+  // GH #85 — Format button. Inline error message lives below the textarea
+  // and self-clears after 3s. We intentionally don't disable the button on
+  // unparseable input (per issue: "always enabled, fail gracefully").
+  const [formatError, setFormatError] = useState<string | null>(null)
+  const formatErrorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    return () => {
+      if (formatErrorTimerRef.current) clearTimeout(formatErrorTimerRef.current)
+    }
+  }, [])
+
+  const handleFormat = useCallback(() => {
+    // When the textarea is showing the auto-generated baseline (not
+    // pinned), the text is already 2-space formatted via the
+    // `JSON.stringify(_, null, 2)` in `generatedText`. Re-pinning a
+    // formatted copy here would lock the preview to that snapshot and
+    // stop tracking field-add / field-edit events on the canvas — the
+    // user would have to hit Reset to see new columns appear. So
+    // Format is a no-op in the unpinned state; the user only needs it
+    // after they've edited the textarea (which already pinned it).
+    if (!isPinned) return
+    const result = formatJsonString(value)
+    if (result.ok) {
+      setPreviewJsonText(result.text)
+      setFormatError(null)
+      if (formatErrorTimerRef.current) clearTimeout(formatErrorTimerRef.current)
+      return
+    }
+    setFormatError(result.error)
+    if (formatErrorTimerRef.current) clearTimeout(formatErrorTimerRef.current)
+    formatErrorTimerRef.current = setTimeout(() => setFormatError(null), 3000)
+  }, [isPinned, value, setPreviewJsonText])
+
+  const handleTextareaKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      // Cmd/Ctrl+Shift+F triggers Format from inside the textarea (#85).
+      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key.toLowerCase() === 'f') {
+        e.preventDefault()
+        handleFormat()
+      }
+    },
+    [handleFormat],
+  )
+
   return (
     <div className="tg-panel-section">
       <div
@@ -69,10 +115,20 @@ export function JsonPreview() {
               style={{ fontSize: 10, padding: '2px 8px' }}
               onClick={() => setPreviewJsonText(null)}
               title="Discard your edits and show the auto-generated example"
+              data-testid="json-preview-reset"
             >
               Reset
             </button>
           )}
+          <button
+            className="tg-btn"
+            style={{ fontSize: 10, padding: '2px 8px' }}
+            onClick={handleFormat}
+            title="Pretty-print the JSON with 2-space indentation (Cmd/Ctrl+Shift+F)"
+            data-testid="json-preview-format"
+          >
+            Format
+          </button>
           <button
             className="tg-btn"
             style={{ fontSize: 10, padding: '2px 8px' }}
@@ -99,30 +155,47 @@ export function JsonPreview() {
           No fields defined yet
         </div>
       ) : (
-        <textarea
-          className="tg-json-preview"
-          value={value}
-          onChange={(e) => setPreviewJsonText(e.target.value)}
-          style={{
-            fontFamily: 'var(--font-mono)',
-            fontSize: 11,
-            background: 'var(--bg-primary)',
-            border: '1px solid var(--border)',
-            borderRadius: 4,
-            padding: 10,
-            minHeight: 120,
-            maxHeight: 300,
-            overflowY: 'auto',
-            whiteSpace: 'pre',
-            lineHeight: 1.4,
-            color: 'var(--text-primary)',
-            width: '100%',
-            resize: 'vertical',
-            outline: 'none',
-            boxSizing: 'border-box',
-          }}
-          spellCheck={false}
-        />
+        <>
+          <textarea
+            className="tg-json-preview"
+            data-testid="json-preview-textarea"
+            value={value}
+            onChange={(e) => setPreviewJsonText(e.target.value)}
+            onKeyDown={handleTextareaKeyDown}
+            style={{
+              fontFamily: 'var(--font-mono)',
+              fontSize: 11,
+              background: 'var(--bg-primary)',
+              border: '1px solid var(--border)',
+              borderRadius: 4,
+              padding: 10,
+              minHeight: 120,
+              maxHeight: 300,
+              overflowY: 'auto',
+              whiteSpace: 'pre',
+              lineHeight: 1.4,
+              color: 'var(--text-primary)',
+              width: '100%',
+              resize: 'vertical',
+              outline: 'none',
+              boxSizing: 'border-box',
+            }}
+            spellCheck={false}
+          />
+          {formatError && (
+            <div
+              role="alert"
+              data-testid="json-preview-format-error"
+              style={{
+                marginTop: 6,
+                fontSize: 11,
+                color: 'var(--error)',
+              }}
+            >
+              {formatError}
+            </div>
+          )}
+        </>
       )}
     </div>
   )

--- a/packages/ui/src/components/RightPanel/__tests__/formatJson.test.ts
+++ b/packages/ui/src/components/RightPanel/__tests__/formatJson.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import { formatJsonString, FORMAT_ERROR_MESSAGE } from '../formatJson.js'
+
+describe('formatJsonString', () => {
+  it('pretty-prints a valid object with 2-space indentation', () => {
+    const r = formatJsonString('{"texts":{"a":"x"},"tables":{}}')
+    expect(r.ok).toBe(true)
+    if (r.ok) {
+      expect(r.text).toBe('{\n  "texts": {\n    "a": "x"\n  },\n  "tables": {}\n}')
+    }
+  })
+
+  it('reformats already-pretty input idempotently', () => {
+    const pretty = '{\n  "n": 1\n}'
+    const r = formatJsonString(pretty)
+    expect(r.ok).toBe(true)
+    if (r.ok) expect(r.text).toBe(pretty)
+  })
+
+  it('handles a top-level array', () => {
+    const r = formatJsonString('[1,2,3]')
+    expect(r.ok).toBe(true)
+    if (r.ok) expect(r.text).toBe('[\n  1,\n  2,\n  3\n]')
+  })
+
+  it('returns a stable error on malformed JSON', () => {
+    const r = formatJsonString('{not valid}')
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.error).toBe(FORMAT_ERROR_MESSAGE)
+  })
+
+  it('returns the error on an empty string', () => {
+    const r = formatJsonString('')
+    expect(r.ok).toBe(false)
+  })
+
+  it('does not mutate the caller — failure leaves the input alone (no-op contract)', () => {
+    // Function is pure; this just locks the contract: failure never returns
+    // a `text` field, so the caller can't accidentally overwrite the
+    // textarea with the error string.
+    const r = formatJsonString('{"a":')
+    expect(r.ok).toBe(false)
+    expect('text' in r).toBe(false)
+  })
+})

--- a/packages/ui/src/components/RightPanel/formatJson.ts
+++ b/packages/ui/src/components/RightPanel/formatJson.ts
@@ -1,0 +1,24 @@
+/**
+ * formatJson — pure helper behind the right-panel JSON Preview's "Format"
+ * button (#85). Lives outside the component so the parse/stringify logic
+ * is unit-testable without rendering React.
+ */
+
+export type FormatResult = { ok: true; text: string } | { ok: false; error: string }
+
+export const FORMAT_ERROR_MESSAGE = 'Invalid JSON — fix the highlighted issue'
+
+/**
+ * Parse `input` as JSON and re-emit it with 2-space indentation. Mirrors
+ * `generateExampleJson`'s formatting so a freshly-formatted pin reads the
+ * same as the auto-generated default. On failure returns a stable error
+ * string; the textarea content is left for the caller to preserve.
+ */
+export function formatJsonString(input: string): FormatResult {
+  try {
+    const parsed = JSON.parse(input) as unknown
+    return { ok: true, text: JSON.stringify(parsed, null, 2) }
+  } catch {
+    return { ok: false, error: FORMAT_ERROR_MESSAGE }
+  }
+}

--- a/packages/ui/src/utils/selectAllOnFocus.ts
+++ b/packages/ui/src/utils/selectAllOnFocus.ts
@@ -38,6 +38,14 @@ function handleFocusIn(target: EventTarget | null): void {
   if (target instanceof HTMLInputElement && SKIP_INPUT_TYPES.has(target.type)) {
     return
   }
+  // Skip <textarea> entirely — these hold multi-line content (e.g. the
+  // right-panel JSON preview) where the user clicks at a specific
+  // position to edit one value. Auto-selecting all wipes the buffer
+  // out the moment they start typing. Single-line <input>s still get
+  // select-on-focus.
+  if (target instanceof HTMLTextAreaElement) {
+    return
+  }
   setTimeout(() => {
     if (document.activeElement !== target) return
     if (target.selectionStart !== target.selectionEnd) return


### PR DESCRIPTION
## Summary
Adds a **Format** button alongside Reset / Max Fill / Copy in the JSON Preview header. Click pretty-prints the textarea with 2-space indentation; **Cmd/Ctrl+Shift+F** does the same from inside the textarea. Invalid JSON shows a brief inline error and leaves the buffer untouched.

## Two non-obvious behaviours, baked into the e2e suite
1. **Format on the unpinned baseline is a no-op.** Pinning a formatted snapshot would freeze the preview from tracking subsequent column / field edits, forcing a Reset click to see new keys. The user surfaced this regression mid-review.
2. **Right-panel select-all-on-focus now skips `<textarea>`.** Single-line inputs still get select-on-focus, but multi-line textareas (the JSON Preview) let users click at a position to edit one value without the next keystroke wiping the buffer.

## What's in the PR
- `formatJson.ts` — pure helper (`formatJsonString`) so parse/stringify is unit-testable without React.
- `JsonPreview.tsx` — Format button, inline error state with 3 s auto-clear, keyboard shortcut, opt-out of select-all on focus.
- `selectAllOnFocus.ts` — skip textareas.
- `__tests__/formatJson.test.ts` — 6 unit cases covering pretty-print, idempotence, top-level array, malformed, empty, no-`text`-on-failure contract.
- `e2e/json-preview.spec.ts` — 10 Playwright cases covering both bugs above plus all happy-path / shortcut / error scenarios.

## Test plan
- [x] `pnpm type-check` clean
- [x] `pnpm lint` clean
- [x] `pnpm --filter template-goblin-ui test` — 404/404 (was 398, +6 from formatJson unit tests)
- [x] `pnpm exec playwright test json-preview --config=e2e/playwright.config.ts` — 10/10 pass