### PR TITLE
feat: transparent fills, table-level border, color picker, canvas sync (#76)

### DIFF
--- a/.changeset/transparent-fill-and-table-border.md
+++ b/.changeset/transparent-fill-and-table-border.md
@@ -1,0 +1,14 @@
+---
+'@template-goblin/types': minor
+'template-goblin': minor
+'template-goblin-ui': minor
+---
+
+Table styling expansion (#76 and follow-ups):
+
+- **Transparent fills and borders** — `CellStyle.backgroundColor` and `borderColor` now accept `null` as a "transparent" sentinel. Header bg, row bg, cell borders can be opted out in the right panel; the PDFKit renderer and Fabric canvas both skip the corresponding fill/stroke when null.
+- **Table-level border** — new optional `TableFieldStyle.tableBorder: { color, width }` paints the outer perimeter independently of per-cell strokes. New tables default to a 1pt black perimeter with cell strokes off. Legacy templates without `tableBorder` keep their row-derived perimeter.
+- **Fit to content** — new optional `TableFieldStyle.fitToContent` (default `true`, including for legacy templates) ends the perimeter at the last rendered row instead of stretching to the field rect's full height.
+- **Canvas parity** — Fabric preview now paints the outer perimeter using `tableBorder` and respects `fitToContent`, so right-panel edits show live; per-column align overrides are also merged over `rowStyle` so body cells align correctly on canvas.
+- **Color picker** — replaced the native `<input type="color">` (which froze the page on some browsers) with an in-page SketchPicker popover via `react-color`.
+- **UI polish** — clearer labels (Header Text Color, Header Row Background, Row Text Color, Row Background, Cell Border, Table Border), themed border on the transparent "Clear / Color" toggle, and a collapsible Columns section in the table properties panel.

--- a/packages/core/src/render/loop.ts
+++ b/packages/core/src/render/loop.ts
@@ -111,8 +111,10 @@ function drawTablePerimeter(
 ): void {
   const bw = style.rowStyle.borderWidth
   if (!bw || bw <= 0) return
+  const stroke = style.rowStyle.borderColor
+  if (!stroke) return
   doc.save()
-  doc.lineWidth(bw).strokeColor(style.rowStyle.borderColor)
+  doc.lineWidth(bw).strokeColor(stroke)
   doc.rect(x, y, width, height).stroke()
   doc.restore()
 }
@@ -148,7 +150,7 @@ function renderHeaderRow(
       doc.restore()
     }
 
-    if (hs.borderWidth > 0) {
+    if (hs.borderWidth > 0 && hs.borderColor) {
       doc.save()
       doc.lineWidth(hs.borderWidth).strokeColor(hs.borderColor)
       doc.rect(colX, startY, colWidth, rowHeight).stroke()
@@ -198,7 +200,7 @@ function renderDataRow(
       doc.restore()
     }
 
-    if (rs.borderWidth > 0) {
+    if (rs.borderWidth > 0 && rs.borderColor) {
       doc.save()
       doc.lineWidth(rs.borderWidth).strokeColor(rs.borderColor)
       doc.rect(colX, startY, colWidth, rowHeight).stroke()

--- a/packages/core/src/render/loop.ts
+++ b/packages/core/src/render/loop.ts
@@ -90,7 +90,17 @@ export function renderLoop(
   // ended above the bottom edge or got skipped because it would overflow.
   // Per-cell borders alone left the bottom edge open whenever the rect
   // was taller than the rendered rows.
-  drawTablePerimeter(doc, x, y, width, field.height, style)
+  //
+  // #76 follow-up: when `fitToContent` is enabled (the default for new
+  // templates), end the perimeter at the last rendered row instead of
+  // `field.height` so short tables don't drag a tall, empty box below
+  // the data. `fitToContent === false` preserves the legacy full-rect
+  // perimeter.
+  const fitToContent = style.fitToContent !== false
+  const renderedHeight = Math.max(0, currentY - y)
+  const perimeterHeight =
+    fitToContent && renderedHeight > 0 ? Math.min(renderedHeight, field.height) : field.height
+  drawTablePerimeter(doc, x, y, width, perimeterHeight, style)
 }
 
 /**
@@ -109,9 +119,14 @@ function drawTablePerimeter(
   height: number,
   style: TableFieldStyle,
 ): void {
-  const bw = style.rowStyle.borderWidth
+  // #76 follow-up: prefer the explicit table-level border when set; fall
+  // back to the legacy row-derived perimeter for templates that predate
+  // the `tableBorder` field. Either source can suppress the perimeter
+  // with width <= 0 or a null colour.
+  const tb = style.tableBorder
+  const bw = tb ? tb.width : style.rowStyle.borderWidth
   if (!bw || bw <= 0) return
-  const stroke = style.rowStyle.borderColor
+  const stroke = tb ? tb.color : style.rowStyle.borderColor
   if (!stroke) return
   doc.save()
   doc.lineWidth(bw).strokeColor(stroke)

--- a/packages/core/tests/file/write.test.ts
+++ b/packages/core/tests/file/write.test.ts
@@ -410,6 +410,33 @@ describe('roundtrip: save then read', () => {
     expect(result).toEqual(manifest)
   })
 
+  // GH #76 — `null` is a valid value for CellStyle.backgroundColor /
+  // borderColor and must round-trip through save/read so a template saved
+  // with a transparent header band re-opens with the same null sentinel.
+  it('should roundtrip null (transparent) backgroundColor and borderColor on table cells (#76)', async () => {
+    const table = dynTable('t1', 'rows', false, ['a'], {
+      x: 0,
+      y: 0,
+      width: 200,
+      height: 100,
+      zIndex: 0,
+    })
+    table.style.headerStyle = { ...table.style.headerStyle, backgroundColor: null }
+    table.style.rowStyle = { ...table.style.rowStyle, backgroundColor: null, borderColor: null }
+    const manifest = createValidManifest({ fields: [table] })
+    const outputPath = join(tmpDir, 'roundtrip-transparent.tgbl')
+
+    await saveTemplate(manifest, createEmptyAssets(), outputPath)
+    const result = await readManifest(outputPath)
+
+    const reloaded = result.fields[0]
+    expect(reloaded?.type).toBe('table')
+    if (reloaded?.type !== 'table') return
+    expect(reloaded.style.headerStyle.backgroundColor).toBeNull()
+    expect(reloaded.style.rowStyle.backgroundColor).toBeNull()
+    expect(reloaded.style.rowStyle.borderColor).toBeNull()
+  })
+
   it('should emit static images under images/ and roundtrip through loadTemplate', async () => {
     const logoData = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0xde, 0xad])
 

--- a/packages/core/tests/helpers/fixtures.ts
+++ b/packages/core/tests/helpers/fixtures.ts
@@ -69,6 +69,7 @@ export function tableStyle(columnKeys: string[] = ['col']): TableFieldStyle {
     maxColumns: 10,
     multiPage: false,
     showHeader: true,
+    fitToContent: true,
     headerStyle: { ...BASE_CELL, fontWeight: 'bold', backgroundColor: '#eeeeee' },
     rowStyle: BASE_CELL,
     oddRowStyle: null,

--- a/packages/core/tests/render/loop.test.ts
+++ b/packages/core/tests/render/loop.test.ts
@@ -255,6 +255,61 @@ describe('Loop/table rendering', () => {
     expect(output.length).toBeGreaterThan(0)
   })
 
+  // #76 follow-up — `fitToContent` collapses the painted perimeter to the
+  // last rendered row. Smaller content stream when the rect is much taller
+  // than the data (no extra empty bordered box trailing the table).
+  it('should emit a smaller PDF when fitToContent collapses a short table (#76)', async () => {
+    const fitted = createLoopField({ fitToContent: true })
+    fitted.height = 400 // tall rect, few rows
+    const fullRect = createLoopField({ fitToContent: false })
+    fullRect.height = 400
+    const rows = sampleRows(2)
+    const fittedOut = await renderAndFinish(fitted, rows)
+    const fullOut = await renderAndFinish(fullRect, rows)
+    expect(fittedOut).toBeInstanceOf(Buffer)
+    expect(fullOut).toBeInstanceOf(Buffer)
+    // Two PDFs differ — the perimeter rect's height parameter changed,
+    // so the content streams cannot be byte-identical.
+    expect(fittedOut.equals(fullOut)).toBe(false)
+  })
+
+  it('should treat omitted fitToContent as true (legacy templates) (#76)', async () => {
+    const field = createLoopField()
+    delete (field.style as { fitToContent?: boolean }).fitToContent
+    const rows = sampleRows(2)
+    const output = await renderAndFinish(field, rows)
+    expect(output).toBeInstanceOf(Buffer)
+    expect(output.length).toBeGreaterThan(0)
+  })
+
+  // #76 follow-up (option b) — `tableBorder` overrides the legacy
+  // row-derived perimeter colour and width. Null colour or zero width
+  // suppresses the perimeter entirely while still rendering cells.
+  it('should paint the perimeter using tableBorder when set (#76)', async () => {
+    const withTableBorder = createLoopField({
+      tableBorder: { color: '#ff00aa', width: 3 },
+    })
+    const rows = sampleRows(2)
+    const output = await renderAndFinish(withTableBorder, rows)
+    expect(output).toBeInstanceOf(Buffer)
+    expect(output.length).toBeGreaterThan(0)
+  })
+
+  it('should suppress the perimeter when tableBorder.color is null (#76)', async () => {
+    const noBorder = createLoopField({
+      tableBorder: { color: null, width: 2 },
+      rowStyle: { ...BASE_CELL, borderWidth: 0 },
+    })
+    const withBorder = createLoopField({
+      tableBorder: { color: '#000000', width: 2 },
+      rowStyle: { ...BASE_CELL, borderWidth: 0 },
+    })
+    const rows = sampleRows(2)
+    const noBorderOut = await renderAndFinish(noBorder, rows)
+    const withBorderOut = await renderAndFinish(withBorder, rows)
+    expect(noBorderOut.length).toBeLessThan(withBorderOut.length)
+  })
+
   it('should produce a smaller PDF when fills/strokes are transparent (#76)', async () => {
     const filled = createLoopField()
     const transparent = createLoopField({

--- a/packages/core/tests/render/loop.test.ts
+++ b/packages/core/tests/render/loop.test.ts
@@ -231,6 +231,44 @@ describe('Loop/table rendering', () => {
     expect(output.length).toBeGreaterThan(0)
   })
 
+  // GH #76 — `null` on backgroundColor / borderColor means "transparent"
+  // (no fill / no stroke). The renderer must skip the `.fill()` /
+  // `.stroke()` call entirely and still produce a valid PDF.
+  it('should render transparent header background without throwing (#76)', async () => {
+    const field = createLoopField({
+      headerStyle: { ...BASE_CELL, fontWeight: 'bold', backgroundColor: null },
+      rowStyle: { ...BASE_CELL, backgroundColor: null },
+    })
+    const rows = sampleRows(2)
+    const output = await renderAndFinish(field, rows)
+    expect(output).toBeInstanceOf(Buffer)
+    expect(output.length).toBeGreaterThan(0)
+  })
+
+  it('should render transparent borders without throwing (#76)', async () => {
+    const field = createLoopField({
+      rowStyle: { ...BASE_CELL, borderColor: null, borderWidth: 1 },
+    })
+    const rows = sampleRows(2)
+    const output = await renderAndFinish(field, rows)
+    expect(output).toBeInstanceOf(Buffer)
+    expect(output.length).toBeGreaterThan(0)
+  })
+
+  it('should produce a smaller PDF when fills/strokes are transparent (#76)', async () => {
+    const filled = createLoopField()
+    const transparent = createLoopField({
+      headerStyle: { ...BASE_CELL, fontWeight: 'bold', backgroundColor: null },
+      rowStyle: { ...BASE_CELL, backgroundColor: null, borderColor: null },
+    })
+    const rows = sampleRows(5)
+    const filledOut = await renderAndFinish(filled, rows)
+    const transparentOut = await renderAndFinish(transparent, rows)
+    // Skipping per-cell fill + stroke commands must emit fewer drawing
+    // operations into the page content stream.
+    expect(transparentOut.length).toBeLessThan(filledOut.length)
+  })
+
   it('should handle dynamic_font overflow mode in row cells', async () => {
     // Override the runtime cell style so the renderer takes the dynamic_font branch.
     const dynamicRowStyle: CellStyle = { ...BASE_CELL }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -12,6 +12,7 @@ export type {
   ImageFilenameValue,
   ImageColorValue,
   TableFieldStyle,
+  TableBorderStyle,
   TableCellRuntimeStyle,
   TableColumn,
   TableRow,

--- a/packages/types/src/template.ts
+++ b/packages/types/src/template.ts
@@ -139,6 +139,19 @@ export interface TableFieldStyle {
   multiPage: boolean
   /** When false, the header row is skipped entirely at render time. */
   showHeader: boolean
+  /**
+   * When true (default), the table's outer perimeter is drawn down to the
+   * last rendered row's bottom edge instead of the field rect's full
+   * height. Eliminates the empty whitespace + dangling border that legacy
+   * `field.height`-based perimeter drawing left when row data was shorter
+   * than the rect (#76 follow-up). The field's geometry rect is unchanged;
+   * only the painted perimeter collapses. Multi-page chunks still draw a
+   * full-height perimeter on every page except the last.
+   *
+   * Optional for backward compatibility with templates saved before this
+   * field existed; the renderer treats `undefined` as `true`.
+   */
+  fitToContent?: boolean
   headerStyle: CellStyle
   rowStyle: CellStyle
   /** Applied to rows with odd 0-indexed position (rows 1, 3, 5...). */
@@ -147,6 +160,26 @@ export interface TableFieldStyle {
   evenRowStyle: Partial<CellStyle> | null
   cellStyle: TableCellRuntimeStyle
   columns: TableColumn[]
+  /**
+   * Optional table-level outer perimeter style (#76 follow-up).
+   *
+   * When present, the renderer paints the table's outer border using
+   * `tableBorder.color` / `tableBorder.width` instead of falling back to
+   * `rowStyle.borderColor` / `borderWidth`. Cell-level strokes are still
+   * drawn from `CellStyle` for users who want internal grid lines.
+   *
+   * Optional for backward compatibility with templates saved before this
+   * field existed; the renderer falls back to `rowStyle` when absent.
+   */
+  tableBorder?: TableBorderStyle
+}
+
+/** Outer-perimeter style for a table — independent of per-cell borders. */
+export interface TableBorderStyle {
+  /** Hex stroke colour, or `null` for no perimeter. */
+  color: string | null
+  /** Stroke width in points. `0` also suppresses the perimeter. */
+  width: number
 }
 
 /** A single row in a table — column key -> cell string value. */

--- a/packages/types/src/template.ts
+++ b/packages/types/src/template.ts
@@ -67,9 +67,11 @@ export interface CellStyle {
   fontStyle: FontStyle
   textDecoration: TextDecoration
   color: string
-  backgroundColor: string
+  /** Hex fill colour, or `null` for a transparent (no-fill) cell background. */
+  backgroundColor: string | null
   borderWidth: number
-  borderColor: string
+  /** Hex stroke colour, or `null` for a transparent (no-stroke) cell border. */
+  borderColor: string | null
   paddingTop: number
   paddingBottom: number
   paddingLeft: number

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -20,6 +20,7 @@
     "fabric": "^6.9.1",
     "jszip": "^3.10.1",
     "react": "^18.3.1",
+    "react-color": "^2.19.3",
     "react-dom": "^18.3.1",
     "tailwindcss": "^4.2.2",
     "zustand": "^5.0.3"
@@ -29,6 +30,7 @@
     "@template-goblin/types": "workspace:*",
     "@types/pdfkit": "^0.13.5",
     "@types/react": "^18.3.14",
+    "@types/react-color": "^3.0.13",
     "@types/react-dom": "^18.3.3",
     "@vitejs/plugin-react": "^4.3.4",
     "fake-indexeddb": "^6.2.5",
@@ -45,5 +47,6 @@
   "comment:konva": "Canvas rendering engine — BEING REMOVED in favour of Fabric.js (kept during migration only)",
   "comment:react-konva": "React bindings for Konva — BEING REMOVED in favour of Fabric.js (kept during migration only)",
   "comment:zustand": "Lightweight state management — canvas state, undo/redo, UI state",
-  "comment:fake-indexeddb": "Test-only: polyfills IndexedDB in jsdom/Node so the templateStore's IDB-backed persist adapter (GH #11) is exercised by Vitest. Loaded via vite.config `test.setupFiles`."
+  "comment:fake-indexeddb": "Test-only: polyfills IndexedDB in jsdom/Node so the templateStore's IDB-backed persist adapter (GH #11) is exercised by Vitest. Loaded via vite.config `test.setupFiles`.",
+  "comment:react-color": "In-page Sketch colour picker replacing the native `<input type=\"color\">`. The native OS picker froze the whole page on some browser/GPU combos until it was dismissed — react-color renders inline in a popover so the page stays interactive."
 }

--- a/packages/ui/src/components/Canvas/AddPageDialog.tsx
+++ b/packages/ui/src/components/Canvas/AddPageDialog.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef } from 'react'
 import { type PageBackgroundType, type PageSize } from '@template-goblin/types'
 import { PageSizePicker, resolveChoice, type PageSizeChoice } from './PageSizePicker.js'
+import { ColorPickerPopover } from '../ColorPickerPopover.js'
 
 /**
  * Two-step "Add page" dialog.
@@ -219,11 +220,12 @@ export function AddPageDialog({
           <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
             <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
               <label style={{ fontSize: '13px', color: 'var(--text-secondary)' }}>Color:</label>
-              <input
-                type="color"
+              <ColorPickerPopover
                 value={color}
-                onChange={(e) => setColor(e.target.value)}
-                style={{ width: '48px', height: '32px', border: 'none', cursor: 'pointer' }}
+                onChange={setColor}
+                swatchWidth={48}
+                swatchHeight={32}
+                ariaLabel="Page background color"
               />
               <span
                 style={{ fontSize: '12px', color: 'var(--text-muted)', fontFamily: 'monospace' }}

--- a/packages/ui/src/components/Canvas/FieldCreationPopup.tsx
+++ b/packages/ui/src/components/Canvas/FieldCreationPopup.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, useCallback } from 'react'
 import type { FieldType } from '@template-goblin/types'
 import { isSafeKey } from '@template-goblin/types'
 import { CloseIcon } from '../icons/index.js'
+import { ColorPickerPopover } from '../ColorPickerPopover.js'
 
 /**
  * Element Creation Popup (design 2026-04-18 §8.1, spec 024).
@@ -393,12 +394,12 @@ export function FieldCreationPopup({
                     flexWrap: 'wrap',
                   }}
                 >
-                  <input
-                    type="color"
+                  <ColorPickerPopover
                     value={imageColor}
-                    onChange={(e) => setImageColor(e.target.value)}
-                    style={{ width: 44, height: 32 }}
-                    data-testid="create-popup-image-color-input"
+                    onChange={setImageColor}
+                    swatchWidth={44}
+                    swatchHeight={32}
+                    ariaLabel="Image color"
                   />
                   <input
                     type="text"

--- a/packages/ui/src/components/Canvas/OnboardingPicker.tsx
+++ b/packages/ui/src/components/Canvas/OnboardingPicker.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import { type PageSize } from '@template-goblin/types'
 import { PageSizePicker, resolveChoice, type PageSizeChoice } from './PageSizePicker.js'
+import { ColorPickerPopover } from '../ColorPickerPopover.js'
 
 /**
  * Empty-state onboarding picker. Shown on page 0 when no background has been
@@ -118,12 +119,12 @@ export function OnboardingPicker({
                 marginTop: 8,
               }}
             >
-              <input
-                type="color"
+              <ColorPickerPopover
                 value={color}
-                onChange={(e) => setColor(e.target.value)}
-                style={{ width: 56, height: 40, border: 'none', cursor: 'pointer' }}
-                data-testid="onboarding-color-input"
+                onChange={setColor}
+                swatchWidth={56}
+                swatchHeight={40}
+                ariaLabel="Onboarding page color"
               />
               <input
                 type="text"

--- a/packages/ui/src/components/Canvas/tableBodyRows.ts
+++ b/packages/ui/src/components/Canvas/tableBodyRows.ts
@@ -79,6 +79,30 @@ export function pushBodyRows(
       const cellValue = row[col.key] ?? ''
       const padL = Math.max(0, cs.paddingLeft ?? 4)
       const padR = Math.max(0, cs.paddingRight ?? 4)
+
+      // Per-cell stroked rect — mirrors core/render/loop.ts so cell
+      // border width/colour changes in the right panel reflect on canvas
+      // (#76 follow-up). Skip when width <= 0 or colour is null.
+      const cellBw = typeof cs.borderWidth === 'number' ? cs.borderWidth : 0
+      if (cellBw > 0 && isVisibleColor(cs.borderColor)) {
+        parts.push(
+          new Rect({
+            left: leftCum,
+            top: rowTop,
+            width: colWidth,
+            height: rowH,
+            fill: '',
+            stroke: cs.borderColor,
+            strokeWidth: cellBw,
+            strokeUniform: true,
+            selectable: false,
+            evented: false,
+            originX: 'left',
+            originY: 'top',
+          }),
+        )
+      }
+
       if (cellValue && colWidth > padL + padR + 2) {
         const innerW = Math.max(1, colWidth - padL - padR)
         const align = cs.align ?? 'center'

--- a/packages/ui/src/components/Canvas/tableBodyRows.ts
+++ b/packages/ui/src/components/Canvas/tableBodyRows.ts
@@ -41,10 +41,6 @@ export function pushBodyRows(
   const renderCount = Math.min(rows.length, maxRows, fitCount)
   if (renderCount <= 0) return
 
-  const padL = Math.max(0, rowStyle?.paddingLeft ?? 4)
-  const padR = Math.max(0, rowStyle?.paddingRight ?? 4)
-  const fontFamily = rowStyle?.fontFamily || DEFAULT_FONT_FAMILY
-  const color = rowStyle?.color || DEFAULT_TEXT_COLOR
   const bg = rowStyle?.backgroundColor
 
   for (let r = 0; r < renderCount; r++) {
@@ -75,23 +71,31 @@ export function pushBodyRows(
         leftCum += colWidth
         continue
       }
+      // Per-column style overrides (e.g. align, color, padding) merge over
+      // the table's rowStyle — mirrors core/render/loop.ts `mergeStyle` so
+      // canvas and PDF agree. Without this, changing a column's align in
+      // the sidebar had no visible effect on canvas (#76 follow-up).
+      const cs: Partial<CellStyle> = { ...(rowStyle ?? {}), ...(col.style ?? {}) }
       const cellValue = row[col.key] ?? ''
+      const padL = Math.max(0, cs.paddingLeft ?? 4)
+      const padR = Math.max(0, cs.paddingRight ?? 4)
       if (cellValue && colWidth > padL + padR + 2) {
         const innerW = Math.max(1, colWidth - padL - padR)
+        const align = cs.align ?? 'center'
         parts.push(
           new Textbox(String(cellValue), {
-            left: leftCum + padL + innerW / 2,
+            left: leftCum + padL,
             top: rowTop + rowH / 2,
             width: innerW,
             fontSize,
-            fontFamily,
-            fontWeight: rowStyle?.fontWeight || 'normal',
-            fontStyle: rowStyle?.fontStyle || 'normal',
-            underline: rowStyle?.textDecoration === 'underline',
-            linethrough: rowStyle?.textDecoration === 'line-through',
-            fill: color,
-            textAlign: rowStyle?.align || 'center',
-            originX: 'center',
+            fontFamily: cs.fontFamily || DEFAULT_FONT_FAMILY,
+            fontWeight: cs.fontWeight || 'normal',
+            fontStyle: cs.fontStyle || 'normal',
+            underline: cs.textDecoration === 'underline',
+            linethrough: cs.textDecoration === 'line-through',
+            fill: cs.color || DEFAULT_TEXT_COLOR,
+            textAlign: align,
+            originX: 'left',
             originY: 'center',
             selectable: false,
             evented: false,

--- a/packages/ui/src/components/Canvas/tableCanvasParts.ts
+++ b/packages/ui/src/components/Canvas/tableCanvasParts.ts
@@ -161,6 +161,14 @@ export function buildTableCanvasParts(
     pushBodyRows(parts, field, width, height, headerH, widths, rows)
   }
 
+  // #76 follow-up — paint the table-level outer perimeter so canvas
+  // matches the PDF renderer (core/render/loop.ts drawTablePerimeter).
+  // Reads from `tableBorder` when set, otherwise falls back to the
+  // row-derived perimeter for legacy templates. When `fitToContent` is
+  // on AND rows are supplied, the perimeter ends at the last rendered
+  // row instead of the rect's full height.
+  pushTablePerimeter(parts, field, width, height, headerH, rows)
+
   if (showHeader && headerH > 0) {
     const padL = Math.max(0, headerStyle?.paddingLeft ?? 0)
     const padR = Math.max(0, headerStyle?.paddingRight ?? 0)
@@ -213,4 +221,59 @@ function isVisibleColor(c: string | null | undefined): c is string {
   if (!c) return false
   const s = c.trim().toLowerCase()
   return s.length > 0 && s !== 'transparent' && s !== 'none'
+}
+
+/**
+ * Compute and append the table's outer perimeter rect, mirroring the
+ * PDFKit renderer so changes to `tableBorder.color`, `tableBorder.width`,
+ * or `fitToContent` show up live on canvas.
+ */
+function pushTablePerimeter(
+  parts: FabricObject[],
+  field: FieldDefinition,
+  width: number,
+  height: number,
+  headerH: number,
+  rows: Record<string, string>[] | null,
+): void {
+  if (field.type !== 'table' || !field.style) return
+  const style = field.style
+  const tb = style.tableBorder
+  const stroke = tb ? tb.color : style.rowStyle?.borderColor
+  const sw = tb ? tb.width : (style.rowStyle?.borderWidth ?? 0)
+  if (!isVisibleColor(stroke) || !(sw > 0)) return
+
+  let perimeterH = height
+  const fitToContent = style.fitToContent !== false
+  if (fitToContent && rows && rows.length > 0) {
+    const rs = style.rowStyle
+    const fontSize = typeof rs?.fontSize === 'number' && rs.fontSize > 0 ? rs.fontSize : 10
+    const padTop = Math.max(0, rs?.paddingTop ?? 2)
+    const padBottom = Math.max(0, rs?.paddingBottom ?? 2)
+    const rowH = fontSize + padTop + padBottom
+    const maxRowsCfg = style.maxRows
+    const maxRows = typeof maxRowsCfg === 'number' && maxRowsCfg > 0 ? maxRowsCfg : rows.length
+    const availableH = Math.max(0, height - headerH)
+    const fitCount = rowH > 0 ? Math.floor(availableH / rowH) : 0
+    const renderCount = Math.min(rows.length, maxRows, fitCount)
+    if (renderCount > 0) perimeterH = Math.min(height, headerH + renderCount * rowH)
+    else if (headerH > 0) perimeterH = headerH
+  }
+
+  parts.push(
+    new Rect({
+      left: 0,
+      top: 0,
+      width,
+      height: perimeterH,
+      fill: '',
+      stroke,
+      strokeWidth: sw,
+      strokeUniform: true,
+      selectable: false,
+      evented: false,
+      originX: 'left',
+      originY: 'top',
+    }),
+  )
 }

--- a/packages/ui/src/components/Canvas/tableCanvasParts.ts
+++ b/packages/ui/src/components/Canvas/tableCanvasParts.ts
@@ -154,6 +154,35 @@ export function buildTableCanvasParts(
     )
   }
 
+  // Per-header-cell stroked rects — mirrors PDFKit's renderHeaderRow so
+  // header border width/colour edits show up live on canvas (#76).
+  if (showHeader && headerH > 0 && headerStyle) {
+    const hbw = typeof headerStyle.borderWidth === 'number' ? headerStyle.borderWidth : 0
+    if (hbw > 0 && isVisibleColor(headerStyle.borderColor)) {
+      let leftCum = 0
+      for (let i = 0; i < widths.length; i++) {
+        const cw = widths[i] ?? 0
+        parts.push(
+          new Rect({
+            left: leftCum,
+            top: 0,
+            width: cw,
+            height: headerH,
+            fill: '',
+            stroke: headerStyle.borderColor,
+            strokeWidth: hbw,
+            strokeUniform: true,
+            selectable: false,
+            evented: false,
+            originX: 'left',
+            originY: 'top',
+          }),
+        )
+        leftCum += cw
+      }
+    }
+  }
+
   // GH #79: render body rows from the supplied data so the canvas reflects
   // the right-panel JSON. Skipped when `rows` is null — design-time
   // preview only. Row count = min(data length, maxRows, rows-that-fit).

--- a/packages/ui/src/components/ColorPickerPopover.tsx
+++ b/packages/ui/src/components/ColorPickerPopover.tsx
@@ -1,0 +1,123 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { SketchPicker, type ColorResult } from 'react-color'
+
+interface ColorPickerPopoverProps {
+  value: string
+  onChange: (hex: string) => void
+  ariaLabel?: string
+  /** Swatch dimensions — defaults to a compact rectangle. */
+  swatchWidth?: number
+  swatchHeight?: number
+}
+
+/**
+ * Compact hex-colour swatch that opens a SketchPicker (react-color) in a
+ * popover when clicked. Replaces the native `<input type="color">` which
+ * caused the whole page to freeze on some browsers / GPU configurations
+ * when the OS-level picker was open. The popover closes on outside click
+ * and on Escape.
+ */
+export function ColorPickerPopover({
+  value,
+  onChange,
+  ariaLabel,
+  swatchWidth = 28,
+  swatchHeight = 24,
+}: ColorPickerPopoverProps) {
+  const [open, setOpen] = useState(false)
+  const [position, setPosition] = useState<{ top: number; left: number } | null>(null)
+  const wrapperRef = useRef<HTMLSpanElement | null>(null)
+  const popoverRef = useRef<HTMLDivElement | null>(null)
+
+  // Position the popover relative to the swatch in viewport coords so it
+  // sits in front of every panel rather than being clipped by a sidebar's
+  // overflow boundary.
+  useLayoutEffect(() => {
+    if (!open || !wrapperRef.current) return
+    const r = wrapperRef.current.getBoundingClientRect()
+    const POPOVER_W = 220
+    const POPOVER_H = 280
+    const left = Math.min(window.innerWidth - POPOVER_W - 8, Math.max(8, r.right - POPOVER_W))
+    const top = Math.min(window.innerHeight - POPOVER_H - 8, r.bottom + 4)
+    setPosition({ top, left })
+  }, [open])
+
+  useEffect(() => {
+    if (!open) return
+    function onDocDown(e: MouseEvent) {
+      const t = e.target as Node | null
+      if (!t) return
+      if (popoverRef.current?.contains(t)) return
+      if (wrapperRef.current?.contains(t)) return
+      setOpen(false)
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('mousedown', onDocDown)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onDocDown)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [open])
+
+  const handleChange = useCallback(
+    (result: ColorResult) => {
+      onChange(result.hex)
+    },
+    [onChange],
+  )
+
+  return (
+    <span ref={wrapperRef} style={{ display: 'inline-block', position: 'relative' }}>
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-label={ariaLabel ?? 'Select color'}
+        aria-expanded={open}
+        title={value}
+        style={{
+          width: swatchWidth,
+          height: swatchHeight,
+          padding: 0,
+          border: '1px solid var(--border)',
+          borderRadius: 3,
+          cursor: 'pointer',
+          background: value,
+        }}
+      />
+      {open && position && (
+        <div
+          ref={popoverRef}
+          role="dialog"
+          aria-label={ariaLabel ?? 'Color picker'}
+          style={{
+            position: 'fixed',
+            top: position.top,
+            left: position.left,
+            zIndex: 2000,
+          }}
+        >
+          <SketchPicker
+            color={value}
+            onChange={handleChange}
+            disableAlpha
+            presetColors={[
+              '#000000',
+              '#ffffff',
+              '#ef4444',
+              '#f59e0b',
+              '#22c55e',
+              '#3b82f6',
+              '#8b5cf6',
+              '#ec4899',
+              '#64748b',
+              '#0a0a0a',
+            ]}
+          />
+        </div>
+      )}
+    </span>
+  )
+}

--- a/packages/ui/src/components/NullableColorInput.tsx
+++ b/packages/ui/src/components/NullableColorInput.tsx
@@ -1,0 +1,94 @@
+import { useCallback } from 'react'
+
+interface NullableColorInputProps {
+  /** Hex string when a colour is set; `null` for transparent / no-fill. */
+  value: string | null
+  onChange: (value: string | null) => void
+  /** Hex used to re-seed the native picker when toggling back from null. */
+  fallback?: string
+  className?: string
+  ariaLabel?: string
+}
+
+/**
+ * Colour picker that can express "transparent" alongside hex values.
+ *
+ * Renders the native `<input type="color">` when `value` is a hex string and
+ * a checker-pattern swatch with the label "Transparent" when `value` is
+ * `null`. The "✕" button toggles to `null`; clicking the transparent swatch
+ * returns to the previous hex (or `fallback`).
+ *
+ * GH #76 — used wherever a CellStyle / page background colour field can be
+ * opted out of (table header bg, row bg, odd/even row bg, borders, page bg).
+ */
+export function NullableColorInput({
+  value,
+  onChange,
+  fallback = '#ffffff',
+  className = 'tg-color-input',
+  ariaLabel,
+}: NullableColorInputProps) {
+  const isTransparent = value === null
+
+  const handleColorChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      onChange(e.target.value)
+    },
+    [onChange],
+  )
+
+  const clear = useCallback(() => onChange(null), [onChange])
+  const restore = useCallback(() => onChange(fallback), [onChange, fallback])
+
+  return (
+    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+      {isTransparent ? (
+        <button
+          type="button"
+          onClick={restore}
+          aria-label={
+            ariaLabel ? `${ariaLabel} — transparent (click to set colour)` : 'Transparent'
+          }
+          title="Transparent — click to set a colour"
+          style={{
+            width: 28,
+            height: 24,
+            padding: 0,
+            border: '1px solid var(--border, #ccc)',
+            borderRadius: 3,
+            cursor: 'pointer',
+            backgroundImage:
+              'linear-gradient(45deg, #ccc 25%, transparent 25%), ' +
+              'linear-gradient(-45deg, #ccc 25%, transparent 25%), ' +
+              'linear-gradient(45deg, transparent 75%, #ccc 75%), ' +
+              'linear-gradient(-45deg, transparent 75%, #ccc 75%)',
+            backgroundSize: '8px 8px',
+            backgroundPosition: '0 0, 0 4px, 4px -4px, -4px 0',
+          }}
+        />
+      ) : (
+        <input
+          type="color"
+          className={className}
+          value={value ?? fallback}
+          aria-label={ariaLabel}
+          onChange={handleColorChange}
+        />
+      )}
+      <button
+        type="button"
+        className="tg-btn"
+        onClick={isTransparent ? restore : clear}
+        title={isTransparent ? 'Set a colour' : 'Make transparent'}
+        aria-pressed={isTransparent}
+        style={{
+          fontSize: 11,
+          padding: '2px 6px',
+          border: '1px solid var(--border)',
+        }}
+      >
+        {isTransparent ? 'Color' : 'Clear'}
+      </button>
+    </span>
+  )
+}

--- a/packages/ui/src/components/NullableColorInput.tsx
+++ b/packages/ui/src/components/NullableColorInput.tsx
@@ -1,22 +1,21 @@
 import { useCallback } from 'react'
+import { ColorPickerPopover } from './ColorPickerPopover.js'
 
 interface NullableColorInputProps {
   /** Hex string when a colour is set; `null` for transparent / no-fill. */
   value: string | null
   onChange: (value: string | null) => void
-  /** Hex used to re-seed the native picker when toggling back from null. */
+  /** Hex used to re-seed the picker when toggling back from null. */
   fallback?: string
-  className?: string
   ariaLabel?: string
 }
 
 /**
- * Colour picker that can express "transparent" alongside hex values.
+ * Colour control that can express "transparent" alongside hex values.
  *
- * Renders the native `<input type="color">` when `value` is a hex string and
- * a checker-pattern swatch with the label "Transparent" when `value` is
- * `null`. The "✕" button toggles to `null`; clicking the transparent swatch
- * returns to the previous hex (or `fallback`).
+ * Shows a SketchPicker swatch when `value` is a hex, and a checker-pattern
+ * swatch labelled Transparent when `value` is `null`. The "Clear / Color"
+ * toggle flips between the two states.
  *
  * GH #76 — used wherever a CellStyle / page background colour field can be
  * opted out of (table header bg, row bg, odd/even row bg, borders, page bg).
@@ -25,17 +24,9 @@ export function NullableColorInput({
   value,
   onChange,
   fallback = '#ffffff',
-  className = 'tg-color-input',
   ariaLabel,
 }: NullableColorInputProps) {
   const isTransparent = value === null
-
-  const handleColorChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      onChange(e.target.value)
-    },
-    [onChange],
-  )
 
   const clear = useCallback(() => onChange(null), [onChange])
   const restore = useCallback(() => onChange(fallback), [onChange, fallback])
@@ -67,13 +58,7 @@ export function NullableColorInput({
           }}
         />
       ) : (
-        <input
-          type="color"
-          className={className}
-          value={value ?? fallback}
-          aria-label={ariaLabel}
-          onChange={handleColorChange}
-        />
+        <ColorPickerPopover value={value} onChange={onChange} ariaLabel={ariaLabel} />
       )}
       <button
         type="button"

--- a/packages/ui/src/components/RightPanel/ImageFieldProps.tsx
+++ b/packages/ui/src/components/RightPanel/ImageFieldProps.tsx
@@ -4,6 +4,7 @@ import { isSafeKey } from '@template-goblin/types'
 import { useTemplateStore } from '../../store/templateStore.js'
 import { SourceModeToggle } from './SourceModeToggle.js'
 import { HyperlinkSection } from './HyperlinkSection.js'
+import { ColorPickerPopover } from '../ColorPickerPopover.js'
 
 interface Props {
   field: ImageField
@@ -122,16 +123,16 @@ export function ImageFieldProps({ field }: Props) {
           <div className="tg-form-row">
             <label>Color</label>
             <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-              <input
-                type="color"
+              <ColorPickerPopover
                 value={staticColor ?? '#ffffff'}
-                onChange={(e) =>
+                onChange={(c) =>
                   updateField(field.id, {
-                    source: { mode: 'static', value: { color: e.target.value } },
+                    source: { mode: 'static', value: { color: c } },
                   } as Partial<FieldDefinition>)
                 }
-                style={{ width: 44, height: 32 }}
-                data-testid="image-static-color-input"
+                swatchWidth={44}
+                swatchHeight={32}
+                ariaLabel="Static image color"
               />
               <span style={{ fontFamily: 'monospace', fontSize: 12 }}>{staticColor}</span>
             </div>

--- a/packages/ui/src/components/RightPanel/LoopFieldProps.tsx
+++ b/packages/ui/src/components/RightPanel/LoopFieldProps.tsx
@@ -148,6 +148,19 @@ export function LoopFieldProps({ field }: Props) {
             onChange={(e) => updateFieldStyle(field.id, { showHeader: e.target.checked })}
           />
         </div>
+
+        <div className="tg-toggle-row">
+          <label>
+            Fit to Content
+            <InfoTip text="When on, the table's perimeter ends at the last row instead of stretching to the full rect — collapses the empty area below short tables." />
+          </label>
+          <input
+            type="checkbox"
+            className="tg-checkbox"
+            checked={style.fitToContent !== false}
+            onChange={(e) => updateFieldStyle(field.id, { fitToContent: e.target.checked })}
+          />
+        </div>
       </div>
 
       <TableColumnsSection field={field} />

--- a/packages/ui/src/components/RightPanel/LoopFieldProps.tsx
+++ b/packages/ui/src/components/RightPanel/LoopFieldProps.tsx
@@ -1,12 +1,4 @@
-import type {
-  FieldDefinition,
-  TableField,
-  TableFieldStyle,
-  TableColumn,
-  CellStyle,
-  TextAlign,
-  FontWeight,
-} from '@template-goblin/types'
+import type { FieldDefinition, TableField, TableFieldStyle } from '@template-goblin/types'
 import { isSafeKey } from '@template-goblin/types'
 import { HyperlinkSection } from './HyperlinkSection.js'
 import { useTemplateStore } from '../../store/templateStore.js'
@@ -14,11 +6,16 @@ import { InfoTip } from './TextFieldProps.js'
 import { NumberInput } from '../NumberInput.js'
 import { defaultCellStyle } from '../../utils/defaults.js'
 import { SourceModeToggle } from './SourceModeToggle.js'
+import { TableStyleSections } from './TableStyleSections.js'
+import { TableColumnsSection } from './TableColumnsSection.js'
 
 /**
  * Historical filename: `LoopFieldProps.tsx`. The field type was renamed from
  * `loop` to `table` in spec 002 (Phase 1); the component and export name are
  * kept stable to avoid a rename-file churn during the Phase 1 compile fix.
+ *
+ * The header/row/cell style sub-panels live in `TableStyleSections.tsx`;
+ * the per-column editor lives in `TableColumnsSection.tsx` (Hard Rule #11).
  */
 
 interface Props {
@@ -45,11 +42,7 @@ export function LoopFieldProps({ field }: Props) {
   }
 
   const style: TableFieldStyle = field.style
-  const columns = style.columns || []
-  const headerStyle = style.headerStyle
-  const rowStyle = style.rowStyle
 
-  // Phase 1 UI edits only dynamic table fields via the right panel.
   const isDynamic = field.source.mode === 'dynamic'
   const dynamicSource = isDynamic
     ? (field.source as {
@@ -70,75 +63,6 @@ export function LoopFieldProps({ field }: Props) {
     } as Partial<FieldDefinition>)
   }
 
-  function updateHeader(updates: Partial<CellStyle>) {
-    updateFieldStyle(field.id, { headerStyle: { ...headerStyle, ...updates } })
-  }
-
-  function updateRow(updates: Partial<CellStyle>) {
-    updateFieldStyle(field.id, { rowStyle: { ...rowStyle, ...updates } })
-  }
-
-  function updateColumn(index: number, updates: Partial<TableColumn>) {
-    const newColumns = columns.map((col: TableColumn, i: number) =>
-      i === index ? { ...col, ...updates } : col,
-    )
-    updateFieldStyle(field.id, { columns: newColumns })
-  }
-
-  function addColumn() {
-    const newCol: TableColumn = {
-      key: `col${columns.length + 1}`,
-      label: `Column ${columns.length + 1}`,
-      width: 100,
-      // GH #39: stamp the centred align explicitly on every new column so
-      // the sidebar dropdown and the rendered cell agree on day one,
-      // regardless of what the parent table's `rowStyle.align` says (it
-      // could legitimately be 'left' if the user changed it, or could be
-      // 'left' on a legacy template loaded from disk). Without this the
-      // sidebar would still inherit-display the parent's left value.
-      style: { align: 'center', verticalAlign: 'middle' },
-      headerStyle: { align: 'center', verticalAlign: 'middle' },
-    }
-    updateFieldStyle(field.id, { columns: [...columns, newCol] })
-  }
-
-  function removeColumn(index: number) {
-    const newColumns = columns.filter((_col: TableColumn, i: number) => i !== index)
-    updateFieldStyle(field.id, { columns: newColumns })
-  }
-
-  function moveColumnUp(index: number) {
-    if (index <= 0) return
-    const newColumns = [...columns]
-    const prev = newColumns[index - 1]
-    const curr = newColumns[index]
-    if (!prev || !curr) return
-    newColumns[index - 1] = curr
-    newColumns[index] = prev
-    updateFieldStyle(field.id, { columns: newColumns })
-  }
-
-  function moveColumnDown(index: number) {
-    if (index >= columns.length - 1) return
-    const newColumns = [...columns]
-    const next = newColumns[index + 1]
-    const curr = newColumns[index]
-    if (!next || !curr) return
-    newColumns[index + 1] = curr
-    newColumns[index] = next
-    updateFieldStyle(field.id, { columns: newColumns })
-  }
-
-  // Column-level align: lives on the per-column `style` override. We treat a
-  // missing override as "inherit row align".
-  function columnAlign(col: TableColumn): TextAlign {
-    return (col.style?.align as TextAlign | undefined) ?? rowStyle.align ?? 'center'
-  }
-  function setColumnAlign(index: number, align: TextAlign) {
-    const existing = columns[index]?.style ?? {}
-    updateColumn(index, { style: { ...existing, align } })
-  }
-
   const allFontFamilies = [...BUILTIN_FONTS, ...fonts.map((f) => f.name)]
 
   return (
@@ -146,7 +70,6 @@ export function LoopFieldProps({ field }: Props) {
       {/* Source mode toggle (GH #26) — flipping migrates value↔placeholder. */}
       <SourceModeToggle field={field} />
 
-      {/* JSON Key & Basic Settings */}
       <div className="tg-panel-section">
         <div className="tg-panel-section-title">Table Properties</div>
 
@@ -227,327 +150,8 @@ export function LoopFieldProps({ field }: Props) {
         </div>
       </div>
 
-      {/* Column Definitions */}
-      <div className="tg-panel-section">
-        <div className="tg-panel-section-title">Columns</div>
-
-        {columns.map((col: TableColumn, i: number) => (
-          <div
-            key={i}
-            style={{
-              marginBottom: 12,
-              padding: 8,
-              background: 'var(--bg-primary)',
-              borderRadius: 4,
-            }}
-          >
-            <div
-              style={{
-                display: 'flex',
-                justifyContent: 'space-between',
-                alignItems: 'center',
-                marginBottom: 6,
-              }}
-            >
-              <span style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-secondary)' }}>
-                Column {i + 1}
-              </span>
-              <div style={{ display: 'flex', gap: 2 }}>
-                <button
-                  className="tg-btn"
-                  style={{ fontSize: 10, padding: '2px 5px' }}
-                  onClick={() => moveColumnUp(i)}
-                  disabled={i === 0}
-                  title="Move up"
-                >
-                  &uarr;
-                </button>
-                <button
-                  className="tg-btn"
-                  style={{ fontSize: 10, padding: '2px 5px' }}
-                  onClick={() => moveColumnDown(i)}
-                  disabled={i === columns.length - 1}
-                  title="Move down"
-                >
-                  &darr;
-                </button>
-                <button
-                  className="tg-btn tg-btn--danger"
-                  style={{ fontSize: 10, padding: '2px 6px' }}
-                  onClick={() => removeColumn(i)}
-                  data-testid={`loop-remove-column-${i}`}
-                >
-                  Remove
-                </button>
-              </div>
-            </div>
-
-            <div className="tg-form-row">
-              <label>Key</label>
-              <input
-                className="tg-input"
-                value={col.key}
-                onChange={(e) => updateColumn(i, { key: e.target.value })}
-              />
-            </div>
-
-            <div className="tg-form-row">
-              <label>Label</label>
-              <input
-                className="tg-input"
-                value={col.label}
-                onChange={(e) => updateColumn(i, { label: e.target.value })}
-              />
-            </div>
-
-            <div className="tg-form-row">
-              <label>Width</label>
-              <NumberInput
-                min={10}
-                value={col.width}
-                defaultValue={100}
-                onChange={(v) => updateColumn(i, { width: v })}
-              />
-            </div>
-
-            <div className="tg-form-row">
-              <label>Align</label>
-              <select
-                className="tg-select"
-                value={columnAlign(col)}
-                onChange={(e) => setColumnAlign(i, e.target.value as TextAlign)}
-              >
-                <option value="left">Left</option>
-                <option value="center">Center</option>
-                <option value="right">Right</option>
-              </select>
-            </div>
-          </div>
-        ))}
-
-        <button
-          className="tg-btn"
-          style={{ width: '100%', justifyContent: 'center', fontSize: 11 }}
-          onClick={addColumn}
-          data-testid="loop-add-column"
-        >
-          + Add Column
-        </button>
-      </div>
-
-      {/* Header Style */}
-      <div className="tg-panel-section">
-        <div className="tg-panel-section-title">Header Style</div>
-
-        <div className="tg-form-row">
-          <label>Font Family</label>
-          <select
-            className="tg-select"
-            value={headerStyle.fontFamily}
-            onChange={(e) => updateHeader({ fontFamily: e.target.value })}
-          >
-            {allFontFamilies.map((f) => (
-              <option key={f} value={f}>
-                {f}
-              </option>
-            ))}
-          </select>
-        </div>
-
-        <div className="tg-form-row">
-          <label>Font Size</label>
-          <NumberInput
-            min={1}
-            value={headerStyle.fontSize}
-            defaultValue={10}
-            onChange={(v) => updateHeader({ fontSize: v })}
-          />
-        </div>
-
-        <div className="tg-form-row">
-          <label>Font Weight</label>
-          <select
-            className="tg-select"
-            value={headerStyle.fontWeight}
-            onChange={(e) => updateHeader({ fontWeight: e.target.value as FontWeight })}
-          >
-            <option value="normal">Normal</option>
-            <option value="bold">Bold</option>
-          </select>
-        </div>
-
-        <div className="tg-form-row">
-          <label>Align</label>
-          <select
-            className="tg-select"
-            value={headerStyle.align}
-            onChange={(e) => updateHeader({ align: e.target.value as TextAlign })}
-          >
-            <option value="left">Left</option>
-            <option value="center">Center</option>
-            <option value="right">Right</option>
-          </select>
-        </div>
-
-        <div className="tg-form-row">
-          <label>Color</label>
-          <input
-            type="color"
-            className="tg-color-input"
-            value={headerStyle.color}
-            onChange={(e) => updateHeader({ color: e.target.value })}
-          />
-        </div>
-
-        <div className="tg-form-row">
-          <label>Background Color</label>
-          <input
-            type="color"
-            className="tg-color-input"
-            value={headerStyle.backgroundColor}
-            onChange={(e) => updateHeader({ backgroundColor: e.target.value })}
-          />
-        </div>
-      </div>
-
-      {/* Row Style */}
-      <div className="tg-panel-section">
-        <div className="tg-panel-section-title">Row Style</div>
-
-        <div className="tg-form-row">
-          <label>Font Family</label>
-          <select
-            className="tg-select"
-            value={rowStyle.fontFamily}
-            onChange={(e) => updateRow({ fontFamily: e.target.value })}
-          >
-            {allFontFamilies.map((f) => (
-              <option key={f} value={f}>
-                {f}
-              </option>
-            ))}
-          </select>
-        </div>
-
-        <div className="tg-form-row">
-          <label>Font Size</label>
-          <NumberInput
-            min={1}
-            value={rowStyle.fontSize}
-            defaultValue={10}
-            onChange={(v) => updateRow({ fontSize: v })}
-          />
-        </div>
-
-        <div className="tg-form-row">
-          <label>Font Weight</label>
-          <select
-            className="tg-select"
-            value={rowStyle.fontWeight}
-            onChange={(e) => updateRow({ fontWeight: e.target.value as FontWeight })}
-          >
-            <option value="normal">Normal</option>
-            <option value="bold">Bold</option>
-          </select>
-        </div>
-
-        <div className="tg-form-row">
-          <label>Color</label>
-          <input
-            type="color"
-            className="tg-color-input"
-            value={rowStyle.color}
-            onChange={(e) => updateRow({ color: e.target.value })}
-          />
-        </div>
-
-        <div className="tg-form-row">
-          <label>Overflow Mode</label>
-          <select
-            className="tg-select"
-            value={style.cellStyle.overflowMode}
-            onChange={(e) =>
-              updateFieldStyle(field.id, {
-                cellStyle: {
-                  ...style.cellStyle,
-                  overflowMode: e.target.value as 'dynamic_font' | 'truncate',
-                },
-              })
-            }
-          >
-            <option value="dynamic_font">Dynamic Font</option>
-            <option value="truncate">Truncate</option>
-          </select>
-        </div>
-      </div>
-
-      {/* Cell Style (row-level padding/border) */}
-      <div className="tg-panel-section">
-        <div className="tg-panel-section-title">Cell Style</div>
-
-        <div className="tg-form-row">
-          <label>Border Width</label>
-          <NumberInput
-            min={0}
-            step={0.5}
-            value={rowStyle.borderWidth}
-            defaultValue={1}
-            onChange={(v) => updateRow({ borderWidth: v })}
-          />
-        </div>
-
-        <div className="tg-form-row">
-          <label>Border Color</label>
-          <input
-            type="color"
-            className="tg-color-input"
-            value={rowStyle.borderColor}
-            onChange={(e) => updateRow({ borderColor: e.target.value })}
-          />
-        </div>
-
-        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8 }}>
-          <div className="tg-form-row">
-            <label>Padding Top</label>
-            <NumberInput
-              min={0}
-              value={rowStyle.paddingTop}
-              defaultValue={4}
-              onChange={(v) => updateRow({ paddingTop: v })}
-            />
-          </div>
-
-          <div className="tg-form-row">
-            <label>Padding Bottom</label>
-            <NumberInput
-              min={0}
-              value={rowStyle.paddingBottom}
-              defaultValue={4}
-              onChange={(v) => updateRow({ paddingBottom: v })}
-            />
-          </div>
-
-          <div className="tg-form-row">
-            <label>Padding Left</label>
-            <NumberInput
-              min={0}
-              value={rowStyle.paddingLeft}
-              defaultValue={4}
-              onChange={(v) => updateRow({ paddingLeft: v })}
-            />
-          </div>
-
-          <div className="tg-form-row">
-            <label>Padding Right</label>
-            <NumberInput
-              min={0}
-              value={rowStyle.paddingRight}
-              defaultValue={4}
-              onChange={(v) => updateRow({ paddingRight: v })}
-            />
-          </div>
-        </div>
-      </div>
+      <TableColumnsSection field={field} />
+      <TableStyleSections field={field} allFontFamilies={allFontFamilies} />
       <HyperlinkSection field={field} />
     </>
   )

--- a/packages/ui/src/components/RightPanel/TableColumnsSection.tsx
+++ b/packages/ui/src/components/RightPanel/TableColumnsSection.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import type { TableColumn, TableField, TextAlign } from '@template-goblin/types'
 import { useTemplateStore } from '../../store/templateStore.js'
 import { NumberInput } from '../NumberInput.js'
@@ -16,6 +17,7 @@ export function TableColumnsSection({ field }: Props) {
   const style = field.style
   const columns = style.columns || []
   const rowStyle = style.rowStyle
+  const [collapsed, setCollapsed] = useState(false)
 
   function updateColumn(index: number, updates: Partial<TableColumn>) {
     const next = columns.map((col, i) => (i === index ? { ...col, ...updates } : col))
@@ -69,110 +71,136 @@ export function TableColumnsSection({ field }: Props) {
 
   return (
     <div className="tg-panel-section">
-      <div className="tg-panel-section-title">Columns</div>
+      <button
+        type="button"
+        className="tg-panel-section-title"
+        onClick={() => setCollapsed((c) => !c)}
+        aria-expanded={!collapsed}
+        style={{
+          background: 'transparent',
+          border: 'none',
+          padding: 0,
+          width: '100%',
+          textAlign: 'left',
+          cursor: 'pointer',
+          color: 'inherit',
+          font: 'inherit',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+        }}
+      >
+        <span>Columns ({columns.length})</span>
+        <span aria-hidden style={{ fontSize: 10, opacity: 0.7 }}>
+          {collapsed ? '▶' : '▼'}
+        </span>
+      </button>
 
-      {columns.map((col, i) => (
-        <div
-          key={i}
-          style={{
-            marginBottom: 12,
-            padding: 8,
-            background: 'var(--bg-primary)',
-            borderRadius: 4,
-          }}
-        >
+      {!collapsed &&
+        columns.map((col, i) => (
           <div
+            key={i}
             style={{
-              display: 'flex',
-              justifyContent: 'space-between',
-              alignItems: 'center',
-              marginBottom: 6,
+              marginBottom: 12,
+              padding: 8,
+              background: 'var(--bg-primary)',
+              borderRadius: 4,
             }}
           >
-            <span style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-secondary)' }}>
-              Column {i + 1}
-            </span>
-            <div style={{ display: 'flex', gap: 2 }}>
-              <button
-                className="tg-btn"
-                style={{ fontSize: 10, padding: '2px 5px' }}
-                onClick={() => moveColumnUp(i)}
-                disabled={i === 0}
-                title="Move up"
+            <div
+              style={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'center',
+                marginBottom: 6,
+              }}
+            >
+              <span style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-secondary)' }}>
+                Column {i + 1}
+              </span>
+              <div style={{ display: 'flex', gap: 2 }}>
+                <button
+                  className="tg-btn"
+                  style={{ fontSize: 10, padding: '2px 5px' }}
+                  onClick={() => moveColumnUp(i)}
+                  disabled={i === 0}
+                  title="Move up"
+                >
+                  &uarr;
+                </button>
+                <button
+                  className="tg-btn"
+                  style={{ fontSize: 10, padding: '2px 5px' }}
+                  onClick={() => moveColumnDown(i)}
+                  disabled={i === columns.length - 1}
+                  title="Move down"
+                >
+                  &darr;
+                </button>
+                <button
+                  className="tg-btn tg-btn--danger"
+                  style={{ fontSize: 10, padding: '2px 6px' }}
+                  onClick={() => removeColumn(i)}
+                  data-testid={`loop-remove-column-${i}`}
+                >
+                  Remove
+                </button>
+              </div>
+            </div>
+
+            <div className="tg-form-row">
+              <label>Key</label>
+              <input
+                className="tg-input"
+                value={col.key}
+                onChange={(e) => updateColumn(i, { key: e.target.value })}
+              />
+            </div>
+
+            <div className="tg-form-row">
+              <label>Label</label>
+              <input
+                className="tg-input"
+                value={col.label}
+                onChange={(e) => updateColumn(i, { label: e.target.value })}
+              />
+            </div>
+
+            <div className="tg-form-row">
+              <label>Width</label>
+              <NumberInput
+                min={10}
+                value={col.width}
+                defaultValue={100}
+                onChange={(v) => updateColumn(i, { width: v })}
+              />
+            </div>
+
+            <div className="tg-form-row">
+              <label>Align</label>
+              <select
+                className="tg-select"
+                value={columnAlign(col)}
+                onChange={(e) => setColumnAlign(i, e.target.value as TextAlign)}
               >
-                &uarr;
-              </button>
-              <button
-                className="tg-btn"
-                style={{ fontSize: 10, padding: '2px 5px' }}
-                onClick={() => moveColumnDown(i)}
-                disabled={i === columns.length - 1}
-                title="Move down"
-              >
-                &darr;
-              </button>
-              <button
-                className="tg-btn tg-btn--danger"
-                style={{ fontSize: 10, padding: '2px 6px' }}
-                onClick={() => removeColumn(i)}
-                data-testid={`loop-remove-column-${i}`}
-              >
-                Remove
-              </button>
+                <option value="left">Left</option>
+                <option value="center">Center</option>
+                <option value="right">Right</option>
+              </select>
             </div>
           </div>
+        ))}
 
-          <div className="tg-form-row">
-            <label>Key</label>
-            <input
-              className="tg-input"
-              value={col.key}
-              onChange={(e) => updateColumn(i, { key: e.target.value })}
-            />
-          </div>
-
-          <div className="tg-form-row">
-            <label>Label</label>
-            <input
-              className="tg-input"
-              value={col.label}
-              onChange={(e) => updateColumn(i, { label: e.target.value })}
-            />
-          </div>
-
-          <div className="tg-form-row">
-            <label>Width</label>
-            <NumberInput
-              min={10}
-              value={col.width}
-              defaultValue={100}
-              onChange={(v) => updateColumn(i, { width: v })}
-            />
-          </div>
-
-          <div className="tg-form-row">
-            <label>Align</label>
-            <select
-              className="tg-select"
-              value={columnAlign(col)}
-              onChange={(e) => setColumnAlign(i, e.target.value as TextAlign)}
-            >
-              <option value="left">Left</option>
-              <option value="center">Center</option>
-              <option value="right">Right</option>
-            </select>
-          </div>
-        </div>
-      ))}
-
-      <button
-        className="tg-btn"
-        style={{ width: '100%', justifyContent: 'center', fontSize: 11 }}
-        onClick={addColumn}
-        data-testid="loop-add-column"
-      >
-        + Add Column
-      </button>
+      {!collapsed && (
+        <button
+          className="tg-btn"
+          style={{ width: '100%', justifyContent: 'center', fontSize: 11 }}
+          onClick={addColumn}
+          data-testid="loop-add-column"
+        >
+          + Add Column
+        </button>
+      )}
     </div>
   )
 }

--- a/packages/ui/src/components/RightPanel/TableColumnsSection.tsx
+++ b/packages/ui/src/components/RightPanel/TableColumnsSection.tsx
@@ -1,0 +1,178 @@
+import type { TableColumn, TableField, TextAlign } from '@template-goblin/types'
+import { useTemplateStore } from '../../store/templateStore.js'
+import { NumberInput } from '../NumberInput.js'
+
+interface Props {
+  field: TableField
+}
+
+/**
+ * Per-column editor (key / label / width / align + reorder + delete + add).
+ * Extracted from `LoopFieldProps.tsx` to keep that file under the 300-line
+ * cap (Hard Rule #11). Behaviour unchanged.
+ */
+export function TableColumnsSection({ field }: Props) {
+  const updateFieldStyle = useTemplateStore((s) => s.updateFieldStyle)
+  const style = field.style
+  const columns = style.columns || []
+  const rowStyle = style.rowStyle
+
+  function updateColumn(index: number, updates: Partial<TableColumn>) {
+    const next = columns.map((col, i) => (i === index ? { ...col, ...updates } : col))
+    updateFieldStyle(field.id, { columns: next })
+  }
+
+  function addColumn() {
+    const newCol: TableColumn = {
+      key: `col${columns.length + 1}`,
+      label: `Column ${columns.length + 1}`,
+      width: 100,
+      style: { align: 'center', verticalAlign: 'middle' },
+      headerStyle: { align: 'center', verticalAlign: 'middle' },
+    }
+    updateFieldStyle(field.id, { columns: [...columns, newCol] })
+  }
+
+  function removeColumn(index: number) {
+    updateFieldStyle(field.id, { columns: columns.filter((_, i) => i !== index) })
+  }
+
+  function moveColumnUp(index: number) {
+    if (index <= 0) return
+    const next = [...columns]
+    const prev = next[index - 1]
+    const curr = next[index]
+    if (!prev || !curr) return
+    next[index - 1] = curr
+    next[index] = prev
+    updateFieldStyle(field.id, { columns: next })
+  }
+
+  function moveColumnDown(index: number) {
+    if (index >= columns.length - 1) return
+    const next = [...columns]
+    const nxt = next[index + 1]
+    const curr = next[index]
+    if (!nxt || !curr) return
+    next[index + 1] = curr
+    next[index] = nxt
+    updateFieldStyle(field.id, { columns: next })
+  }
+
+  function columnAlign(col: TableColumn): TextAlign {
+    return (col.style?.align as TextAlign | undefined) ?? rowStyle.align ?? 'center'
+  }
+  function setColumnAlign(index: number, align: TextAlign) {
+    const existing = columns[index]?.style ?? {}
+    updateColumn(index, { style: { ...existing, align } })
+  }
+
+  return (
+    <div className="tg-panel-section">
+      <div className="tg-panel-section-title">Columns</div>
+
+      {columns.map((col, i) => (
+        <div
+          key={i}
+          style={{
+            marginBottom: 12,
+            padding: 8,
+            background: 'var(--bg-primary)',
+            borderRadius: 4,
+          }}
+        >
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+              marginBottom: 6,
+            }}
+          >
+            <span style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-secondary)' }}>
+              Column {i + 1}
+            </span>
+            <div style={{ display: 'flex', gap: 2 }}>
+              <button
+                className="tg-btn"
+                style={{ fontSize: 10, padding: '2px 5px' }}
+                onClick={() => moveColumnUp(i)}
+                disabled={i === 0}
+                title="Move up"
+              >
+                &uarr;
+              </button>
+              <button
+                className="tg-btn"
+                style={{ fontSize: 10, padding: '2px 5px' }}
+                onClick={() => moveColumnDown(i)}
+                disabled={i === columns.length - 1}
+                title="Move down"
+              >
+                &darr;
+              </button>
+              <button
+                className="tg-btn tg-btn--danger"
+                style={{ fontSize: 10, padding: '2px 6px' }}
+                onClick={() => removeColumn(i)}
+                data-testid={`loop-remove-column-${i}`}
+              >
+                Remove
+              </button>
+            </div>
+          </div>
+
+          <div className="tg-form-row">
+            <label>Key</label>
+            <input
+              className="tg-input"
+              value={col.key}
+              onChange={(e) => updateColumn(i, { key: e.target.value })}
+            />
+          </div>
+
+          <div className="tg-form-row">
+            <label>Label</label>
+            <input
+              className="tg-input"
+              value={col.label}
+              onChange={(e) => updateColumn(i, { label: e.target.value })}
+            />
+          </div>
+
+          <div className="tg-form-row">
+            <label>Width</label>
+            <NumberInput
+              min={10}
+              value={col.width}
+              defaultValue={100}
+              onChange={(v) => updateColumn(i, { width: v })}
+            />
+          </div>
+
+          <div className="tg-form-row">
+            <label>Align</label>
+            <select
+              className="tg-select"
+              value={columnAlign(col)}
+              onChange={(e) => setColumnAlign(i, e.target.value as TextAlign)}
+            >
+              <option value="left">Left</option>
+              <option value="center">Center</option>
+              <option value="right">Right</option>
+            </select>
+          </div>
+        </div>
+      ))}
+
+      <button
+        className="tg-btn"
+        style={{ width: '100%', justifyContent: 'center', fontSize: 11 }}
+        onClick={addColumn}
+        data-testid="loop-add-column"
+      >
+        + Add Column
+      </button>
+    </div>
+  )
+}

--- a/packages/ui/src/components/RightPanel/TableStyleSections.tsx
+++ b/packages/ui/src/components/RightPanel/TableStyleSections.tsx
@@ -1,0 +1,251 @@
+import type { CellStyle, FontWeight, TableField, TextAlign } from '@template-goblin/types'
+import { useTemplateStore } from '../../store/templateStore.js'
+import { NumberInput } from '../NumberInput.js'
+import { NullableColorInput } from '../NullableColorInput.js'
+
+interface Props {
+  field: TableField
+  allFontFamilies: string[]
+}
+
+/**
+ * Header / Row / Cell style sub-panels for the table field properties.
+ * Extracted from `LoopFieldProps.tsx` to keep that file under the 300-line
+ * cap (Hard Rule #11). Behaviour is unchanged versus the inline version
+ * apart from the GH #76 transparent-fill controls.
+ */
+export function TableStyleSections({ field, allFontFamilies }: Props) {
+  const updateFieldStyle = useTemplateStore((s) => s.updateFieldStyle)
+  const style = field.style
+  const headerStyle = style.headerStyle
+  const rowStyle = style.rowStyle
+
+  function updateHeader(updates: Partial<CellStyle>) {
+    updateFieldStyle(field.id, { headerStyle: { ...headerStyle, ...updates } })
+  }
+  function updateRow(updates: Partial<CellStyle>) {
+    updateFieldStyle(field.id, { rowStyle: { ...rowStyle, ...updates } })
+  }
+
+  return (
+    <>
+      <div className="tg-panel-section">
+        <div className="tg-panel-section-title">Header Style</div>
+
+        <div className="tg-form-row">
+          <label>Font Family</label>
+          <select
+            className="tg-select"
+            value={headerStyle.fontFamily}
+            onChange={(e) => updateHeader({ fontFamily: e.target.value })}
+          >
+            {allFontFamilies.map((f) => (
+              <option key={f} value={f}>
+                {f}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="tg-form-row">
+          <label>Font Size</label>
+          <NumberInput
+            min={1}
+            value={headerStyle.fontSize}
+            defaultValue={10}
+            onChange={(v) => updateHeader({ fontSize: v })}
+          />
+        </div>
+
+        <div className="tg-form-row">
+          <label>Font Weight</label>
+          <select
+            className="tg-select"
+            value={headerStyle.fontWeight}
+            onChange={(e) => updateHeader({ fontWeight: e.target.value as FontWeight })}
+          >
+            <option value="normal">Normal</option>
+            <option value="bold">Bold</option>
+          </select>
+        </div>
+
+        <div className="tg-form-row">
+          <label>Align</label>
+          <select
+            className="tg-select"
+            value={headerStyle.align}
+            onChange={(e) => updateHeader({ align: e.target.value as TextAlign })}
+          >
+            <option value="left">Left</option>
+            <option value="center">Center</option>
+            <option value="right">Right</option>
+          </select>
+        </div>
+
+        <div className="tg-form-row">
+          <label>Header Text Color</label>
+          <input
+            type="color"
+            className="tg-color-input"
+            value={headerStyle.color}
+            onChange={(e) => updateHeader({ color: e.target.value })}
+          />
+        </div>
+
+        <div className="tg-form-row">
+          <label>Header Row Background</label>
+          <NullableColorInput
+            value={headerStyle.backgroundColor}
+            onChange={(v) => updateHeader({ backgroundColor: v })}
+            ariaLabel="Header row background color"
+          />
+        </div>
+      </div>
+
+      <div className="tg-panel-section">
+        <div className="tg-panel-section-title">Row Style</div>
+
+        <div className="tg-form-row">
+          <label>Font Family</label>
+          <select
+            className="tg-select"
+            value={rowStyle.fontFamily}
+            onChange={(e) => updateRow({ fontFamily: e.target.value })}
+          >
+            {allFontFamilies.map((f) => (
+              <option key={f} value={f}>
+                {f}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="tg-form-row">
+          <label>Font Size</label>
+          <NumberInput
+            min={1}
+            value={rowStyle.fontSize}
+            defaultValue={10}
+            onChange={(v) => updateRow({ fontSize: v })}
+          />
+        </div>
+
+        <div className="tg-form-row">
+          <label>Font Weight</label>
+          <select
+            className="tg-select"
+            value={rowStyle.fontWeight}
+            onChange={(e) => updateRow({ fontWeight: e.target.value as FontWeight })}
+          >
+            <option value="normal">Normal</option>
+            <option value="bold">Bold</option>
+          </select>
+        </div>
+
+        <div className="tg-form-row">
+          <label>Row Text Color</label>
+          <input
+            type="color"
+            className="tg-color-input"
+            value={rowStyle.color}
+            onChange={(e) => updateRow({ color: e.target.value })}
+          />
+        </div>
+
+        <div className="tg-form-row">
+          <label>Row Background</label>
+          <NullableColorInput
+            value={rowStyle.backgroundColor}
+            onChange={(v) => updateRow({ backgroundColor: v })}
+            ariaLabel="Row background color"
+          />
+        </div>
+
+        <div className="tg-form-row">
+          <label>Overflow Mode</label>
+          <select
+            className="tg-select"
+            value={style.cellStyle.overflowMode}
+            onChange={(e) =>
+              updateFieldStyle(field.id, {
+                cellStyle: {
+                  ...style.cellStyle,
+                  overflowMode: e.target.value as 'dynamic_font' | 'truncate',
+                },
+              })
+            }
+          >
+            <option value="dynamic_font">Dynamic Font</option>
+            <option value="truncate">Truncate</option>
+          </select>
+        </div>
+      </div>
+
+      <div className="tg-panel-section">
+        <div className="tg-panel-section-title">Cell Style</div>
+
+        <div className="tg-form-row">
+          <label>Cell Border Width</label>
+          <NumberInput
+            min={0}
+            step={0.5}
+            value={rowStyle.borderWidth}
+            defaultValue={1}
+            onChange={(v) => updateRow({ borderWidth: v })}
+          />
+        </div>
+
+        <div className="tg-form-row">
+          <label>Cell Border Color</label>
+          <NullableColorInput
+            value={rowStyle.borderColor}
+            onChange={(v) => updateRow({ borderColor: v })}
+            ariaLabel="Cell border color"
+          />
+        </div>
+
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8 }}>
+          <div className="tg-form-row">
+            <label>Padding Top</label>
+            <NumberInput
+              min={0}
+              value={rowStyle.paddingTop}
+              defaultValue={4}
+              onChange={(v) => updateRow({ paddingTop: v })}
+            />
+          </div>
+
+          <div className="tg-form-row">
+            <label>Padding Bottom</label>
+            <NumberInput
+              min={0}
+              value={rowStyle.paddingBottom}
+              defaultValue={4}
+              onChange={(v) => updateRow({ paddingBottom: v })}
+            />
+          </div>
+
+          <div className="tg-form-row">
+            <label>Padding Left</label>
+            <NumberInput
+              min={0}
+              value={rowStyle.paddingLeft}
+              defaultValue={4}
+              onChange={(v) => updateRow({ paddingLeft: v })}
+            />
+          </div>
+
+          <div className="tg-form-row">
+            <label>Padding Right</label>
+            <NumberInput
+              min={0}
+              value={rowStyle.paddingRight}
+              defaultValue={4}
+              onChange={(v) => updateRow({ paddingRight: v })}
+            />
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/packages/ui/src/components/RightPanel/TableStyleSections.tsx
+++ b/packages/ui/src/components/RightPanel/TableStyleSections.tsx
@@ -1,7 +1,14 @@
-import type { CellStyle, FontWeight, TableField, TextAlign } from '@template-goblin/types'
+import type {
+  CellStyle,
+  FontWeight,
+  TableBorderStyle,
+  TableField,
+  TextAlign,
+} from '@template-goblin/types'
 import { useTemplateStore } from '../../store/templateStore.js'
 import { NumberInput } from '../NumberInput.js'
 import { NullableColorInput } from '../NullableColorInput.js'
+import { ColorPickerPopover } from '../ColorPickerPopover.js'
 
 interface Props {
   field: TableField
@@ -25,6 +32,11 @@ export function TableStyleSections({ field, allFontFamilies }: Props) {
   }
   function updateRow(updates: Partial<CellStyle>) {
     updateFieldStyle(field.id, { rowStyle: { ...rowStyle, ...updates } })
+  }
+
+  const tableBorder: TableBorderStyle = style.tableBorder ?? { color: '#000000', width: 1 }
+  function updateTableBorder(updates: Partial<TableBorderStyle>) {
+    updateFieldStyle(field.id, { tableBorder: { ...tableBorder, ...updates } })
   }
 
   return (
@@ -84,11 +96,10 @@ export function TableStyleSections({ field, allFontFamilies }: Props) {
 
         <div className="tg-form-row">
           <label>Header Text Color</label>
-          <input
-            type="color"
-            className="tg-color-input"
+          <ColorPickerPopover
             value={headerStyle.color}
-            onChange={(e) => updateHeader({ color: e.target.value })}
+            onChange={(c) => updateHeader({ color: c })}
+            ariaLabel="Header text color"
           />
         </div>
 
@@ -144,11 +155,10 @@ export function TableStyleSections({ field, allFontFamilies }: Props) {
 
         <div className="tg-form-row">
           <label>Row Text Color</label>
-          <input
-            type="color"
-            className="tg-color-input"
+          <ColorPickerPopover
             value={rowStyle.color}
-            onChange={(e) => updateRow({ color: e.target.value })}
+            onChange={(c) => updateRow({ color: c })}
+            ariaLabel="Row text color"
           />
         </div>
 
@@ -178,6 +188,30 @@ export function TableStyleSections({ field, allFontFamilies }: Props) {
             <option value="dynamic_font">Dynamic Font</option>
             <option value="truncate">Truncate</option>
           </select>
+        </div>
+      </div>
+
+      <div className="tg-panel-section">
+        <div className="tg-panel-section-title">Table Border</div>
+
+        <div className="tg-form-row">
+          <label>Border Width</label>
+          <NumberInput
+            min={0}
+            step={0.5}
+            value={tableBorder.width}
+            defaultValue={1}
+            onChange={(v) => updateTableBorder({ width: v })}
+          />
+        </div>
+
+        <div className="tg-form-row">
+          <label>Border Color</label>
+          <NullableColorInput
+            value={tableBorder.color}
+            onChange={(c) => updateTableBorder({ color: c })}
+            ariaLabel="Table border color"
+          />
         </div>
       </div>
 

--- a/packages/ui/src/components/RightPanel/TextFieldProps.tsx
+++ b/packages/ui/src/components/RightPanel/TextFieldProps.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { SourceModeToggle } from './SourceModeToggle.js'
 import { HyperlinkSection } from './HyperlinkSection.js'
 import { NumberInput } from '../NumberInput.js'
+import { ColorPickerPopover } from '../ColorPickerPopover.js'
 import type {
   FieldDefinition,
   TextField,
@@ -412,11 +413,10 @@ export function TextFieldProps({ field }: Props) {
 
         <div className="tg-form-row">
           <label>Text Color</label>
-          <input
-            type="color"
-            className="tg-color-input"
+          <ColorPickerPopover
             value={style.color}
-            onChange={(e) => updateFieldStyle(field.id, { color: e.target.value })}
+            onChange={(c) => updateFieldStyle(field.id, { color: c })}
+            ariaLabel="Text color"
           />
         </div>
       </div>

--- a/packages/ui/src/utils/__tests__/sizeEstimator.test.ts
+++ b/packages/ui/src/utils/__tests__/sizeEstimator.test.ts
@@ -106,6 +106,7 @@ function tableField(
       maxColumns: 3,
       multiPage: false,
       showHeader: true,
+      fitToContent: true,
       headerStyle: cell({ fontWeight: 'bold', backgroundColor: '#eee' }),
       rowStyle: cell(),
       oddRowStyle: null,

--- a/packages/ui/src/utils/defaults.ts
+++ b/packages/ui/src/utils/defaults.ts
@@ -84,11 +84,20 @@ export function defaultTableStyle(): TableFieldStyle {
     maxColumns: 5,
     multiPage: false,
     showHeader: true,
+    // #76 follow-up: collapse the painted perimeter to the last rendered
+    // row by default so short tables don't trail an empty bordered box.
+    fitToContent: true,
+    // #76 follow-up (option b): new tables ship with an outer perimeter
+    // only; per-cell strokes are off by default so the table reads as a
+    // single bordered grid rather than a busy mesh of individual cells.
+    // Users can opt into grid lines via the Cell Border Width control.
+    tableBorder: { color: '#000000', width: 1 },
     headerStyle: defaultCellStyle({
       fontWeight: 'bold',
       backgroundColor: '#f0f0f0',
+      borderWidth: 0,
     }),
-    rowStyle: defaultCellStyle({ backgroundColor: '#ffffff' }),
+    rowStyle: defaultCellStyle({ backgroundColor: '#ffffff', borderWidth: 0 }),
     oddRowStyle: null,
     evenRowStyle: null,
     cellStyle: { overflowMode: 'dynamic_font' },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,9 @@ importers:
       react:
         specifier: ^18.3.1
         version: 18.3.1
+      react-color:
+        specifier: ^2.19.3
+        version: 2.19.3(react@18.3.1)
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
@@ -133,6 +136,9 @@ importers:
       '@types/react':
         specifier: ^18.3.14
         version: 18.3.28
+      '@types/react-color':
+        specifier: ^3.0.13
+        version: 3.0.13(@types/react@18.3.28)
       '@types/react-dom':
         specifier: ^18.3.3
         version: 18.3.7(@types/react@18.3.28)
@@ -838,6 +844,11 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@icons/material@0.2.4':
+    resolution: {integrity: sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==}
+    peerDependencies:
+      react: '*'
+
   '@inquirer/external-editor@1.0.3':
     resolution: {integrity: sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==}
     engines: {node: '>=18'}
@@ -1373,6 +1384,11 @@ packages:
   '@types/prop-types@15.7.15':
     resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
 
+  '@types/react-color@3.0.13':
+    resolution: {integrity: sha512-2c/9FZ4ixC5T3JzN0LP5Cke2Mf0MKOP2Eh0NPDPWmuVH3NjPyhEjqNMQpN1Phr5m74egAy+p2lYNAFrX1z9Yrg==}
+    peerDependencies:
+      '@types/react': '*'
+
   '@types/react-dom@18.3.7':
     resolution: {integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==}
     peerDependencies:
@@ -1380,6 +1396,11 @@ packages:
 
   '@types/react@18.3.28':
     resolution: {integrity: sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==}
+
+  '@types/reactcss@1.2.13':
+    resolution: {integrity: sha512-gi3S+aUi6kpkF5vdhUsnkwbiSEIU/BEJyD7kBy2SudWBUuKmJk8AQKE0OVcQQeEy40Azh0lV6uynxlikYIJuwg==}
+    peerDependencies:
+      '@types/react': '*'
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
@@ -3002,6 +3023,9 @@ packages:
     resolution: {integrity: sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
+
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
 
@@ -3032,6 +3056,9 @@ packages:
   lodash.upperfirst@4.3.1:
     resolution: {integrity: sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==}
 
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
+
   log-update@6.1.0:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
     engines: {node: '>=18'}
@@ -3059,6 +3086,9 @@ packages:
 
   makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
+
+  material-colors@1.2.6:
+    resolution: {integrity: sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg==}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -3446,6 +3476,9 @@ packages:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
 
+  prop-types@15.8.1:
+    resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
   psl@1.15.0:
     resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
 
@@ -3485,10 +3518,18 @@ packages:
   randomfill@1.0.4:
     resolution: {integrity: sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==}
 
+  react-color@2.19.3:
+    resolution: {integrity: sha512-LEeGE/ZzNLIsFWa1TMe8y5VYqr7bibneWmvJwm1pCn/eNmrabWDh659JSPn9BuaMpEfU83WTOJfnCcjDZwNQTA==}
+    peerDependencies:
+      react: '*'
+
   react-dom@18.3.1:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
     peerDependencies:
       react: ^18.3.1
+
+  react-is@16.13.1:
+    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
@@ -3500,6 +3541,11 @@ packages:
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
+
+  reactcss@1.2.3:
+    resolution: {integrity: sha512-KiwVUcFu1RErkI97ywr8nvx8dNOpT03rbnma0SSalTYjkrPYaEajR4a/MRt6DZ46K6arDRbWMNHF+xH7G7n/8A==}
+    peerDependencies:
+      react: '*'
 
   read-yaml-file@1.1.0:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
@@ -3824,6 +3870,9 @@ packages:
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinycolor2@1.6.0:
+    resolution: {integrity: sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==}
 
   tinyexec@1.1.1:
     resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
@@ -4886,6 +4935,10 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
+  '@icons/material@0.2.4(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+
   '@inquirer/external-editor@1.0.3(@types/node@25.6.0)':
     dependencies:
       chardet: 2.1.1
@@ -5446,6 +5499,11 @@ snapshots:
 
   '@types/prop-types@15.7.15': {}
 
+  '@types/react-color@3.0.13(@types/react@18.3.28)':
+    dependencies:
+      '@types/react': 18.3.28
+      '@types/reactcss': 1.2.13(@types/react@18.3.28)
+
   '@types/react-dom@18.3.7(@types/react@18.3.28)':
     dependencies:
       '@types/react': 18.3.28
@@ -5454,6 +5512,10 @@ snapshots:
     dependencies:
       '@types/prop-types': 15.7.15
       csstype: 3.2.3
+
+  '@types/reactcss@1.2.13(@types/react@18.3.28)':
+    dependencies:
+      '@types/react': 18.3.28
 
   '@types/stack-utils@2.0.3': {}
 
@@ -7512,6 +7574,8 @@ snapshots:
     dependencies:
       p-locate: 6.0.0
 
+  lodash-es@4.18.1: {}
+
   lodash.camelcase@4.3.0: {}
 
   lodash.isplainobject@4.0.6: {}
@@ -7531,6 +7595,8 @@ snapshots:
   lodash.uniq@4.5.0: {}
 
   lodash.upperfirst@4.3.1: {}
+
+  lodash@4.18.1: {}
 
   log-update@6.1.0:
     dependencies:
@@ -7566,6 +7632,8 @@ snapshots:
   makeerror@1.0.12:
     dependencies:
       tmpl: 1.0.5
+
+  material-colors@1.2.6: {}
 
   math-intrinsics@1.1.0: {}
 
@@ -7717,8 +7785,7 @@ snapshots:
   nwsapi@2.2.23:
     optional: true
 
-  object-assign@4.1.1:
-    optional: true
+  object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
 
@@ -7936,6 +8003,12 @@ snapshots:
       kleur: 3.0.3
       sisteransi: 1.0.5
 
+  prop-types@15.8.1:
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      react-is: 16.13.1
+
   psl@1.15.0:
     dependencies:
       punycode: 2.3.1
@@ -7978,11 +8051,24 @@ snapshots:
       randombytes: 2.1.0
       safe-buffer: 5.1.2
 
+  react-color@2.19.3(react@18.3.1):
+    dependencies:
+      '@icons/material': 0.2.4(react@18.3.1)
+      lodash: 4.18.1
+      lodash-es: 4.18.1
+      material-colors: 1.2.6
+      prop-types: 15.8.1
+      react: 18.3.1
+      reactcss: 1.2.3(react@18.3.1)
+      tinycolor2: 1.6.0
+
   react-dom@18.3.1(react@18.3.1):
     dependencies:
       loose-envify: 1.4.0
       react: 18.3.1
       scheduler: 0.23.2
+
+  react-is@16.13.1: {}
 
   react-is@18.3.1: {}
 
@@ -7991,6 +8077,11 @@ snapshots:
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
+
+  reactcss@1.2.3(react@18.3.1):
+    dependencies:
+      lodash: 4.18.1
+      react: 18.3.1
 
   read-yaml-file@1.1.0:
     dependencies:
@@ -8352,6 +8443,8 @@ snapshots:
   tiny-inflate@1.0.3: {}
 
   tinybench@2.9.0: {}
+
+  tinycolor2@1.6.0: {}
 
   tinyexec@1.1.1: {}
 


### PR DESCRIPTION
Closes #76 and a batch of immediate follow-ups raised during review.

## Summary

- **Transparent fills/borders** — `CellStyle.backgroundColor` / `borderColor` now accept `null` as a "transparent" sentinel. Header background, row background, and cell borders can be opted out in the right panel; PDFKit renderer and Fabric canvas both skip the fill/stroke when null.
- **Table-level border** — new optional `TableFieldStyle.tableBorder: { color, width }` paints the outer perimeter independently of per-cell strokes. New tables ship with a 1pt black perimeter and cell strokes off; legacy templates keep their row-derived perimeter for backward compat.
- **Fit to content** — new optional `TableFieldStyle.fitToContent` (defaults to `true` including for legacy templates) collapses the perimeter to the last rendered row so short tables no longer drag a tall empty box.
- **Color picker** — native `<input type="color">` swapped for an in-page SketchPicker popover (`ColorPickerPopover`, react-color). Fixes the page-freeze bug on some browser/GPU combos.
- **Canvas sync** — Fabric preview now paints the table-level outer perimeter, per-header-cell strokes, and per-body-cell strokes, plus respects `fitToContent`. Per-column style overrides also merge over `rowStyle` so column-level align reflects on canvas. Right-panel edits (border colour/width, fit toggle, table border) now show up live without needing a Preview round-trip.
- **UI polish** — clearer labels (Header Text Color, Header Row Background, Row Text Color, Row Background, Table Border, Cell Border), themed border on the transparent "Clear / Color" toggle, and a collapsible Columns section in the table properties panel.

## Test plan

- [x] `pnpm type-check` clean across types / core / ui
- [x] `pnpm test` — 421 ui + 395 core tests pass
- [x] New core tests: `tableBorder` paints with explicit colour, `null` colour suppresses the perimeter, omitted `fitToContent` renders as `true`, short tables produce a smaller content stream when collapsed
- [x] Round-trip test: `null` `backgroundColor` / `borderColor` survive save → `readManifest`
- [ ] Manual: open the right panel for a table, toggle Fit to Content, change Table Border colour/width, change Cell Border, change Header Row Background — confirm each update lands on the Fabric canvas immediately