### PR TITLE
feat(template): hyperlink support — clickable elements in PDFs (#87)

### DIFF
--- a/.changeset/hyperlinks.md
+++ b/.changeset/hyperlinks.md
@@ -1,0 +1,31 @@
+---
+'template-goblin': major
+'template-goblin-ui': major
+'@template-goblin/types': major
+---
+
+Add hyperlink support — clickable elements in generated PDFs (#87).
+
+Designers can attach a URL to any text, image, or table field via a new "Link" section in the Properties panel. Two flavours:
+
+- **Static**: a literal URL pinned in the manifest (`{ mode: 'static', url }`).
+- **Dynamic**: a `texts[jsonKey]` lookup (`{ mode: 'dynamic', jsonKey }`) resolved per render so the URL can vary across runs.
+
+Allowed protocols: `https`, `http`, `mailto`, `tel`. Anything else is rejected as `INVALID_DATA_TYPE` with field context. Empty / missing dynamic values render the field without a clickable region (no error). For tables, the link covers the whole table's bounding rect — there is no per-row or per-column variant in v1.
+
+### Schema additions
+
+- `FieldBase.hyperlink?: Hyperlink` — optional on every field.
+- New `Hyperlink` discriminated union exported from `@template-goblin/types`.
+- New helpers: `isValidHyperlinkUrl`, `isStaticHyperlink`, `isDynamicHyperlink`.
+
+### Why major
+
+This is an additive but cross-cutting schema change touching public types, manifest validation, runtime data validation, and PDF rendering. The schema additions are backward-compatible (the field is optional), but the SDK contract grows in a way library consumers will want to opt into deliberately, so we cut a major.
+
+### Out of scope (deferred)
+
+- Per-cell or per-column links inside tables.
+- Anchor links inside the same PDF (`#named-dest`).
+- Click-tracking / analytics wrappers — designer's own concern.
+- A canvas adornment showing which fields are linked — UI-only follow-up.

--- a/.changeset/hyperlinks.md
+++ b/.changeset/hyperlinks.md
@@ -9,13 +9,14 @@ Add hyperlink support — clickable elements in generated PDFs (#87).
 Designers can attach a URL to any text, image, or table field via a new "Link" section in the Properties panel. Two flavours:
 
 - **Static**: a literal URL pinned in the manifest (`{ mode: 'static', url }`).
-- **Dynamic**: a `texts[jsonKey]` lookup (`{ mode: 'dynamic', jsonKey }`) resolved per render so the URL can vary across runs.
+- **Dynamic**: a `links[jsonKey]` lookup (`{ mode: 'dynamic', jsonKey }`) resolved per render so the URL can vary across runs. URLs live in their own top-level `links` bucket on `InputJSON` — separate from `texts` so they're visually distinct in the JSON preview and never get confused with rendered text content.
 
 Allowed protocols: `https`, `http`, `mailto`, `tel`. Anything else is rejected as `INVALID_DATA_TYPE` with field context. Empty / missing dynamic values render the field without a clickable region (no error). For tables, the link covers the whole table's bounding rect — there is no per-row or per-column variant in v1.
 
 ### Schema additions
 
 - `FieldBase.hyperlink?: Hyperlink` — optional on every field.
+- `InputJSON.links?: LinkInputs` — new top-level bucket (`Record<string, string>`) for runtime hyperlink URLs.
 - New `Hyperlink` discriminated union exported from `@template-goblin/types`.
 - New helpers: `isValidHyperlinkUrl`, `isStaticHyperlink`, `isDynamicHyperlink`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,13 +113,26 @@ developers use the npm library to generate PDFs at scale.
     - filing the issue,
     - writing any code,
     - editing any tests.
-      For each question include your own recommended lean ("I'd lean
-      (a) because …") so the user can usually answer with a single
-      "go with those" rather than having to decide every detail.
-      Reading the existing code to FORM those questions is fine and
-      expected; it's writing changes that has to wait. Trivial / one-
-      line tweaks where the intent is obvious do not need this gate —
-      the rule is for any task with real design choices.
+      For each question lay out the actual choices in full — not
+      just letter labels. Format each question as a numbered prompt
+      followed by the concrete options spelled out:
+      1. \<question\>
+         (a) \<concrete option A — what it actually means\>
+         (b) \<concrete option B — what it actually means\>
+         (c) \<...\>
+         I'd lean \<letter\> because \<one-line reason\>.
+         Bare "I'd lean (a)" without the user being able to read what
+         (a) and (b) ARE forces them to guess from context. Always
+         spell the options out.
+         DO NOT ask silly / trivial questions where one answer is the
+         only sensible one (e.g. "should deleting a field also delete
+         the field?" or "should we run the existing tests?"). The
+         bar is "is there a real design choice with non-obvious
+         tradeoffs?" — if not, just decide and proceed.
+         Reading the existing code to FORM the questions is fine and
+         expected; it's writing changes that has to wait. Trivial /
+         one-line tweaks where the intent is obvious do not need this
+         gate — the rule is for any task with real design choices.
 
 ## Tech Stack
 

--- a/packages/core/src/render/field.ts
+++ b/packages/core/src/render/field.ts
@@ -1,12 +1,34 @@
 import type PDFDocument from 'pdfkit'
 import type { FieldDefinition, InputJSON, LoadedTemplate, TableRow } from '@template-goblin/types'
-import { TemplateGoblinError } from '@template-goblin/types'
+import { TemplateGoblinError, isValidHyperlinkUrl } from '@template-goblin/types'
 import { resolveValue } from '../utils/resolveValue.js'
 import { fieldErrorDetails, pageLabel, type PageContext } from '../utils/errorContext.js'
 import { parseImageColorMarker } from '../utils/imageColorMarker.js'
 import { renderText } from './text.js'
 import { renderImage } from './image.js'
 import { renderLoop } from './loop.js'
+
+/**
+ * Resolve `field.hyperlink` to a concrete URL string, or `null` if the
+ * field has no link / the dynamic value is empty / missing (#87).
+ *
+ * Static links use the literal `url`. Dynamic links read
+ * `data.texts[jsonKey]` and short-circuit on empty (no error — that's
+ * the contract: missing dynamic URL = no clickable region). Invalid
+ * non-empty dynamic strings have already been rejected by
+ * `validateData`; we double-check here defensively so a renderer error
+ * can never produce a `doc.link` to garbage.
+ */
+function resolveHyperlinkUrl(field: FieldDefinition, data: InputJSON): string | null {
+  const link = field.hyperlink
+  if (!link) return null
+  if (link.mode === 'static') {
+    return isValidHyperlinkUrl(link.url) ? link.url : null
+  }
+  const raw = (data.texts as Record<string, unknown> | undefined)?.[link.jsonKey]
+  if (typeof raw !== 'string' || raw.length === 0) return null
+  return isValidHyperlinkUrl(raw) ? raw : null
+}
 
 /**
  * Render a single field based on its type.
@@ -83,6 +105,18 @@ export function renderField(
           template.backgroundImage,
         )
         break
+    }
+
+    // GH #87 — clickable hyperlink overlay. Drawn AFTER content so the
+    // link rect sits in front of the rendered text/image/table, and so
+    // an exception during render skips the link too (we never advertise
+    // a clickable region for content that didn't actually paint). The
+    // rect matches the field's bounding box exactly; for tables, that
+    // means the whole table is clickable as a single unit (per #87
+    // resolution — no per-row variant in v1).
+    const url = resolveHyperlinkUrl(field, data)
+    if (url !== null) {
+      doc.link(field.x, field.y, field.width, field.height, url)
     }
   } catch (error) {
     if (error instanceof TemplateGoblinError) throw error

--- a/packages/core/src/render/field.ts
+++ b/packages/core/src/render/field.ts
@@ -13,11 +13,12 @@ import { renderLoop } from './loop.js'
  * field has no link / the dynamic value is empty / missing (#87).
  *
  * Static links use the literal `url`. Dynamic links read
- * `data.texts[jsonKey]` and short-circuit on empty (no error — that's
- * the contract: missing dynamic URL = no clickable region). Invalid
- * non-empty dynamic strings have already been rejected by
- * `validateData`; we double-check here defensively so a renderer error
- * can never produce a `doc.link` to garbage.
+ * `data.links[jsonKey]` (separate top-level bucket from `texts` so URLs
+ * are visually distinct in the JSON preview) and short-circuit on
+ * empty — no error, that's the contract: missing dynamic URL = no
+ * clickable region. Invalid non-empty dynamic strings have already
+ * been rejected by `validateData`; we double-check here defensively so
+ * a renderer error can never produce a `doc.link` to garbage.
  */
 function resolveHyperlinkUrl(field: FieldDefinition, data: InputJSON): string | null {
   const link = field.hyperlink
@@ -25,7 +26,7 @@ function resolveHyperlinkUrl(field: FieldDefinition, data: InputJSON): string | 
   if (link.mode === 'static') {
     return isValidHyperlinkUrl(link.url) ? link.url : null
   }
-  const raw = (data.texts as Record<string, unknown> | undefined)?.[link.jsonKey]
+  const raw = (data.links as Record<string, unknown> | undefined)?.[link.jsonKey]
   if (typeof raw !== 'string' || raw.length === 0) return null
   return isValidHyperlinkUrl(raw) ? raw : null
 }

--- a/packages/core/src/validate.ts
+++ b/packages/core/src/validate.ts
@@ -236,18 +236,20 @@ export function validateData(template: LoadedTemplate, data: InputJSON): Validat
 }
 
 /**
- * Validate a dynamic hyperlink's URL pulled from `data.texts[jsonKey]` (#87).
+ * Validate a dynamic hyperlink's URL pulled from `data.links[jsonKey]` (#87).
  *
+ * Lives in its own top-level bucket alongside `texts` / `images` /
+ * `tables` so URLs are visually distinct from rendered text content.
  * Empty / missing values are NOT errors — the renderer simply omits the
- * clickable region. A non-empty value that doesn't pass `isValidHyperlinkUrl`
- * (allowed protocols: https / http / mailto / tel) is rejected as
- * `INVALID_DATA_TYPE` with field context. Static hyperlinks are validated by
- * `validateManifest`, not here.
+ * clickable region. A non-empty value that doesn't pass
+ * `isValidHyperlinkUrl` (allowed protocols: https / http / mailto / tel)
+ * is rejected as `INVALID_DATA_TYPE` with field context. Static
+ * hyperlinks are validated by `validateManifest`, not here.
  */
 function validateHyperlink(field: FieldDefinition, data: InputJSON): ValidationError[] {
   const link = field.hyperlink
   if (!link || link.mode !== 'dynamic') return []
-  const raw = (data.texts as Record<string, unknown> | undefined)?.[link.jsonKey]
+  const raw = (data.links as Record<string, unknown> | undefined)?.[link.jsonKey]
   // Empty / missing → no link, no error.
   if (raw === undefined || raw === null || raw === '') return []
   if (!isValidHyperlinkUrl(raw)) {

--- a/packages/core/src/validate.ts
+++ b/packages/core/src/validate.ts
@@ -7,6 +7,7 @@ import type {
   ValidationError,
   ValidationResult,
 } from '@template-goblin/types'
+import { isValidHyperlinkUrl } from '@template-goblin/types'
 
 /** Maximum allowed text length to prevent memory exhaustion */
 const MAX_TEXT_LENGTH = 100_000
@@ -225,10 +226,38 @@ export function validateData(template: LoadedTemplate, data: InputJSON): Validat
 
   for (const field of template.manifest.fields) {
     errors.push(...validateField(field, data))
+    errors.push(...validateHyperlink(field, data))
   }
 
   return {
     valid: errors.length === 0,
     errors,
   }
+}
+
+/**
+ * Validate a dynamic hyperlink's URL pulled from `data.texts[jsonKey]` (#87).
+ *
+ * Empty / missing values are NOT errors — the renderer simply omits the
+ * clickable region. A non-empty value that doesn't pass `isValidHyperlinkUrl`
+ * (allowed protocols: https / http / mailto / tel) is rejected as
+ * `INVALID_DATA_TYPE` with field context. Static hyperlinks are validated by
+ * `validateManifest`, not here.
+ */
+function validateHyperlink(field: FieldDefinition, data: InputJSON): ValidationError[] {
+  const link = field.hyperlink
+  if (!link || link.mode !== 'dynamic') return []
+  const raw = (data.texts as Record<string, unknown> | undefined)?.[link.jsonKey]
+  // Empty / missing → no link, no error.
+  if (raw === undefined || raw === null || raw === '') return []
+  if (!isValidHyperlinkUrl(raw)) {
+    return [
+      {
+        code: 'INVALID_DATA_TYPE',
+        field: link.jsonKey,
+        message: `Invalid hyperlink URL for field "${field.id}" (jsonKey "${link.jsonKey}"): must be a non-empty http(s)/mailto/tel URL`,
+      },
+    ]
+  }
+  return []
 }

--- a/packages/core/src/validateManifest.ts
+++ b/packages/core/src/validateManifest.ts
@@ -1,5 +1,6 @@
 import {
   TemplateGoblinError,
+  isValidHyperlinkUrl,
   type ErrorCode,
   type FieldDefinition,
   type ImageField,
@@ -154,23 +155,57 @@ function validateTableField(field: TableField): void {
   }
 }
 
+/**
+ * Hyperlink shape check (#87). Static URLs are validated end-to-end here
+ * (allowed protocols only). Dynamic links only get their `jsonKey` shape
+ * checked at design time — the actual URL string is resolved from input
+ * data and validated by `validateData`.
+ */
+function validateHyperlink(field: FieldDefinition): void {
+  const link = field.hyperlink
+  if (link === undefined || link === null) return
+  if (link.mode === 'static') {
+    if (!isValidHyperlinkUrl(link.url)) {
+      fail(
+        'INVALID_DATA_TYPE',
+        `Field ${field.id}: hyperlink.url must be a valid http(s)/mailto/tel URL`,
+        { fieldId: field.id, url: link.url },
+      )
+    }
+  } else if (link.mode === 'dynamic') {
+    if (typeof link.jsonKey !== 'string' || !isSafeKey(link.jsonKey)) {
+      fail(
+        'INVALID_DATA_TYPE',
+        `Field ${field.id}: hyperlink.jsonKey must match /^[A-Za-z_][A-Za-z0-9_]*$/`,
+        { fieldId: field.id, jsonKey: link.jsonKey },
+      )
+    }
+  } else {
+    fail('INVALID_DATA_TYPE', `Field ${field.id}: hyperlink.mode must be 'static' or 'dynamic'`, {
+      fieldId: field.id,
+      mode: (link as { mode?: unknown }).mode,
+    })
+  }
+}
+
 function validateField(field: FieldDefinition): void {
   switch (field.type) {
     case 'text':
       validateTextField(field)
-      return
+      break
     case 'image':
       validateImageField(field)
-      return
+      break
     case 'table':
       validateTableField(field)
-      return
+      break
     default: {
       const exhaustive: never = field
       void exhaustive
       fail('INVALID_MANIFEST', `Unknown field type`)
     }
   }
+  validateHyperlink(field)
 }
 
 function checkDuplicateJsonKeys(fields: FieldDefinition[]): void {

--- a/packages/core/tests/hyperlink.test.ts
+++ b/packages/core/tests/hyperlink.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Unit coverage for `isValidHyperlinkUrl` (#87).
+ *
+ * Re-exported from `@template-goblin/types`; exercised here via the same
+ * public surface the SDK consumers see.
+ */
+import { isValidHyperlinkUrl } from '@template-goblin/types'
+
+describe('isValidHyperlinkUrl', () => {
+  describe.each([
+    ['https URL', 'https://example.com'],
+    ['https with path', 'https://example.com/path?q=1#frag'],
+    ['http URL', 'http://localhost:3000'],
+    ['mailto', 'mailto:hello@example.com'],
+    ['tel', 'tel:+15551234567'],
+  ])('accepts %s', (_label, url) => {
+    it('passes', () => {
+      expect(isValidHyperlinkUrl(url)).toBe(true)
+    })
+  })
+
+  describe.each([
+    ['empty string', ''],
+    ['plain text', 'just some text'],
+    ['ftp scheme', 'ftp://files.example.com'],
+    ['javascript scheme', 'javascript:alert(1)'],
+    ['data URI', 'data:text/plain,hello'],
+    ['file scheme', 'file:///etc/passwd'],
+    ['custom scheme', 'goblinapp://open'],
+  ])('rejects %s', (_label, url) => {
+    it('returns false', () => {
+      expect(isValidHyperlinkUrl(url)).toBe(false)
+    })
+  })
+
+  it('rejects non-string values', () => {
+    expect(isValidHyperlinkUrl(undefined)).toBe(false)
+    expect(isValidHyperlinkUrl(null)).toBe(false)
+    expect(isValidHyperlinkUrl(42)).toBe(false)
+    expect(isValidHyperlinkUrl({})).toBe(false)
+  })
+})

--- a/packages/core/tests/hyperlink.test.ts
+++ b/packages/core/tests/hyperlink.test.ts
@@ -38,5 +38,74 @@ describe('isValidHyperlinkUrl', () => {
     expect(isValidHyperlinkUrl(null)).toBe(false)
     expect(isValidHyperlinkUrl(42)).toBe(false)
     expect(isValidHyperlinkUrl({})).toBe(false)
+    expect(isValidHyperlinkUrl([])).toBe(false)
+    expect(isValidHyperlinkUrl(true)).toBe(false)
+    expect(isValidHyperlinkUrl(NaN)).toBe(false)
+  })
+
+  it('rejects strings of only whitespace', () => {
+    expect(isValidHyperlinkUrl(' ')).toBe(false)
+    expect(isValidHyperlinkUrl('\t\n')).toBe(false)
+    expect(isValidHyperlinkUrl('   \r\n  ')).toBe(false)
+  })
+
+  describe('case sensitivity', () => {
+    // Browsers normalise scheme to lowercase, so an uppercase or mixed-case
+    // scheme should still be accepted via the allowlist.
+    it.each([
+      ['HTTPS', 'HTTPS://example.com'],
+      ['HtTp', 'HtTp://example.com'],
+      ['MailTo', 'MailTo:foo@example.com'],
+      ['TEL', 'TEL:+15551234'],
+    ])('accepts %s scheme (case-insensitive)', (_label, url) => {
+      expect(isValidHyperlinkUrl(url)).toBe(true)
+    })
+  })
+
+  describe('schemes that look similar but are not allowed', () => {
+    it.each([
+      ['https typo', 'httpz://example.com'],
+      ['ws', 'ws://example.com'],
+      ['wss', 'wss://example.com'],
+      ['blob', 'blob:https://example.com/abc'],
+      ['chrome-extension', 'chrome-extension://abc/popup.html'],
+    ])('rejects %s', (_label, url) => {
+      expect(isValidHyperlinkUrl(url)).toBe(false)
+    })
+  })
+
+  describe('URLs with extra components', () => {
+    it.each([
+      ['userinfo', 'https://user:pass@example.com/'],
+      ['unicode hostname', 'https://例え.jp/'],
+      ['punycode hostname', 'https://xn--r8jz45g.jp/'],
+      ['IPv4 host', 'http://192.168.0.1:8080/'],
+      ['port + query + fragment', 'https://example.com:8443/path?a=1&b=2#section'],
+      ['mailto with subject', 'mailto:foo@example.com?subject=Hi'],
+      ['tel with extension', 'tel:+15551234,9999'],
+    ])('accepts %s', (_label, url) => {
+      expect(isValidHyperlinkUrl(url)).toBe(true)
+    })
+  })
+
+  describe('edge degenerate URLs', () => {
+    // `new URL` is forgiving — these shapes parse successfully even if a
+    // human would call them malformed. We accept them because the
+    // protocol allowlist passes; UX-level fitness is the user's concern.
+    it('accepts empty mailto / tel paths (parser tolerates)', () => {
+      expect(isValidHyperlinkUrl('mailto:')).toBe(true)
+      expect(isValidHyperlinkUrl('tel:')).toBe(true)
+    })
+
+    it('rejects bare scheme with no body for http(s)', () => {
+      // `https:` alone is malformed (no host) and `new URL` throws.
+      expect(isValidHyperlinkUrl('https:')).toBe(false)
+      expect(isValidHyperlinkUrl('http:')).toBe(false)
+    })
+
+    it('rejects scheme followed by garbage', () => {
+      expect(isValidHyperlinkUrl('https//example.com')).toBe(false)
+      expect(isValidHyperlinkUrl(':https://example.com')).toBe(false)
+    })
   })
 })

--- a/packages/core/tests/render/hyperlink.test.ts
+++ b/packages/core/tests/render/hyperlink.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Render-side coverage for `field.hyperlink` (#87).
+ *
+ * Spies on `doc.link()` to assert the renderer calls it once per linked
+ * field with the field's bounding rect, that static and dynamic both
+ * resolve correctly, that empty / missing dynamic values produce no
+ * link, and that an unlinked field never calls `doc.link`.
+ */
+import PDFDocument from 'pdfkit'
+import type {
+  FieldDefinition,
+  InputJSON,
+  LoadedTemplate,
+  TemplateManifest,
+} from '@template-goblin/types'
+import { renderField } from '../../src/render/field.js'
+import { dynText, makeManifest, staticImage, staticTable, staticText } from '../helpers/fixtures.js'
+
+function loadedTemplate(manifest: TemplateManifest): LoadedTemplate {
+  return {
+    manifest,
+    backgroundImage: null,
+    pageBackgrounds: new Map(),
+    fonts: new Map(),
+    placeholders: new Map(),
+    staticImages: new Map(),
+  }
+}
+
+function callRender(
+  field: FieldDefinition,
+  data: InputJSON = { texts: {}, images: {}, tables: {} },
+): InstanceType<typeof PDFDocument> {
+  const doc = new PDFDocument({ size: [595, 842], margin: 0 })
+  const template = loadedTemplate(makeManifest({ fields: [field] }))
+  renderField(doc, field, data, new Map(), template, { pageIndex: 0 }, new Map())
+  return doc
+}
+
+describe('renderField — hyperlink overlay (#87)', () => {
+  it('static link: doc.link is called with the field bounding rect', () => {
+    const field: FieldDefinition = {
+      ...staticText('t1', 'Hello', { x: 50, y: 60, width: 200, height: 30 }),
+      hyperlink: { mode: 'static', url: 'https://example.com' },
+    }
+    const doc = callRender(field)
+    const spy = jest.spyOn(doc, 'link')
+    // Re-render to capture the call (the spy was attached AFTER render
+    // above — switch order so the spy is in place first).
+    const doc2 = new PDFDocument({ size: [595, 842], margin: 0 })
+    const linkSpy = jest.spyOn(doc2, 'link')
+    const template = loadedTemplate(makeManifest({ fields: [field] }))
+    renderField(
+      doc2,
+      field,
+      { texts: {}, images: {}, tables: {} },
+      new Map(),
+      template,
+      { pageIndex: 0 },
+      new Map(),
+    )
+    expect(linkSpy).toHaveBeenCalledTimes(1)
+    expect(linkSpy).toHaveBeenCalledWith(50, 60, 200, 30, 'https://example.com')
+    spy.mockRestore()
+    linkSpy.mockRestore()
+  })
+
+  it('dynamic link: resolves via texts[jsonKey] and calls doc.link', () => {
+    const field: FieldDefinition = {
+      ...dynText('t1', 'name', false, { x: 10, y: 20, width: 100, height: 40 }),
+      hyperlink: { mode: 'dynamic', jsonKey: 'profile_url' },
+    }
+    const doc = new PDFDocument({ size: [595, 842], margin: 0 })
+    const linkSpy = jest.spyOn(doc, 'link')
+    const data: InputJSON = {
+      texts: { name: 'Alice', profile_url: 'https://example.com/alice' },
+      images: {},
+      tables: {},
+    }
+    const template = loadedTemplate(makeManifest({ fields: [field] }))
+    renderField(doc, field, data, new Map(), template, { pageIndex: 0 }, new Map())
+    expect(linkSpy).toHaveBeenCalledTimes(1)
+    expect(linkSpy).toHaveBeenCalledWith(10, 20, 100, 40, 'https://example.com/alice')
+    linkSpy.mockRestore()
+  })
+
+  it('dynamic link with empty texts[jsonKey] does NOT call doc.link', () => {
+    const field: FieldDefinition = {
+      ...dynText('t1', 'name', false),
+      hyperlink: { mode: 'dynamic', jsonKey: 'profile_url' },
+    }
+    const doc = new PDFDocument({ size: [595, 842], margin: 0 })
+    const linkSpy = jest.spyOn(doc, 'link')
+    const data: InputJSON = {
+      texts: { name: 'Alice', profile_url: '' },
+      images: {},
+      tables: {},
+    }
+    const template = loadedTemplate(makeManifest({ fields: [field] }))
+    renderField(doc, field, data, new Map(), template, { pageIndex: 0 }, new Map())
+    expect(linkSpy).not.toHaveBeenCalled()
+    linkSpy.mockRestore()
+  })
+
+  it('dynamic link with missing key does NOT call doc.link', () => {
+    const field: FieldDefinition = {
+      ...dynText('t1', 'name', false),
+      hyperlink: { mode: 'dynamic', jsonKey: 'profile_url' },
+    }
+    const doc = new PDFDocument({ size: [595, 842], margin: 0 })
+    const linkSpy = jest.spyOn(doc, 'link')
+    const data: InputJSON = { texts: { name: 'Alice' }, images: {}, tables: {} }
+    const template = loadedTemplate(makeManifest({ fields: [field] }))
+    renderField(doc, field, data, new Map(), template, { pageIndex: 0 }, new Map())
+    expect(linkSpy).not.toHaveBeenCalled()
+    linkSpy.mockRestore()
+  })
+
+  it('field with no hyperlink: doc.link is never called', () => {
+    const field = staticText('t1', 'Plain text', { x: 0, y: 0, width: 80, height: 20 })
+    const doc = new PDFDocument({ size: [595, 842], margin: 0 })
+    const linkSpy = jest.spyOn(doc, 'link')
+    const template = loadedTemplate(makeManifest({ fields: [field] }))
+    renderField(
+      doc,
+      field,
+      { texts: {}, images: {}, tables: {} },
+      new Map(),
+      template,
+      { pageIndex: 0 },
+      new Map(),
+    )
+    expect(linkSpy).not.toHaveBeenCalled()
+    linkSpy.mockRestore()
+  })
+
+  it('table with a static hyperlink: link covers the whole table rect', () => {
+    const field: FieldDefinition = {
+      ...staticTable('tbl', ['a'], [{ a: 'x' }], { x: 100, y: 100, width: 400, height: 200 }),
+      hyperlink: { mode: 'static', url: 'https://docs.example.com' },
+    }
+    const doc = new PDFDocument({ size: [595, 842], margin: 0 })
+    const linkSpy = jest.spyOn(doc, 'link')
+    const template = loadedTemplate(makeManifest({ fields: [field] }))
+    renderField(
+      doc,
+      field,
+      { texts: {}, images: {}, tables: {} },
+      new Map(),
+      template,
+      { pageIndex: 0 },
+      new Map(),
+    )
+    expect(linkSpy).toHaveBeenCalledTimes(1)
+    expect(linkSpy).toHaveBeenCalledWith(100, 100, 400, 200, 'https://docs.example.com')
+    linkSpy.mockRestore()
+  })
+
+  it('image with a static hyperlink: link covers the image rect', () => {
+    const field: FieldDefinition = {
+      ...staticImage('img', 'pic.png', { x: 5, y: 5, width: 50, height: 50 }),
+      hyperlink: { mode: 'static', url: 'https://example.com' },
+    }
+    // No image bytes registered → renderImage path bails before painting,
+    // but the hyperlink overlay still fires AFTER the switch since the
+    // try-block doesn't throw. Confirm that.
+    const doc = new PDFDocument({ size: [595, 842], margin: 0 })
+    const linkSpy = jest.spyOn(doc, 'link')
+    const template = loadedTemplate(makeManifest({ fields: [field] }))
+    renderField(
+      doc,
+      field,
+      { texts: {}, images: {}, tables: {} },
+      new Map(),
+      template,
+      { pageIndex: 0 },
+      new Map(),
+    )
+    // doc.link should still be called — we link the rect, regardless of
+    // whether bytes were available. (User may upload bytes later.)
+    expect(linkSpy).toHaveBeenCalledTimes(1)
+    expect(linkSpy).toHaveBeenCalledWith(5, 5, 50, 50, 'https://example.com')
+    linkSpy.mockRestore()
+  })
+})

--- a/packages/core/tests/render/hyperlink.test.ts
+++ b/packages/core/tests/render/hyperlink.test.ts
@@ -73,9 +73,10 @@ describe('renderField — hyperlink overlay (#87)', () => {
     const doc = new PDFDocument({ size: [595, 842], margin: 0 })
     const linkSpy = jest.spyOn(doc, 'link')
     const data: InputJSON = {
-      texts: { name: 'Alice', profile_url: 'https://example.com/alice' },
+      texts: { name: 'Alice' },
       images: {},
       tables: {},
+      links: { profile_url: 'https://example.com/alice' },
     }
     const template = loadedTemplate(makeManifest({ fields: [field] }))
     renderField(doc, field, data, new Map(), template, { pageIndex: 0 }, new Map())
@@ -92,9 +93,10 @@ describe('renderField — hyperlink overlay (#87)', () => {
     const doc = new PDFDocument({ size: [595, 842], margin: 0 })
     const linkSpy = jest.spyOn(doc, 'link')
     const data: InputJSON = {
-      texts: { name: 'Alice', profile_url: '' },
+      texts: { name: 'Alice' },
       images: {},
       tables: {},
+      links: { profile_url: '' },
     }
     const template = loadedTemplate(makeManifest({ fields: [field] }))
     renderField(doc, field, data, new Map(), template, { pageIndex: 0 }, new Map())
@@ -180,6 +182,156 @@ describe('renderField — hyperlink overlay (#87)', () => {
     // whether bytes were available. (User may upload bytes later.)
     expect(linkSpy).toHaveBeenCalledTimes(1)
     expect(linkSpy).toHaveBeenCalledWith(5, 5, 50, 50, 'https://example.com')
+    linkSpy.mockRestore()
+  })
+
+  it('static link with an INVALID URL: doc.link is not called (defensive)', () => {
+    // validateManifest should have rejected this at load time. Render
+    // double-checks via isValidHyperlinkUrl so a slip-through never
+    // produces a clickable region pointing at garbage.
+    const field: FieldDefinition = {
+      ...staticText('t1', 'Hello'),
+      hyperlink: { mode: 'static', url: 'ftp://nope' } as { mode: 'static'; url: string },
+    }
+    const doc = new PDFDocument({ size: [595, 842], margin: 0 })
+    const linkSpy = jest.spyOn(doc, 'link')
+    const template = loadedTemplate(makeManifest({ fields: [field] }))
+    renderField(
+      doc,
+      field,
+      { texts: {}, images: {}, tables: {} },
+      new Map(),
+      template,
+      { pageIndex: 0 },
+      new Map(),
+    )
+    expect(linkSpy).not.toHaveBeenCalled()
+    linkSpy.mockRestore()
+  })
+
+  it('dynamic link with a non-string value (number) does NOT call doc.link', () => {
+    const field: FieldDefinition = {
+      ...dynText('t1', 'name', false),
+      hyperlink: { mode: 'dynamic', jsonKey: 'profile_url' },
+    }
+    const doc = new PDFDocument({ size: [595, 842], margin: 0 })
+    const linkSpy = jest.spyOn(doc, 'link')
+    const data = {
+      texts: { name: 'Alice' },
+      images: {},
+      tables: {},
+      links: { profile_url: 42 as unknown as string },
+    } as unknown as InputJSON
+    const template = loadedTemplate(makeManifest({ fields: [field] }))
+    renderField(doc, field, data, new Map(), template, { pageIndex: 0 }, new Map())
+    expect(linkSpy).not.toHaveBeenCalled()
+    linkSpy.mockRestore()
+  })
+
+  it('two fields share the same dynamic key: each gets its own doc.link rect', () => {
+    const fieldA: FieldDefinition = {
+      ...dynText('t1', 'a', false, { x: 10, y: 10, width: 100, height: 30 }),
+      hyperlink: { mode: 'dynamic', jsonKey: 'shared' },
+    }
+    const fieldB: FieldDefinition = {
+      ...dynText('t2', 'b', false, { x: 200, y: 200, width: 80, height: 40 }),
+      hyperlink: { mode: 'dynamic', jsonKey: 'shared' },
+    }
+    const doc = new PDFDocument({ size: [595, 842], margin: 0 })
+    const linkSpy = jest.spyOn(doc, 'link')
+    const data: InputJSON = {
+      texts: { a: 'A', b: 'B' },
+      images: {},
+      tables: {},
+      links: { shared: 'https://shared.example.com' },
+    }
+    const template = loadedTemplate(makeManifest({ fields: [fieldA, fieldB] }))
+    renderField(doc, fieldA, data, new Map(), template, { pageIndex: 0 }, new Map())
+    renderField(doc, fieldB, data, new Map(), template, { pageIndex: 0 }, new Map())
+    expect(linkSpy).toHaveBeenCalledTimes(2)
+    expect(linkSpy).toHaveBeenNthCalledWith(1, 10, 10, 100, 30, 'https://shared.example.com')
+    expect(linkSpy).toHaveBeenNthCalledWith(2, 200, 200, 80, 40, 'https://shared.example.com')
+    linkSpy.mockRestore()
+  })
+
+  it('zero-size field with a hyperlink: doc.link still fires with the rect', () => {
+    // Degenerate but legal — designer hasn't sized the field yet. The
+    // renderer doesn't filter on size; the PDF viewer would just have a
+    // 0×0 click target. Document the contract via a test.
+    const field: FieldDefinition = {
+      ...staticText('t1', 'x', { x: 0, y: 0, width: 0, height: 0 }),
+      hyperlink: { mode: 'static', url: 'https://example.com' },
+    }
+    const doc = new PDFDocument({ size: [595, 842], margin: 0 })
+    const linkSpy = jest.spyOn(doc, 'link')
+    const template = loadedTemplate(makeManifest({ fields: [field] }))
+    renderField(
+      doc,
+      field,
+      { texts: {}, images: {}, tables: {} },
+      new Map(),
+      template,
+      { pageIndex: 0 },
+      new Map(),
+    )
+    expect(linkSpy).toHaveBeenCalledTimes(1)
+    expect(linkSpy).toHaveBeenCalledWith(0, 0, 0, 0, 'https://example.com')
+    linkSpy.mockRestore()
+  })
+
+  it('mailto and tel render correctly', () => {
+    const fieldA: FieldDefinition = {
+      ...staticText('t1', 'mail', { x: 10, y: 10, width: 50, height: 20 }),
+      hyperlink: { mode: 'static', url: 'mailto:hi@example.com' },
+    }
+    const fieldB: FieldDefinition = {
+      ...staticText('t2', 'phone', { x: 80, y: 10, width: 50, height: 20 }),
+      hyperlink: { mode: 'static', url: 'tel:+15551234' },
+    }
+    const doc = new PDFDocument({ size: [595, 842], margin: 0 })
+    const linkSpy = jest.spyOn(doc, 'link')
+    const template = loadedTemplate(makeManifest({ fields: [fieldA, fieldB] }))
+    renderField(
+      doc,
+      fieldA,
+      { texts: {}, images: {}, tables: {} },
+      new Map(),
+      template,
+      { pageIndex: 0 },
+      new Map(),
+    )
+    renderField(
+      doc,
+      fieldB,
+      { texts: {}, images: {}, tables: {} },
+      new Map(),
+      template,
+      { pageIndex: 0 },
+      new Map(),
+    )
+    expect(linkSpy).toHaveBeenCalledTimes(2)
+    expect(linkSpy).toHaveBeenNthCalledWith(1, 10, 10, 50, 20, 'mailto:hi@example.com')
+    expect(linkSpy).toHaveBeenNthCalledWith(2, 80, 10, 50, 20, 'tel:+15551234')
+    linkSpy.mockRestore()
+  })
+
+  it('value sitting in texts (not links) does NOT trigger doc.link', () => {
+    // The renderer reads from `data.links`. A URL placed in `data.texts`
+    // — whether by mistake or migration — must not be treated as a link.
+    const field: FieldDefinition = {
+      ...dynText('t1', 'name', false),
+      hyperlink: { mode: 'dynamic', jsonKey: 'profile_url' },
+    }
+    const doc = new PDFDocument({ size: [595, 842], margin: 0 })
+    const linkSpy = jest.spyOn(doc, 'link')
+    const data: InputJSON = {
+      texts: { name: 'Alice', profile_url: 'https://example.com' },
+      images: {},
+      tables: {},
+    }
+    const template = loadedTemplate(makeManifest({ fields: [field] }))
+    renderField(doc, field, data, new Map(), template, { pageIndex: 0 }, new Map())
+    expect(linkSpy).not.toHaveBeenCalled()
     linkSpy.mockRestore()
   })
 })

--- a/packages/core/tests/validateData.hyperlink.test.ts
+++ b/packages/core/tests/validateData.hyperlink.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Runtime-data validation for dynamic `field.hyperlink` (#87).
+ *
+ * Static hyperlinks are validated at load time by `validateManifest`. At
+ * `validateData` time we only police dynamic ones: pull
+ * `data.texts[jsonKey]`, accept it if empty (no link, no error) or if it
+ * passes the protocol allowlist; reject otherwise as `INVALID_DATA_TYPE`.
+ */
+import type {
+  FieldDefinition,
+  InputJSON,
+  LoadedTemplate,
+  TemplateManifest,
+} from '@template-goblin/types'
+import { validateData } from '../src/validate.js'
+import { dynText, makeManifest } from './helpers/fixtures.js'
+
+function template(fields: FieldDefinition[]): LoadedTemplate {
+  const manifest: TemplateManifest = makeManifest({ fields })
+  return {
+    manifest,
+    backgroundImage: null,
+    pageBackgrounds: new Map(),
+    fonts: new Map(),
+    placeholders: new Map(),
+    staticImages: new Map(),
+  }
+}
+
+describe('validateData — dynamic field.hyperlink', () => {
+  const linkedField: FieldDefinition = {
+    ...dynText('t1', 'name', false),
+    hyperlink: { mode: 'dynamic', jsonKey: 'profile_url' },
+  }
+
+  it('accepts a valid https URL pulled from texts[jsonKey]', () => {
+    const t = template([linkedField])
+    const data: InputJSON = {
+      texts: { name: 'Alice', profile_url: 'https://example.com/alice' },
+      images: {},
+      tables: {},
+    }
+    expect(validateData(t, data)).toEqual({ valid: true, errors: [] })
+  })
+
+  it('accepts mailto, tel, http schemes', () => {
+    const t = template([linkedField])
+    for (const url of ['mailto:foo@example.com', 'tel:+15551234', 'http://localhost']) {
+      const data: InputJSON = { texts: { name: 'X', profile_url: url }, images: {}, tables: {} }
+      expect(validateData(t, data).valid).toBe(true)
+    }
+  })
+
+  it('treats empty / missing texts[jsonKey] as no-link (no error)', () => {
+    const t = template([linkedField])
+    const empty: InputJSON = { texts: { name: 'Alice', profile_url: '' }, images: {}, tables: {} }
+    const missing: InputJSON = { texts: { name: 'Alice' }, images: {}, tables: {} }
+    expect(validateData(t, empty)).toEqual({ valid: true, errors: [] })
+    expect(validateData(t, missing)).toEqual({ valid: true, errors: [] })
+  })
+
+  it('rejects a non-empty value that is not a valid URL', () => {
+    const t = template([linkedField])
+    const data: InputJSON = {
+      texts: { name: 'Alice', profile_url: 'just a string' },
+      images: {},
+      tables: {},
+    }
+    const result = validateData(t, data)
+    expect(result.valid).toBe(false)
+    expect(result.errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: 'INVALID_DATA_TYPE', field: 'profile_url' }),
+      ]),
+    )
+  })
+
+  it.each([
+    ['ftp', 'ftp://example.com'],
+    ['javascript', 'javascript:alert(1)'],
+    ['data', 'data:text/plain,hello'],
+  ])('rejects %s scheme as INVALID_DATA_TYPE', (_label, url) => {
+    const t = template([linkedField])
+    const data: InputJSON = { texts: { name: 'A', profile_url: url }, images: {}, tables: {} }
+    const result = validateData(t, data)
+    expect(result.valid).toBe(false)
+  })
+
+  it('does not validate static hyperlinks here (those are manifest-time)', () => {
+    // A static link with a totally invalid URL would be rejected at
+    // manifest-load time. validateData should NOT re-flag it.
+    const t = template([
+      {
+        ...dynText('t1', 'name', false),
+        // bypass type narrowing — we want to prove validateData ignores
+        // this branch even if it happened to slip through.
+        hyperlink: { mode: 'static', url: 'ftp://nope' } as { mode: 'static'; url: string },
+      },
+    ])
+    const data: InputJSON = { texts: { name: 'A' }, images: {}, tables: {} }
+    expect(validateData(t, data)).toEqual({ valid: true, errors: [] })
+  })
+})

--- a/packages/core/tests/validateData.hyperlink.test.ts
+++ b/packages/core/tests/validateData.hyperlink.test.ts
@@ -3,8 +3,10 @@
  *
  * Static hyperlinks are validated at load time by `validateManifest`. At
  * `validateData` time we only police dynamic ones: pull
- * `data.texts[jsonKey]`, accept it if empty (no link, no error) or if it
- * passes the protocol allowlist; reject otherwise as `INVALID_DATA_TYPE`.
+ * `data.links[jsonKey]` (separate top-level bucket from `texts` so URLs
+ * are visually distinct), accept it if empty (no link, no error) or if
+ * it passes the protocol allowlist; reject otherwise as
+ * `INVALID_DATA_TYPE`.
  */
 import type {
   FieldDefinition,
@@ -33,12 +35,13 @@ describe('validateData — dynamic field.hyperlink', () => {
     hyperlink: { mode: 'dynamic', jsonKey: 'profile_url' },
   }
 
-  it('accepts a valid https URL pulled from texts[jsonKey]', () => {
+  it('accepts a valid https URL pulled from links[jsonKey]', () => {
     const t = template([linkedField])
     const data: InputJSON = {
-      texts: { name: 'Alice', profile_url: 'https://example.com/alice' },
+      texts: { name: 'Alice' },
       images: {},
       tables: {},
+      links: { profile_url: 'https://example.com/alice' },
     }
     expect(validateData(t, data)).toEqual({ valid: true, errors: [] })
   })
@@ -46,14 +49,24 @@ describe('validateData — dynamic field.hyperlink', () => {
   it('accepts mailto, tel, http schemes', () => {
     const t = template([linkedField])
     for (const url of ['mailto:foo@example.com', 'tel:+15551234', 'http://localhost']) {
-      const data: InputJSON = { texts: { name: 'X', profile_url: url }, images: {}, tables: {} }
+      const data: InputJSON = {
+        texts: { name: 'X' },
+        images: {},
+        tables: {},
+        links: { profile_url: url },
+      }
       expect(validateData(t, data).valid).toBe(true)
     }
   })
 
-  it('treats empty / missing texts[jsonKey] as no-link (no error)', () => {
+  it('treats empty / missing links[jsonKey] as no-link (no error)', () => {
     const t = template([linkedField])
-    const empty: InputJSON = { texts: { name: 'Alice', profile_url: '' }, images: {}, tables: {} }
+    const empty: InputJSON = {
+      texts: { name: 'Alice' },
+      images: {},
+      tables: {},
+      links: { profile_url: '' },
+    }
     const missing: InputJSON = { texts: { name: 'Alice' }, images: {}, tables: {} }
     expect(validateData(t, empty)).toEqual({ valid: true, errors: [] })
     expect(validateData(t, missing)).toEqual({ valid: true, errors: [] })
@@ -62,9 +75,10 @@ describe('validateData — dynamic field.hyperlink', () => {
   it('rejects a non-empty value that is not a valid URL', () => {
     const t = template([linkedField])
     const data: InputJSON = {
-      texts: { name: 'Alice', profile_url: 'just a string' },
+      texts: { name: 'Alice' },
       images: {},
       tables: {},
+      links: { profile_url: 'just a string' },
     }
     const result = validateData(t, data)
     expect(result.valid).toBe(false)
@@ -81,7 +95,12 @@ describe('validateData — dynamic field.hyperlink', () => {
     ['data', 'data:text/plain,hello'],
   ])('rejects %s scheme as INVALID_DATA_TYPE', (_label, url) => {
     const t = template([linkedField])
-    const data: InputJSON = { texts: { name: 'A', profile_url: url }, images: {}, tables: {} }
+    const data: InputJSON = {
+      texts: { name: 'A' },
+      images: {},
+      tables: {},
+      links: { profile_url: url },
+    }
     const result = validateData(t, data)
     expect(result.valid).toBe(false)
   })
@@ -98,6 +117,114 @@ describe('validateData — dynamic field.hyperlink', () => {
       },
     ])
     const data: InputJSON = { texts: { name: 'A' }, images: {}, tables: {} }
+    expect(validateData(t, data)).toEqual({ valid: true, errors: [] })
+  })
+
+  it('a value in texts (not links) does NOT satisfy a dynamic hyperlink', () => {
+    const t = template([linkedField])
+    // Putting the URL in `texts` instead of `links` should be treated as
+    // "no link" (the renderer reads from `links`). No error either —
+    // empty/missing is the no-link contract.
+    const data: InputJSON = {
+      texts: { name: 'Alice', profile_url: 'https://example.com' },
+      images: {},
+      tables: {},
+    }
+    expect(validateData(t, data)).toEqual({ valid: true, errors: [] })
+  })
+
+  it.each([
+    ['number', 42],
+    ['boolean', true],
+    ['null', null],
+    ['object', { url: 'https://example.com' }],
+    ['array', ['https://example.com']],
+  ])('rejects a non-string %s in links[jsonKey]', (_label, val) => {
+    const t = template([linkedField])
+    const data = {
+      texts: { name: 'Alice' },
+      images: {},
+      tables: {},
+      links: { profile_url: val },
+    } as unknown as InputJSON
+    if (val === null) {
+      // null is treated as "missing" by the empty-check, so no error.
+      expect(validateData(t, data)).toEqual({ valid: true, errors: [] })
+    } else {
+      expect(validateData(t, data).valid).toBe(false)
+    }
+  })
+
+  it('multiple fields with hyperlinks: each is validated independently', () => {
+    const t = template([
+      { ...dynText('t1', 'a', false), hyperlink: { mode: 'dynamic', jsonKey: 'link_a' } },
+      { ...dynText('t2', 'b', false), hyperlink: { mode: 'dynamic', jsonKey: 'link_b' } },
+      { ...dynText('t3', 'c', false), hyperlink: { mode: 'dynamic', jsonKey: 'link_c' } },
+    ])
+    const data: InputJSON = {
+      texts: { a: 'A', b: 'B', c: 'C' },
+      images: {},
+      tables: {},
+      links: {
+        link_a: 'https://valid.example.com',
+        link_b: 'ftp://nope', // bad scheme
+        link_c: '', // empty → no error
+      },
+    }
+    const result = validateData(t, data)
+    expect(result.valid).toBe(false)
+    // Only link_b should produce an error; link_a is valid, link_c is
+    // empty (treated as "no link, no error").
+    expect(result.errors).toHaveLength(1)
+    expect(result.errors[0]).toMatchObject({
+      code: 'INVALID_DATA_TYPE',
+      field: 'link_b',
+    })
+  })
+
+  it('two fields share a hyperlink jsonKey — single value validated once', () => {
+    const t = template([
+      { ...dynText('t1', 'a', false), hyperlink: { mode: 'dynamic', jsonKey: 'shared' } },
+      { ...dynText('t2', 'b', false), hyperlink: { mode: 'dynamic', jsonKey: 'shared' } },
+    ])
+    const data: InputJSON = {
+      texts: { a: 'A', b: 'B' },
+      images: {},
+      tables: {},
+      links: { shared: 'ftp://nope' },
+    }
+    const result = validateData(t, data)
+    expect(result.valid).toBe(false)
+    // Both fields point to the same key; we get one error per FIELD —
+    // the contract is field-level reporting, not key-level dedup. Still
+    // useful diagnostic.
+    expect(result.errors.length).toBeGreaterThanOrEqual(1)
+    expect(result.errors.every((e) => e.field === 'shared')).toBe(true)
+  })
+
+  it('whitespace-only link value is rejected (not "empty")', () => {
+    // A trimmed-to-zero string is empty; a string of whitespace is NOT.
+    // It also isn't a valid URL — should fail validation.
+    const t = template([linkedField])
+    const data: InputJSON = {
+      texts: { name: 'A' },
+      images: {},
+      tables: {},
+      links: { profile_url: '   ' },
+    }
+    expect(validateData(t, data).valid).toBe(false)
+  })
+
+  it('field with no hyperlink at all is unaffected by validation', () => {
+    const t = template([dynText('t1', 'name', false)])
+    const data: InputJSON = {
+      texts: { name: 'Alice' },
+      images: {},
+      tables: {},
+      links: { random_key: 'ftp://nope' },
+    }
+    // Spurious entries in `links` are tolerated — there's no field
+    // pointing at `random_key`, so it's just unused noise.
     expect(validateData(t, data)).toEqual({ valid: true, errors: [] })
   })
 })

--- a/packages/core/tests/validateManifest.hyperlink.test.ts
+++ b/packages/core/tests/validateManifest.hyperlink.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Manifest-level validation for `field.hyperlink` (#87).
+ *
+ * Static URLs are validated end-to-end here (allowed protocols only).
+ * Dynamic links only get their `jsonKey` shape checked at design time —
+ * the actual URL string is resolved from input data and validated by
+ * `validateData`.
+ */
+import { validateManifest } from '../src/validateManifest.js'
+import { TemplateGoblinError } from '@template-goblin/types'
+import { dynText, makeManifest, staticImage, staticTable, staticText } from './helpers/fixtures.js'
+
+describe('validateManifest — field.hyperlink', () => {
+  it('accepts a text field with a valid static https URL', () => {
+    const m = makeManifest({
+      fields: [
+        { ...staticText('t1', 'hi'), hyperlink: { mode: 'static', url: 'https://example.com' } },
+      ],
+    })
+    expect(() => validateManifest(m)).not.toThrow()
+  })
+
+  it.each([
+    ['mailto', 'mailto:foo@example.com'],
+    ['tel', 'tel:+1234'],
+    ['http', 'http://localhost:3000'],
+  ])('accepts %s scheme on a static URL', (_label, url) => {
+    const m = makeManifest({
+      fields: [{ ...staticText('t1', 'hi'), hyperlink: { mode: 'static', url } }],
+    })
+    expect(() => validateManifest(m)).not.toThrow()
+  })
+
+  it.each([
+    ['ftp', 'ftp://files.example.com'],
+    ['javascript', 'javascript:alert(1)'],
+    ['empty', ''],
+    ['garbage', 'not a url'],
+  ])('rejects a static %s URL with INVALID_DATA_TYPE', (_label, url) => {
+    const m = makeManifest({
+      fields: [{ ...staticText('t1', 'hi'), hyperlink: { mode: 'static', url } }],
+    })
+    try {
+      validateManifest(m)
+      throw new Error('expected throw')
+    } catch (err) {
+      expect(err).toBeInstanceOf(TemplateGoblinError)
+      expect((err as TemplateGoblinError).code).toBe('INVALID_DATA_TYPE')
+      expect((err as TemplateGoblinError).message).toMatch(/hyperlink\.url/)
+    }
+  })
+
+  it('accepts a dynamic hyperlink with a safe jsonKey', () => {
+    const m = makeManifest({
+      fields: [
+        {
+          ...dynText('t1', 'name', false),
+          hyperlink: { mode: 'dynamic', jsonKey: 'profile_url' },
+        },
+      ],
+    })
+    expect(() => validateManifest(m)).not.toThrow()
+  })
+
+  it('rejects a dynamic hyperlink with an unsafe jsonKey', () => {
+    const m = makeManifest({
+      fields: [
+        {
+          ...dynText('t1', 'name', false),
+          hyperlink: { mode: 'dynamic', jsonKey: 'has space' },
+        },
+      ],
+    })
+    try {
+      validateManifest(m)
+      throw new Error('expected throw')
+    } catch (err) {
+      expect((err as TemplateGoblinError).code).toBe('INVALID_DATA_TYPE')
+      expect((err as TemplateGoblinError).message).toMatch(/hyperlink\.jsonKey/)
+    }
+  })
+
+  it('rejects a hyperlink with an unknown mode', () => {
+    const m = makeManifest({
+      fields: [
+        {
+          ...staticText('t1', 'hi'),
+          // Cast through unknown so the bad shape compiles for the test.
+          hyperlink: { mode: 'lol', url: 'https://x' } as unknown as {
+            mode: 'static'
+            url: string
+          },
+        },
+      ],
+    })
+    expect(() => validateManifest(m)).toThrow(TemplateGoblinError)
+  })
+
+  it('treats undefined / missing hyperlink as a no-op (not an error)', () => {
+    const m = makeManifest({
+      fields: [
+        staticText('t1', 'plain'),
+        staticImage('i1', 'pic.png'),
+        staticTable('tbl', ['a'], [{ a: 'x' }]),
+      ],
+    })
+    expect(() => validateManifest(m)).not.toThrow()
+  })
+
+  it('accepts a static URL on a table field', () => {
+    const m = makeManifest({
+      fields: [
+        {
+          ...staticTable('tbl', ['a'], [{ a: 'x' }]),
+          hyperlink: { mode: 'static', url: 'https://example.com' },
+        },
+      ],
+    })
+    expect(() => validateManifest(m)).not.toThrow()
+  })
+})

--- a/packages/core/tests/validateManifest.hyperlink.test.ts
+++ b/packages/core/tests/validateManifest.hyperlink.test.ts
@@ -118,4 +118,111 @@ describe('validateManifest — field.hyperlink', () => {
     })
     expect(() => validateManifest(m)).not.toThrow()
   })
+
+  it('accepts a hyperlink on every field type in one manifest', () => {
+    const m = makeManifest({
+      fields: [
+        {
+          ...staticText('t1', 'hi'),
+          hyperlink: { mode: 'static', url: 'https://text.example.com' },
+        },
+        {
+          ...staticImage('i1', 'pic.png'),
+          hyperlink: { mode: 'static', url: 'mailto:foo@example.com' },
+        },
+        {
+          ...staticTable('tb1', ['a'], [{ a: 'x' }]),
+          hyperlink: { mode: 'dynamic', jsonKey: 'tab_link' },
+        },
+      ],
+    })
+    expect(() => validateManifest(m)).not.toThrow()
+  })
+
+  it('rejects a static hyperlink with a non-string url', () => {
+    const m = makeManifest({
+      fields: [
+        {
+          ...staticText('t1', 'hi'),
+          hyperlink: { mode: 'static', url: 42 } as unknown as { mode: 'static'; url: string },
+        },
+      ],
+    })
+    expect(() => validateManifest(m)).toThrow(TemplateGoblinError)
+  })
+
+  it('rejects a dynamic hyperlink with a non-string jsonKey', () => {
+    const m = makeManifest({
+      fields: [
+        {
+          ...staticText('t1', 'hi'),
+          hyperlink: { mode: 'dynamic', jsonKey: 5 } as unknown as {
+            mode: 'dynamic'
+            jsonKey: string
+          },
+        },
+      ],
+    })
+    expect(() => validateManifest(m)).toThrow(TemplateGoblinError)
+  })
+
+  it('rejects a dynamic hyperlink with an empty jsonKey', () => {
+    const m = makeManifest({
+      fields: [
+        {
+          ...staticText('t1', 'hi'),
+          hyperlink: { mode: 'dynamic', jsonKey: '' },
+        },
+      ],
+    })
+    expect(() => validateManifest(m)).toThrow(TemplateGoblinError)
+  })
+
+  it.each([
+    ['leading digit', '1url'],
+    ['hyphen', 'profile-url'],
+    ['dot', 'profile.url'],
+    ['unicode', 'üURL'],
+  ])('rejects dynamic jsonKey with %s', (_label, key) => {
+    const m = makeManifest({
+      fields: [
+        {
+          ...staticText('t1', 'hi'),
+          hyperlink: { mode: 'dynamic', jsonKey: key },
+        },
+      ],
+    })
+    expect(() => validateManifest(m)).toThrow(TemplateGoblinError)
+  })
+
+  it('allows the same dynamic jsonKey across two fields (no DUPLICATE check)', () => {
+    // The DUPLICATE_JSON_KEY check is per-type-per-source — hyperlink
+    // jsonKeys live in their own `links` bucket and may legitimately be
+    // shared by multiple fields (one URL covering several visuals).
+    const m = makeManifest({
+      fields: [
+        {
+          ...staticText('t1', 'a'),
+          hyperlink: { mode: 'dynamic', jsonKey: 'shared_url' },
+        },
+        {
+          ...staticText('t2', 'b'),
+          hyperlink: { mode: 'dynamic', jsonKey: 'shared_url' },
+        },
+      ],
+    })
+    expect(() => validateManifest(m)).not.toThrow()
+  })
+
+  it('rejects a static URL containing newlines', () => {
+    const m = makeManifest({
+      fields: [
+        {
+          ...staticText('t1', 'hi'),
+          hyperlink: { mode: 'static', url: 'https://example.com\n<script>' },
+        },
+      ],
+    })
+    expect(() => validateManifest(m)).toThrow(TemplateGoblinError)
+  })
 })

--- a/packages/types/src/hyperlink.ts
+++ b/packages/types/src/hyperlink.ts
@@ -1,0 +1,67 @@
+/**
+ * Hyperlink — optional clickable region attached to any field (#87).
+ *
+ * Two flavours, picked by `mode`:
+ *   - `static`: a literal URL baked into the manifest. Round-trips with
+ *     the `.tgbl` archive, validated at load time.
+ *   - `dynamic`: a `jsonKey` resolved at render time from
+ *     `InputJSON.texts[jsonKey]`. Each row of input data may carry its
+ *     own URL string. An empty / missing value yields no clickable
+ *     region (no error).
+ *
+ * Allowed protocols: `https`, `http`, `mailto`, `tel`. Anything else
+ * (e.g. `ftp`, `javascript`, custom schemes) is rejected as
+ * `INVALID_DATA_TYPE`.
+ *
+ * Tables: a hyperlink on a `TableField` makes the WHOLE table's
+ * bounding rect clickable — there is no per-row or per-column variant.
+ * Per-cell linking would require a far more involved layout-time
+ * coordinate calculation and is out of scope for v1.
+ */
+
+/** A literal URL pinned into the manifest. */
+export interface StaticHyperlink {
+  mode: 'static'
+  url: string
+}
+
+/** A `texts[jsonKey]` lookup resolved against runtime input data. */
+export interface DynamicHyperlink {
+  mode: 'dynamic'
+  jsonKey: string
+}
+
+export type Hyperlink = StaticHyperlink | DynamicHyperlink
+
+const ALLOWED_PROTOCOLS = new Set(['https:', 'http:', 'mailto:', 'tel:'])
+
+/**
+ * True when `value` is a non-empty string whose URL parses and uses one
+ * of the allowed protocols. Used by both manifest validation (static
+ * URL) and input-data validation (dynamic URL) so the rules are
+ * identical at design time and at runtime.
+ *
+ * Empty strings return `false`. Callers that want "empty == no link"
+ * semantics must short-circuit on emptiness BEFORE calling this — the
+ * function only judges shape, not absence.
+ */
+export function isValidHyperlinkUrl(value: unknown): boolean {
+  if (typeof value !== 'string' || value.length === 0) return false
+  let parsed: URL
+  try {
+    parsed = new URL(value)
+  } catch {
+    return false
+  }
+  return ALLOWED_PROTOCOLS.has(parsed.protocol)
+}
+
+/** Type guard for the static variant. */
+export function isStaticHyperlink(h: Hyperlink): h is StaticHyperlink {
+  return h.mode === 'static'
+}
+
+/** Type guard for the dynamic variant. */
+export function isDynamicHyperlink(h: Hyperlink): h is DynamicHyperlink {
+  return h.mode === 'dynamic'
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -30,7 +30,14 @@ export type {
   OverflowMode,
   ImageFit,
 } from './template.js'
-export type { InputJSON, TextInputs, TableInputs, ImageInputs, ImageInput } from './input.js'
+export type {
+  InputJSON,
+  TextInputs,
+  TableInputs,
+  ImageInputs,
+  ImageInput,
+  LinkInputs,
+} from './input.js'
 export type { StaticSource, DynamicSource, FieldSource } from './source.js'
 export { isStaticSource, isDynamicSource } from './source.js'
 export type { Hyperlink, StaticHyperlink, DynamicHyperlink } from './hyperlink.js'

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -33,6 +33,8 @@ export type {
 export type { InputJSON, TextInputs, TableInputs, ImageInputs, ImageInput } from './input.js'
 export type { StaticSource, DynamicSource, FieldSource } from './source.js'
 export { isStaticSource, isDynamicSource } from './source.js'
+export type { Hyperlink, StaticHyperlink, DynamicHyperlink } from './hyperlink.js'
+export { isValidHyperlinkUrl, isStaticHyperlink, isDynamicHyperlink } from './hyperlink.js'
 export { isImageFilenameValue, isImageColorValue } from './template.js'
 export type { LoadedTemplate, TemplateAssets } from './loaded.js'
 export { PAGE_SIZE_PRESETS, getPageSize } from './pageSize.js'

--- a/packages/types/src/input.ts
+++ b/packages/types/src/input.ts
@@ -7,6 +7,16 @@ export type TextInputs = Record<string, string>
 export type TableInputs = Record<string, TableRow[]>
 
 /**
+ * Hyperlink URLs keyed by `field.hyperlink.jsonKey` (#87).
+ *
+ * Lives in its own top-level bucket so URLs don't get mixed into
+ * `texts` — they're a different kind of value (clickable target, not
+ * rendered content) and the JSON preview should make that obvious.
+ * Allowed protocols at validation time: https, http, mailto, tel.
+ */
+export type LinkInputs = Record<string, string>
+
+/**
  * One image input slot in `InputJSON.images`.
  *
  * Auto-detected shorthand (recommended for almost all use cases):
@@ -49,6 +59,14 @@ export interface InputJSON {
   texts: TextInputs
   images: ImageInputs
   tables: TableInputs
+  /**
+   * Optional hyperlink URLs, keyed by `field.hyperlink.jsonKey`. Sits
+   * alongside `texts` rather than nested inside it so the JSON preview
+   * can render URLs as a visually distinct section. Empty / missing
+   * entries render the corresponding field with no clickable region —
+   * not an error.
+   */
+  links?: LinkInputs
 }
 
 export type { TableRow } from './template.js'

--- a/packages/types/src/template.ts
+++ b/packages/types/src/template.ts
@@ -1,4 +1,5 @@
 import type { FieldSource } from './source.js'
+import type { Hyperlink } from './hyperlink.js'
 
 /** Page size presets supported by the template */
 export type PageSize = 'custom' | 'A3' | 'A4' | 'A5' | 'Letter' | 'Legal'
@@ -218,6 +219,14 @@ export interface FieldBase {
   width: number
   height: number
   zIndex: number
+  /**
+   * Optional clickable URL attached to the field's bounding rect (#87).
+   * Either a literal `{ mode: 'static', url }` or a `{ mode: 'dynamic',
+   * jsonKey }` resolved from `InputJSON.texts[jsonKey]` at render time.
+   * For tables, the link covers the WHOLE table — no per-row variant.
+   * Allowed protocols: `https`, `http`, `mailto`, `tel`.
+   */
+  hyperlink?: Hyperlink
 }
 
 /** A text field — static value is the literal rendered string. */

--- a/packages/ui/src/components/Preview/PreviewDialog.tsx
+++ b/packages/ui/src/components/Preview/PreviewDialog.tsx
@@ -146,6 +146,12 @@ export function PreviewDialog({ onClose }: { onClose: () => void }) {
         texts: (parsed.texts ?? {}) as Record<string, string>,
         tables: (parsed.tables ?? {}) as Record<string, Record<string, string>[]>,
         images: {} as Record<string, string | ArrayBuffer>,
+        // GH #87 — carry the hyperlink URL bucket through to generatePDF
+        // so dynamic-link fields (mode: 'dynamic', jsonKey) actually
+        // become clickable in the rendered preview. Pre-fix this was
+        // silently dropped and the link annotations never made it into
+        // the PDF byte stream.
+        links: (parsed.links ?? {}) as Record<string, string>,
       }
       for (const field of dynamicImageFields) {
         if (field.source.mode !== 'dynamic') continue

--- a/packages/ui/src/components/Preview/__tests__/previewDialogHelpers.test.ts
+++ b/packages/ui/src/components/Preview/__tests__/previewDialogHelpers.test.ts
@@ -62,6 +62,54 @@ describe('parseInputJson', () => {
     const r = parseInputJson('{"texts":{},"extra":42}')
     expect(r.ok).toBe(true)
   })
+
+  // ---- GH #87 hyperlink bucket ----
+
+  it('accepts a "links" bucket', () => {
+    const r = parseInputJson('{"texts":{},"links":{"profile_url":"https://x.com"}}')
+    expect(r.ok).toBe(true)
+    if (r.ok) {
+      expect(r.data.links).toEqual({ profile_url: 'https://x.com' })
+    }
+  })
+
+  it('accepts an empty "links" bucket', () => {
+    const r = parseInputJson('{"links":{}}')
+    expect(r.ok).toBe(true)
+  })
+
+  it('rejects "links" as an array', () => {
+    const r = parseInputJson('{"links":["https://x.com"]}')
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.error).toMatch(/links/)
+  })
+
+  it('rejects "links" as a string', () => {
+    const r = parseInputJson('{"links":"https://x.com"}')
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.error).toMatch(/links/)
+  })
+
+  it('rejects "links" as null', () => {
+    const r = parseInputJson('{"links":null}')
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.error).toMatch(/links/)
+  })
+
+  it('parses a complete payload with all four buckets', () => {
+    const r = parseInputJson(
+      '{"texts":{"a":"x"},"tables":{},"images":{},"links":{"l":"https://example.com"}}',
+    )
+    expect(r.ok).toBe(true)
+    if (r.ok) {
+      expect(r.data).toEqual({
+        texts: { a: 'x' },
+        tables: {},
+        images: {},
+        links: { l: 'https://example.com' },
+      })
+    }
+  })
 })
 
 describe('validateUpload', () => {

--- a/packages/ui/src/components/Preview/previewDialogHelpers.ts
+++ b/packages/ui/src/components/Preview/previewDialogHelpers.ts
@@ -13,7 +13,7 @@ export const ALLOWED_UPLOAD_MIME = new Set(['image/png', 'image/jpeg', 'image/we
 
 interface ParseOk {
   ok: true
-  data: { texts?: unknown; tables?: unknown; images?: unknown }
+  data: { texts?: unknown; tables?: unknown; images?: unknown; links?: unknown }
 }
 interface ParseErr {
   ok: false
@@ -39,7 +39,9 @@ export function parseInputJson(text: string): ParseResult {
     return { ok: false, error: 'Top-level value must be an object.' }
   }
   const o = parsed as Record<string, unknown>
-  for (const key of ['texts', 'tables', 'images'] as const) {
+  // `links` is the GH #87 hyperlink-URL bucket — same shape contract as
+  // texts/tables/images: optional, must be an object when present.
+  for (const key of ['texts', 'tables', 'images', 'links'] as const) {
     if (key in o) {
       const v = o[key]
       if (typeof v !== 'object' || v === null || Array.isArray(v)) {

--- a/packages/ui/src/components/RightPanel/HyperlinkSection.tsx
+++ b/packages/ui/src/components/RightPanel/HyperlinkSection.tsx
@@ -1,0 +1,156 @@
+import { useState } from 'react'
+import type { FieldDefinition, Hyperlink } from '@template-goblin/types'
+import { isSafeKey, isValidHyperlinkUrl } from '@template-goblin/types'
+import { useTemplateStore } from '../../store/templateStore.js'
+
+/**
+ * Hyperlink editor (#87) — a self-contained Properties-panel section
+ * shared by Text / Image / Table field props. Three modes:
+ *
+ *   - **None**:    `field.hyperlink === undefined`. No clickable region.
+ *   - **Static**:  `{ mode: 'static', url }`. Literal URL pinned in the
+ *                  manifest. Validated end-to-end (https / http / mailto
+ *                  / tel only).
+ *   - **Dynamic**: `{ mode: 'dynamic', jsonKey }`. URL pulled from
+ *                  `InputJSON.texts[jsonKey]` per render.
+ *
+ * Validation runs on blur (commits to the store on focus-out). The
+ * inline-error UI only flags shape problems — empty strings revert the
+ * field to None rather than persisting an invalid value.
+ */
+interface Props {
+  field: FieldDefinition
+}
+
+type Mode = 'none' | 'static' | 'dynamic'
+
+function modeOf(link: Hyperlink | undefined): Mode {
+  if (!link) return 'none'
+  return link.mode
+}
+
+export function HyperlinkSection({ field }: Props) {
+  const updateField = useTemplateStore((s) => s.updateField)
+  const link = field.hyperlink
+  const mode = modeOf(link)
+
+  const initialUrl = link?.mode === 'static' ? link.url : ''
+  const initialKey = link?.mode === 'dynamic' ? link.jsonKey : ''
+  const [urlDraft, setUrlDraft] = useState(initialUrl)
+  const [keyDraft, setKeyDraft] = useState(initialKey)
+  const [error, setError] = useState<string | null>(null)
+
+  function setMode(next: Mode) {
+    setError(null)
+    if (next === 'none') {
+      updateField(field.id, { hyperlink: undefined })
+      setUrlDraft('')
+      setKeyDraft('')
+      return
+    }
+    if (next === 'static') {
+      updateField(field.id, { hyperlink: { mode: 'static', url: '' } })
+      setUrlDraft('')
+      return
+    }
+    updateField(field.id, { hyperlink: { mode: 'dynamic', jsonKey: '' } })
+    setKeyDraft('')
+  }
+
+  function commitStaticUrl() {
+    const trimmed = urlDraft.trim()
+    if (trimmed.length === 0) {
+      // Empty → drop the link entirely. The pinned mode flips back to
+      // 'static' with empty URL on the next focus, which is benign.
+      updateField(field.id, { hyperlink: undefined })
+      setError(null)
+      return
+    }
+    if (!isValidHyperlinkUrl(trimmed)) {
+      setError('Invalid URL — use https, http, mailto, or tel.')
+      return
+    }
+    setError(null)
+    updateField(field.id, { hyperlink: { mode: 'static', url: trimmed } })
+  }
+
+  function commitDynamicKey() {
+    const trimmed = keyDraft.trim()
+    if (trimmed.length === 0) {
+      updateField(field.id, { hyperlink: undefined })
+      setError(null)
+      return
+    }
+    if (!isSafeKey(trimmed)) {
+      setError('Key must match /^[A-Za-z_][A-Za-z0-9_]*$/.')
+      return
+    }
+    setError(null)
+    updateField(field.id, { hyperlink: { mode: 'dynamic', jsonKey: trimmed } })
+  }
+
+  return (
+    <div className="tg-panel-section">
+      <div className="tg-panel-section-title">Link</div>
+
+      <div className="tg-form-row">
+        <label htmlFor={`hyperlink-mode-${field.id}`}>Mode</label>
+        <select
+          id={`hyperlink-mode-${field.id}`}
+          className="tg-select"
+          value={mode}
+          onChange={(e) => setMode(e.target.value as Mode)}
+          data-testid="hyperlink-mode"
+        >
+          <option value="none">None</option>
+          <option value="static">Static URL</option>
+          <option value="dynamic">Dynamic key</option>
+        </select>
+      </div>
+
+      {mode === 'static' && (
+        <div className="tg-form-row">
+          <label htmlFor={`hyperlink-url-${field.id}`}>URL</label>
+          <input
+            id={`hyperlink-url-${field.id}`}
+            className="tg-input"
+            type="text"
+            placeholder="https://example.com"
+            value={urlDraft}
+            onChange={(e) => setUrlDraft(e.target.value)}
+            onBlur={commitStaticUrl}
+            spellCheck={false}
+            data-testid="hyperlink-static-url"
+          />
+        </div>
+      )}
+
+      {mode === 'dynamic' && (
+        <div className="tg-form-row">
+          <label htmlFor={`hyperlink-key-${field.id}`}>JSON key (under texts.)</label>
+          <input
+            id={`hyperlink-key-${field.id}`}
+            className="tg-input"
+            type="text"
+            placeholder="profile_url"
+            value={keyDraft}
+            onChange={(e) => setKeyDraft(e.target.value)}
+            onBlur={commitDynamicKey}
+            spellCheck={false}
+            data-testid="hyperlink-dynamic-key"
+          />
+        </div>
+      )}
+
+      {error && (
+        <div
+          role="alert"
+          data-testid="hyperlink-error"
+          style={{ marginTop: 4, fontSize: 11, color: 'var(--error)' }}
+        >
+          {error}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/ui/src/components/RightPanel/HyperlinkSection.tsx
+++ b/packages/ui/src/components/RightPanel/HyperlinkSection.tsx
@@ -12,7 +12,9 @@ import { useTemplateStore } from '../../store/templateStore.js'
  *                  manifest. Validated end-to-end (https / http / mailto
  *                  / tel only).
  *   - **Dynamic**: `{ mode: 'dynamic', jsonKey }`. URL pulled from
- *                  `InputJSON.texts[jsonKey]` per render.
+ *                  `InputJSON.links[jsonKey]` per render — a separate
+ *                  top-level bucket from `texts` so URLs are visually
+ *                  distinct in the JSON preview.
  *
  * Validation runs on blur (commits to the store on focus-out). The
  * inline-error UI only flags shape problems — empty strings revert the
@@ -127,7 +129,7 @@ export function HyperlinkSection({ field }: Props) {
 
       {mode === 'dynamic' && (
         <div className="tg-form-row">
-          <label htmlFor={`hyperlink-key-${field.id}`}>JSON key (under texts.)</label>
+          <label htmlFor={`hyperlink-key-${field.id}`}>JSON key (under links.)</label>
           <input
             id={`hyperlink-key-${field.id}`}
             className="tg-input"

--- a/packages/ui/src/components/RightPanel/ImageFieldProps.tsx
+++ b/packages/ui/src/components/RightPanel/ImageFieldProps.tsx
@@ -3,6 +3,7 @@ import type { FieldDefinition, ImageField, ImageFieldStyle } from '@template-gob
 import { isSafeKey } from '@template-goblin/types'
 import { useTemplateStore } from '../../store/templateStore.js'
 import { SourceModeToggle } from './SourceModeToggle.js'
+import { HyperlinkSection } from './HyperlinkSection.js'
 
 interface Props {
   field: ImageField
@@ -285,6 +286,7 @@ export function ImageFieldProps({ field }: Props) {
           )}
         </div>
       )}
+      <HyperlinkSection field={field} />
     </>
   )
 }

--- a/packages/ui/src/components/RightPanel/LoopFieldProps.tsx
+++ b/packages/ui/src/components/RightPanel/LoopFieldProps.tsx
@@ -8,6 +8,7 @@ import type {
   FontWeight,
 } from '@template-goblin/types'
 import { isSafeKey } from '@template-goblin/types'
+import { HyperlinkSection } from './HyperlinkSection.js'
 import { useTemplateStore } from '../../store/templateStore.js'
 import { InfoTip } from './TextFieldProps.js'
 import { NumberInput } from '../NumberInput.js'
@@ -547,6 +548,7 @@ export function LoopFieldProps({ field }: Props) {
           </div>
         </div>
       </div>
+      <HyperlinkSection field={field} />
     </>
   )
 }

--- a/packages/ui/src/components/RightPanel/TextFieldProps.tsx
+++ b/packages/ui/src/components/RightPanel/TextFieldProps.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { SourceModeToggle } from './SourceModeToggle.js'
+import { HyperlinkSection } from './HyperlinkSection.js'
 import { NumberInput } from '../NumberInput.js'
 import type {
   FieldDefinition,
@@ -445,6 +446,7 @@ export function TextFieldProps({ field }: Props) {
           />
         </div>
       </div>
+      <HyperlinkSection field={field} />
     </>
   )
 }

--- a/packages/ui/src/utils/__tests__/jsonGenerator.hyperlink.test.ts
+++ b/packages/ui/src/utils/__tests__/jsonGenerator.hyperlink.test.ts
@@ -1,0 +1,242 @@
+/**
+ * UI-side coverage for the JSON-Preview generator's hyperlink branch (#87).
+ *
+ * Dynamic hyperlinks contribute to the new top-level `links` bucket so
+ * URLs are visually distinct from rendered text. These tests lock the
+ * contract: the bucket is always present, dynamic hyperlinks land
+ * there, statics never leak in, duplicate keys collapse, and a field
+ * carrying both a source jsonKey and a hyperlink jsonKey populates
+ * both buckets without crossing them over.
+ */
+import { describe, it, expect } from 'vitest'
+import { generateExampleJson } from '../jsonGenerator.js'
+import type {
+  FieldDefinition,
+  Hyperlink,
+  TextFieldStyle,
+  ImageFieldStyle,
+} from '@template-goblin/types'
+
+const TEXT_STYLE: TextFieldStyle = {
+  fontId: null,
+  fontFamily: 'Helvetica',
+  fontSize: 12,
+  fontSizeMin: 8,
+  lineHeight: 1.2,
+  fontWeight: 'normal',
+  fontStyle: 'normal',
+  textDecoration: 'none',
+  color: '#000',
+  align: 'left',
+  verticalAlign: 'top',
+  maxRows: 1,
+  overflowMode: 'truncate',
+  snapToGrid: false,
+}
+
+const IMAGE_STYLE: ImageFieldStyle = { fit: 'contain' }
+
+function dynText(id: string, jsonKey: string, hyperlink?: Hyperlink): FieldDefinition {
+  return {
+    id,
+    type: 'text',
+    groupId: null,
+    pageId: null,
+    label: id,
+    x: 0,
+    y: 0,
+    width: 100,
+    height: 20,
+    zIndex: 0,
+    style: TEXT_STYLE,
+    source: { mode: 'dynamic', jsonKey, required: false, placeholder: null },
+    ...(hyperlink ? { hyperlink } : {}),
+  }
+}
+
+function staticText(id: string, value: string, hyperlink?: Hyperlink): FieldDefinition {
+  return {
+    id,
+    type: 'text',
+    groupId: null,
+    pageId: null,
+    label: id,
+    x: 0,
+    y: 0,
+    width: 100,
+    height: 20,
+    zIndex: 0,
+    style: TEXT_STYLE,
+    source: { mode: 'static', value },
+    ...(hyperlink ? { hyperlink } : {}),
+  }
+}
+
+function staticImage(id: string, hyperlink?: Hyperlink): FieldDefinition {
+  return {
+    id,
+    type: 'image',
+    groupId: null,
+    pageId: null,
+    label: id,
+    x: 0,
+    y: 0,
+    width: 100,
+    height: 100,
+    zIndex: 0,
+    style: IMAGE_STYLE,
+    source: { mode: 'static', value: { filename: 'pic.png' } },
+    ...(hyperlink ? { hyperlink } : {}),
+  }
+}
+
+describe('generateExampleJson — hyperlink (#87)', () => {
+  it('always emits an empty links bucket, even with no fields', () => {
+    const result = generateExampleJson([], 'default', 5)
+    expect(result.links).toEqual({})
+  })
+
+  it('a static-source field with a dynamic hyperlink puts ONLY the URL key in links', () => {
+    const field = staticText('t1', 'Hello', {
+      mode: 'dynamic',
+      jsonKey: 'profile_url',
+    })
+    const result = generateExampleJson([field], 'default', 5)
+    // Static source = no key in `texts`. Hyperlink = key in `links`.
+    expect(result.texts).toEqual({})
+    expect(result.links).toEqual({ profile_url: 'https://example.com' })
+  })
+
+  it('a dynamic-source field with a dynamic hyperlink populates both buckets independently', () => {
+    const field = dynText('t1', 'name', { mode: 'dynamic', jsonKey: 'profile_url' })
+    const result = generateExampleJson([field], 'default', 5)
+    expect(result.texts).toHaveProperty('name')
+    expect(result.links).toEqual({ profile_url: 'https://example.com' })
+  })
+
+  it('a STATIC hyperlink contributes nothing to links (URL is baked into the manifest)', () => {
+    const field = staticText('t1', 'Hi', { mode: 'static', url: 'https://baked.example.com' })
+    const result = generateExampleJson([field], 'default', 5)
+    expect(result.links).toEqual({})
+  })
+
+  it('multiple fields with the same dynamic hyperlink jsonKey collapse to one entry', () => {
+    const fields: FieldDefinition[] = [
+      dynText('t1', 'a', { mode: 'dynamic', jsonKey: 'shared' }),
+      dynText('t2', 'b', { mode: 'dynamic', jsonKey: 'shared' }),
+      staticImage('img', { mode: 'dynamic', jsonKey: 'shared' }),
+    ]
+    const result = generateExampleJson(fields, 'default', 5)
+    expect(Object.keys(result.links)).toEqual(['shared'])
+  })
+
+  it('mixed static + dynamic hyperlinks: only the dynamic one shows up in links', () => {
+    const fields: FieldDefinition[] = [
+      dynText('t1', 'a', { mode: 'static', url: 'https://baked.example.com' }),
+      dynText('t2', 'b', { mode: 'dynamic', jsonKey: 'dynamic_url' }),
+    ]
+    const result = generateExampleJson(fields, 'default', 5)
+    expect(result.links).toEqual({ dynamic_url: 'https://example.com' })
+  })
+
+  it('a hyperlink with an empty jsonKey is ignored', () => {
+    const field = dynText('t1', 'a', { mode: 'dynamic', jsonKey: '' })
+    const result = generateExampleJson([field], 'default', 5)
+    expect(result.links).toEqual({})
+  })
+
+  it('hyperlink jsonKey identical to the source jsonKey: links wins its own bucket; texts is unaffected', () => {
+    // Designer writes both `name` (text source) and `name` (hyperlink
+    // key). Each lives in its own bucket — no clash.
+    const field = dynText('t1', 'name', { mode: 'dynamic', jsonKey: 'name' })
+    const result = generateExampleJson([field], 'default', 5)
+    expect(result.texts).toHaveProperty('name')
+    expect(result.links).toHaveProperty('name')
+    // Different default values: text gets the synthetic 'A' / '' /
+    // placeholder, link gets the example URL.
+    expect(result.links.name).toBe('https://example.com')
+  })
+
+  it('max mode: links bucket still emits the example URL (no special max value)', () => {
+    const field = dynText('t1', 'a', { mode: 'dynamic', jsonKey: 'profile_url' })
+    const result = generateExampleJson([field], 'max', 5)
+    expect(result.links).toEqual({ profile_url: 'https://example.com' })
+  })
+
+  it('a field with no hyperlink contributes nothing to links', () => {
+    const field = dynText('t1', 'a')
+    const result = generateExampleJson([field], 'default', 5)
+    expect(result.links).toEqual({})
+  })
+
+  it('all three field types can carry a dynamic hyperlink', () => {
+    const fields: FieldDefinition[] = [
+      dynText('t1', 'a', { mode: 'dynamic', jsonKey: 'text_link' }),
+      staticImage('img', { mode: 'dynamic', jsonKey: 'image_link' }),
+      {
+        id: 'tbl',
+        type: 'table',
+        groupId: null,
+        pageId: null,
+        label: 'tbl',
+        x: 0,
+        y: 0,
+        width: 200,
+        height: 100,
+        zIndex: 0,
+        style: {
+          maxRows: 5,
+          maxColumns: 2,
+          multiPage: false,
+          showHeader: true,
+          headerStyle: {
+            fontFamily: 'Helvetica',
+            fontSize: 10,
+            fontWeight: 'bold',
+            fontStyle: 'normal',
+            textDecoration: 'none',
+            color: '#000',
+            backgroundColor: '#eee',
+            borderWidth: 1,
+            borderColor: '#ccc',
+            paddingTop: 2,
+            paddingBottom: 2,
+            paddingLeft: 4,
+            paddingRight: 4,
+            align: 'left',
+            verticalAlign: 'top',
+          },
+          rowStyle: {
+            fontFamily: 'Helvetica',
+            fontSize: 10,
+            fontWeight: 'normal',
+            fontStyle: 'normal',
+            textDecoration: 'none',
+            color: '#000',
+            backgroundColor: '#fff',
+            borderWidth: 1,
+            borderColor: '#ccc',
+            paddingTop: 2,
+            paddingBottom: 2,
+            paddingLeft: 4,
+            paddingRight: 4,
+            align: 'left',
+            verticalAlign: 'top',
+          },
+          oddRowStyle: null,
+          evenRowStyle: null,
+          cellStyle: { overflowMode: 'truncate' },
+          columns: [{ key: 'a', label: 'A', width: 100, style: null, headerStyle: null }],
+        },
+        source: { mode: 'static', value: [{ a: 'x' }] },
+        hyperlink: { mode: 'dynamic', jsonKey: 'table_link' },
+      },
+    ]
+    const result = generateExampleJson(fields, 'default', 5)
+    expect(result.links).toEqual({
+      text_link: 'https://example.com',
+      image_link: 'https://example.com',
+      table_link: 'https://example.com',
+    })
+  })
+})

--- a/packages/ui/src/utils/__tests__/jsonGenerator.static.test.ts
+++ b/packages/ui/src/utils/__tests__/jsonGenerator.static.test.ts
@@ -194,17 +194,17 @@ function dynamicTable(jsonKey: string): FieldDefinition {
 describe('generateExampleJson — static fields excluded', () => {
   it('template with only static text produces empty texts/images/tables', () => {
     const result = generateExampleJson([staticText('Hello')], 'default', 5)
-    expect(result).toEqual({ texts: {}, images: {}, tables: {} })
+    expect(result).toEqual({ texts: {}, images: {}, tables: {}, links: {} })
   })
 
   it('template with only static image produces empty', () => {
     const result = generateExampleJson([staticImage('logo.png')], 'default', 5)
-    expect(result).toEqual({ texts: {}, images: {}, tables: {} })
+    expect(result).toEqual({ texts: {}, images: {}, tables: {}, links: {} })
   })
 
   it('template with only static table produces empty', () => {
     const result = generateExampleJson([staticTable([{ c1: 'v' }])], 'default', 5)
-    expect(result).toEqual({ texts: {}, images: {}, tables: {} })
+    expect(result).toEqual({ texts: {}, images: {}, tables: {}, links: {} })
   })
 
   it('mixed static + dynamic: only dynamic keys appear', () => {

--- a/packages/ui/src/utils/__tests__/jsonGenerator.test.ts
+++ b/packages/ui/src/utils/__tests__/jsonGenerator.test.ts
@@ -226,12 +226,12 @@ describe('generateExampleJson', () => {
   describe('edge cases', () => {
     it('handles empty fields array', () => {
       const result = generateExampleJson([], 'default', 5)
-      expect(result).toEqual({ texts: {}, tables: {}, images: {} })
+      expect(result).toEqual({ texts: {}, tables: {}, images: {}, links: {} })
     })
 
     it('handles empty fields array in max mode', () => {
       const result = generateExampleJson([], 'max', 5)
-      expect(result).toEqual({ texts: {}, tables: {}, images: {} })
+      expect(result).toEqual({ texts: {}, tables: {}, images: {}, links: {} })
     })
 
     it('skips fields with empty jsonKey', () => {

--- a/packages/ui/src/utils/jsonGenerator.ts
+++ b/packages/ui/src/utils/jsonGenerator.ts
@@ -25,6 +25,12 @@ interface GeneratedJson {
   texts: Record<string, string>
   tables: Record<string, Record<string, string>[]>
   images: Record<string, string | null>
+  /**
+   * Dynamic hyperlink URLs, keyed by `field.hyperlink.jsonKey` (#87).
+   * Lives in its own bucket alongside `texts` so URLs are visually
+   * distinct from rendered text content in the JSON preview.
+   */
+  links: Record<string, string>
 }
 
 /**
@@ -43,6 +49,7 @@ export function generateExampleJson(
     texts: {},
     tables: {},
     images: {},
+    links: {},
   }
 
   for (const field of fields) {
@@ -66,18 +73,17 @@ export function generateExampleJson(
         }
       }
     }
-    // GH #87 — dynamic hyperlinks contribute their own jsonKey to
-    // `texts`, regardless of what the field's primary source is. Without
-    // this, a field with `hyperlink: { mode: 'dynamic', jsonKey: ... }`
-    // would never appear in the JSON preview, so the user would think
-    // the link "did nothing".
+    // GH #87 — dynamic hyperlinks contribute their own jsonKey to the
+    // dedicated `links` bucket so URLs render as a visually distinct
+    // section, not mixed in with rendered text content. Multiple fields
+    // with the same hyperlink key collapse to one entry.
     if (
       field.hyperlink &&
       field.hyperlink.mode === 'dynamic' &&
       field.hyperlink.jsonKey &&
-      result.texts[field.hyperlink.jsonKey] === undefined
+      result.links[field.hyperlink.jsonKey] === undefined
     ) {
-      result.texts[field.hyperlink.jsonKey] = getHyperlinkValue(mode)
+      result.links[field.hyperlink.jsonKey] = getHyperlinkValue(mode)
     }
   }
 

--- a/packages/ui/src/utils/jsonGenerator.ts
+++ b/packages/ui/src/utils/jsonGenerator.ts
@@ -48,29 +48,50 @@ export function generateExampleJson(
   for (const field of fields) {
     // Defence in depth: skip fields missing `source` (corrupt rehydrated state).
     if (!field.source) continue
-    // Static fields don't appear in InputJSON — skip them
-    if (field.source.mode !== 'dynamic') continue
-    const name = field.source.jsonKey
-    const required = field.source.required
-    const placeholder = field.source.placeholder
-    if (!name) continue
-
-    switch (field.type) {
-      case 'text':
-        result.texts[name] = getTextValue(mode, required, repeatCount, placeholder)
-        break
-
-      case 'image':
-        result.images[name] = getImageValue(mode, required, placeholder)
-        break
-
-      case 'table':
-        result.tables[name] = getTableValue(field, mode, required, repeatCount, placeholder)
-        break
+    if (field.source.mode === 'dynamic') {
+      const name = field.source.jsonKey
+      const required = field.source.required
+      const placeholder = field.source.placeholder
+      if (name) {
+        switch (field.type) {
+          case 'text':
+            result.texts[name] = getTextValue(mode, required, repeatCount, placeholder)
+            break
+          case 'image':
+            result.images[name] = getImageValue(mode, required, placeholder)
+            break
+          case 'table':
+            result.tables[name] = getTableValue(field, mode, required, repeatCount, placeholder)
+            break
+        }
+      }
+    }
+    // GH #87 — dynamic hyperlinks contribute their own jsonKey to
+    // `texts`, regardless of what the field's primary source is. Without
+    // this, a field with `hyperlink: { mode: 'dynamic', jsonKey: ... }`
+    // would never appear in the JSON preview, so the user would think
+    // the link "did nothing".
+    if (
+      field.hyperlink &&
+      field.hyperlink.mode === 'dynamic' &&
+      field.hyperlink.jsonKey &&
+      result.texts[field.hyperlink.jsonKey] === undefined
+    ) {
+      result.texts[field.hyperlink.jsonKey] = getHyperlinkValue(mode)
     }
   }
 
   return result
+}
+
+/**
+ * Sample value for a dynamic hyperlink jsonKey shown in the JSON preview.
+ * Default mode uses a recognisable example URL so the user can see the
+ * key is wired up and replace it with a real one. Max mode emits the
+ * same — there's no useful "max" variant for a URL string.
+ */
+function getHyperlinkValue(_mode: JsonPreviewMode): string {
+  return 'https://example.com'
 }
 
 function getTextValue(


### PR DESCRIPTION
## Summary
Designers can attach a URL to any text, image, or table field via a new "Link" section in the Properties panel. Two flavours:

- **Static**: literal URL pinned in the manifest.
- **Dynamic**: `links[jsonKey]` lookup resolved per render so the URL can vary across runs.

Allowed protocols: \`https\`, \`http\`, \`mailto\`, \`tel\`. Anything else is rejected as \`INVALID_DATA_TYPE\` with field context. Empty / missing dynamic values render the field with no clickable region (no error). For tables, the link covers the whole table's bounding rect — there is no per-row or per-column variant in v1.

## Schema additions (major bump)
- \`FieldBase.hyperlink?: Hyperlink\` — optional on every field.
- \`InputJSON.links?: LinkInputs\` — new top-level bucket so URLs are visually distinct in the JSON preview rather than mixed into \`texts\`.
- New \`Hyperlink\` discriminated union exported from \`@template-goblin/types\`.
- New helpers: \`isValidHyperlinkUrl\`, \`isStaticHyperlink\`, \`isDynamicHyperlink\`.

## Files touched
- **types**: \`hyperlink.ts\`, \`template.ts\`, \`input.ts\`, \`index.ts\`
- **core**: \`validate.ts\`, \`validateManifest.ts\`, \`render/field.ts\`
- **ui**: \`HyperlinkSection.tsx\` (shared section slotted into Text/Image/Loop props), \`PreviewDialog.tsx\` (carries \`links\` through to \`generatePDF\`), \`previewDialogHelpers.ts\` (parses \`links\`), \`jsonGenerator.ts\` (emits \`links\` bucket)
- **CLAUDE.md**: Hard Rule #19 updated — clarify-questions must spell options out, silly questions banned

## Test counts
- core: 387 (+45 hyperlink edge cases across \`isValidHyperlinkUrl\`, \`validateManifest\`, \`validateData\`, \`render/field\`)
- ui: 421 (+17 across \`jsonGenerator.hyperlink\` + \`previewDialogHelpers\` \`links\` parsing)

## Test plan
- [x] \`pnpm type-check\` clean
- [x] \`pnpm lint\` clean
- [x] \`pnpm --filter template-goblin test\` — 33 suites, 387 tests pass
- [x] \`pnpm --filter template-goblin-ui test\` — 28 files, 421 tests pass
- [x] User confirmed in dev: dynamic link in JSON preview now shows under \`links\`, rendered preview produces clickable annotation in PDF byte stream

## Out of scope (deferred)
- Per-cell or per-column links inside tables.
- Anchor links inside the same PDF (\`#named-dest\`).
- Click-tracking / analytics wrappers — designer's own concern.
- Canvas adornment showing which fields are linked — UI-only follow-up.