### PR TITLE
ci(publish): stage repo README into each package before npm publish

### DIFF
--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -89,6 +89,13 @@ jobs:
       - name: Build types
         run: pnpm --filter @template-goblin/types build
 
+      # Copy the repo-root README into the package so npm shows it on the
+      # package page. The README is shared verbatim across all three
+      # published packages; per-package READMEs would drift. Done at
+      # publish time only so the working tree stays clean.
+      - name: Stage README for npm
+        run: cp README.md packages/types/README.md
+
       - name: Publish @template-goblin/types
         run: pnpm --filter @template-goblin/types publish --no-git-checks --access public || true
         env:
@@ -130,6 +137,9 @@ jobs:
       - name: Build all
         run: pnpm build
 
+      - name: Stage README for npm
+        run: cp README.md packages/core/README.md
+
       - name: Publish template-goblin
         run: pnpm --filter template-goblin publish --no-git-checks --access public || true
         env:
@@ -170,6 +180,9 @@ jobs:
 
       - name: Build all
         run: pnpm build
+
+      - name: Stage README for npm
+        run: cp README.md packages/ui/README.md
 
       - name: Publish template-goblin-ui
         run: pnpm --filter template-goblin-ui publish --no-git-checks --access public || true


### PR DESCRIPTION
npm shows the README from the published tarball; previously every template-goblin package landed on npm with no description because packages/{types,core,ui} have no README.md of their own. Per-package READMEs would drift out of sync — the repo-root README is the single source of truth.

Each publish job now copies README.md into its target package right before `pnpm publish`. Done in CI so the working tree stays clean (no committed copies, no .gitignore games) and the contents go out in the tarball alongside the package.json npm auto-includes.

Future v2.0.x / v2.1+ tags will land on npm with the README visible. v2.0.0 is already shipped without it — re-tag or workflow_dispatch with a patch bump if you want to back-fill.