### PR TITLE
fix(release): correct template-goblin to 2.1.0

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # template-goblin
 
-## 3.0.0
+## 2.1.0
 
 ### Minor Changes
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "template-goblin",
-  "version": "3.0.0",
+  "version": "2.1.0",
   "description": "PDF template engine — load a .tgbl template + JSON data, generate PDFs at scale",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
The release bump in #102 inadvertently jumped \`template-goblin\` to **3.0.0** even though the consumed changeset declared a minor release for all three packages (and the generated CHANGELOG header for that version still reads "Minor Changes"). No breaking change shipped in #101.

This PR restores the intended target:

| Package | Before this PR | After this PR |
|---|---|---|
| \`template-goblin\` | 3.0.0 | **2.1.0** |
| \`@template-goblin/types\` | 2.1.0 | 2.1.0 (unchanged) |
| \`template-goblin-ui\` | 2.1.0 | 2.1.0 (unchanged) |

No git tag or GitHub release was created, so nothing public to revert.