### PR TITLE
chore(npm): per-package READMEs + automated releases

### DIFF
--- a/.changeset/brave-signs-grow.md
+++ b/.changeset/brave-signs-grow.md
@@ -1,0 +1,7 @@
+---
+'@template-goblin/types': minor
+'template-goblin': minor
+'template-goblin-ui': minor
+---
+
+Add README

--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -89,13 +89,6 @@ jobs:
       - name: Build types
         run: pnpm --filter @template-goblin/types build
 
-      # Copy the repo-root README into the package so npm shows it on the
-      # package page. The README is shared verbatim across all three
-      # published packages; per-package READMEs would drift. Done at
-      # publish time only so the working tree stays clean.
-      - name: Stage README for npm
-        run: cp README.md packages/types/README.md
-
       - name: Publish @template-goblin/types
         run: pnpm --filter @template-goblin/types publish --no-git-checks --access public || true
         env:
@@ -137,9 +130,6 @@ jobs:
       - name: Build all
         run: pnpm build
 
-      - name: Stage README for npm
-        run: cp README.md packages/core/README.md
-
       - name: Publish template-goblin
         run: pnpm --filter template-goblin publish --no-git-checks --access public || true
         env:
@@ -180,9 +170,6 @@ jobs:
 
       - name: Build all
         run: pnpm build
-
-      - name: Stage README for npm
-        run: cp README.md packages/ui/README.md
 
       - name: Publish template-goblin-ui
         run: pnpm --filter template-goblin-ui publish --no-git-checks --access public || true

--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -1,9 +1,12 @@
-name: Publish SDK to npm
+name: Publish SDK to npm (manual escape hatch)
+
+# Default release flow lives in `release.yml` (changesets-driven on
+# push to main). This workflow is kept ONLY as a manual fallback when
+# a one-off republish is needed (e.g. broken npm artifact, registry
+# outage retry). Triggered explicitly via the Actions UI; never on
+# tag push.
 
 on:
-  push:
-    tags:
-      - 'v*'
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,90 @@
+name: Release
+
+# Changesets-driven release pipeline.
+#
+# How it works:
+#   1. Devs include a `.changeset/*.md` in their PRs (via `pnpm changeset`).
+#   2. When a PR merges to `main`, this workflow runs.
+#   3. If there are pending changesets, `changesets/action` opens (or
+#      updates) a "chore(release): version packages" PR that:
+#        - bumps every affected package.json version,
+#        - regenerates each package's CHANGELOG.md,
+#        - consumes (deletes) the .changeset/*.md files.
+#   4. When that release PR is merged, this workflow runs again. No
+#      pending changesets remain, so `changesets/action` switches to
+#      publish mode and runs `pnpm -r publish` for every non-private
+#      workspace package (`@template-goblin/types`, `template-goblin`,
+#      `template-goblin-ui`). Each tarball already carries its own
+#      README from the package root, so npm shows real docs.
+#
+# Manual publishes still live in `publish-sdk.yml` (workflow_dispatch
+# only) as an escape hatch.
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write
+
+env:
+  NODE_VERSION: 22
+
+jobs:
+  release:
+    name: Version or publish via changesets
+    runs-on: ubuntu-latest
+    if: github.repository == 'JaiminPatel345/template-goblin'
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history is required so changeset can read commit
+          # context when generating release-PR bodies.
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+
+      - name: Verify NPM_TOKEN is set
+        run: |
+          if [ -z "${{ secrets.NPM_TOKEN }}" ]; then
+            echo "::error::NPM_TOKEN secret is not set. Add it in Settings → Secrets → Actions."
+            exit 1
+          fi
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build all packages
+        # `pnpm build` runs the per-package build scripts, which also
+        # copy README.md into each dist/. The pre-published tarball
+        # picks up README.md from the package root via the "files"
+        # array; the dist/ copy is for in-bundle consumers.
+        run: pnpm build
+
+      - name: Create release PR or publish to npm
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          # When there ARE pending changesets, this command runs and the
+          # action opens/updates a release PR with the resulting diff.
+          version: pnpm changeset version
+          # When there are NO pending changesets (state immediately after
+          # merging the release PR), this command runs to actually
+          # publish. --no-git-checks is required because changesets
+          # bumps versions without an extra git commit before publish.
+          publish: pnpm -r publish --no-git-checks --access public
+          commit: 'chore(release): version packages'
+          title: 'chore(release): version packages'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,45 @@
+# template-goblin
+
+PDF template engine for Node.js — load a `.tgbl` template + JSON data and generate a PDF.
+
+```bash
+npm install template-goblin
+```
+
+```ts
+import { writeFile } from 'node:fs/promises'
+import { loadTemplate, generatePDF } from 'template-goblin'
+
+const template = await loadTemplate('./result.tgbl')
+
+const pdf = await generatePDF(template, {
+  text: { studentName: 'Aisha Khan', grade: 'A' },
+  tables: { subjects: [{ subject: 'Math', marks: '95' }] },
+})
+
+await writeFile('result.pdf', pdf)
+```
+
+## What is a `.tgbl` template?
+
+A `.tgbl` is a ZIP archive containing the layout, fonts, and images needed to render a page. Design one in the visual builder ([`template-goblin-ui`](https://www.npmjs.com/package/template-goblin-ui)) or hand-craft one with `@template-goblin/types`. Templates are loaded once, then reused for millions of PDFs.
+
+## API
+
+| Function                               | Purpose                                                               |
+| -------------------------------------- | --------------------------------------------------------------------- |
+| `loadTemplate(path)`                   | Parse a `.tgbl` file into an in-memory `LoadedTemplate`               |
+| `generatePDF(template, input)`         | Render a single PDF as a `Buffer`                                     |
+| `generatePDFBatch(template, inputs[])` | Render many PDFs from a shared template                               |
+| `validateData(template, input)`        | Validate input JSON against the template's required keys              |
+| `preflight(template)`                  | Static checks (overflow, missing fonts, broken refs) before rendering |
+
+Types live in [`@template-goblin/types`](https://www.npmjs.com/package/@template-goblin/types).
+
+## Links
+
+- 📖 **Full docs, examples, and the visual builder** — https://github.com/JaiminPatel345/template-goblin
+- 🐛 **Issues & feature requests** — https://github.com/JaiminPatel345/template-goblin/issues
+- 📄 **License** — MIT
+
+> 🚧 **Pre-1.0** — APIs and the `.tgbl` format may change between minor versions. See the repo for the current status.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,13 +35,14 @@
     "pdf-generation"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json && node -e \"require('node:fs').copyFileSync('README.md','dist/README.md')\"",
     "type-check": "tsc --noEmit",
     "lint": "eslint src/ --ext .ts",
     "test": "jest"
   },
   "files": [
-    "dist"
+    "dist",
+    "README.md"
   ],
   "dependencies": {
     "adm-zip": "^0.5.16",

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -1,0 +1,35 @@
+# @template-goblin/types
+
+Shared TypeScript types for the [TemplateGoblin](https://github.com/JaiminPatel345/template-goblin) PDF template engine — the schema for `.tgbl` templates, the shape of input JSON, and the error types thrown by the runtime.
+
+```bash
+npm install --save-dev @template-goblin/types
+```
+
+This is a **types-only** package. It has no runtime code; you don't need it unless you're writing code that constructs or validates `TemplateManifest` / `InputJSON` shapes by hand.
+
+```ts
+import type {
+  TemplateManifest,
+  InputJSON,
+  FieldDefinition,
+  TableFieldStyle,
+  CellStyle,
+} from '@template-goblin/types'
+```
+
+## Use this when…
+
+- You're building tooling that emits or consumes `.tgbl` manifests outside the visual builder.
+- You want autocomplete / type checking for the input JSON your server feeds into [`template-goblin`](https://www.npmjs.com/package/template-goblin).
+- You're contributing to TemplateGoblin core or UI.
+
+If you're just rendering PDFs from a designed template, [`template-goblin`](https://www.npmjs.com/package/template-goblin) re-exports the types you need — install that instead.
+
+## Links
+
+- 📖 **Repo, docs, and examples** — https://github.com/JaiminPatel345/template-goblin
+- 🐛 **Issues** — https://github.com/JaiminPatel345/template-goblin/issues
+- 📄 **License** — MIT
+
+> 🚧 **Pre-1.0** — schema fields may be added, renamed, or removed between minor versions.

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -24,12 +24,13 @@
     "template"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json && node -e \"require('node:fs').copyFileSync('README.md','dist/README.md')\"",
     "type-check": "tsc --noEmit",
     "lint": "eslint src/ --ext .ts"
   },
   "files": [
-    "dist"
+    "dist",
+    "README.md"
   ],
   "devDependencies": {
     "@types/node": "^25.6.0",

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -1,0 +1,43 @@
+# template-goblin-ui
+
+Visual template builder for [TemplateGoblin](https://github.com/JaiminPatel345/template-goblin) — drag-and-drop design surface that exports `.tgbl` templates for the [`template-goblin`](https://www.npmjs.com/package/template-goblin) PDF engine.
+
+## Run locally (no install)
+
+```bash
+npx template-goblin-ui
+```
+
+Opens the visual builder in your browser at `http://localhost:4242`. Design your template, then **Export → .tgbl** and feed the file into the SDK.
+
+## What you can design
+
+- Multi-page templates with custom or preset page sizes (A3 / A4 / A5 / Letter / Legal)
+- Text fields with dynamic font-fitting, alignment, decoration, and JSON-key bindings
+- Image fields with `fill` / `contain` / `cover` modes and static or dynamic sources
+- Table fields with per-column styling, header/row themes, transparent fills, table-level borders, and fit-to-content layout
+- Hyperlinks that open URLs from the input JSON
+- Page-level backgrounds (solid colour, image, or inherit from the previous page)
+
+Everything saves as a single portable `.tgbl` archive — design once, render anywhere with [`template-goblin`](https://www.npmjs.com/package/template-goblin).
+
+## Generate PDFs from your template
+
+```ts
+import { writeFile } from 'node:fs/promises'
+import { loadTemplate, generatePDF } from 'template-goblin'
+
+const template = await loadTemplate('./my-template.tgbl')
+const pdf = await generatePDF(template, {
+  /* your JSON input */
+})
+await writeFile('out.pdf', pdf)
+```
+
+## Links
+
+- 📖 **Full docs and examples** — https://github.com/JaiminPatel345/template-goblin
+- 🐛 **Issues & feature requests** — https://github.com/JaiminPatel345/template-goblin/issues
+- 📄 **License** — MIT
+
+> 🚧 **Pre-1.0** — UI workflows and the `.tgbl` file format may change between minor versions.

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "tsc && vite build && node -e \"require('node:fs').copyFileSync('README.md','dist/README.md')\"",
     "type-check": "tsc --noEmit",
     "lint": "eslint src/ --ext .ts,.tsx",
     "preview": "vite preview",


### PR DESCRIPTION
Two related things in one branch — both keep your npm publishes self-sufficient.

## What's in here

1. **Per-package READMEs that ship to npm.** Each of \`@template-goblin/types\`, \`template-goblin\`, \`template-goblin-ui\` now has its own \`README.md\` at the package root with audience-appropriate content. The build script copies it into \`dist/\` too. \`npm pack --dry-run\` confirms \`README.md\` lands in every tarball.

2. **Automated releases via \`changesets/action\`.** New \`release.yml\` runs on every push to \`main\`:
   - if there are pending \`.changeset/*.md\` files → opens/updates a \"chore(release): version packages\" PR with version bumps + CHANGELOGs pre-applied,
   - if there aren't → runs \`pnpm -r publish\` and pushes all three packages to npm.
   The old \`publish-sdk.yml\` is reduced to a manual escape hatch only (\`workflow_dispatch\`), so the two workflows can't double-publish.

A changeset is included in this branch (minor across all three packages) so merging this PR opens a release PR automatically.

## What happens after this PR merges

1. \`release.yml\` runs on \`main\`, sees \`.changeset/brave-signs-grow.md\`, opens \"chore(release): version packages\" PR.
2. You merge that PR. \`release.yml\` runs again, finds no pending changesets, publishes all three packages to npm with their READMEs.

## Test plan

- [x] \`pnpm type-check\` — clean across all packages
- [x] \`pnpm test\` — 816 tests pass (395 core + 421 ui)
- [x] \`pnpm lint\` — clean
- [x] \`pnpm build\` succeeds; \`packages/*/dist/README.md\` all present
- [x] \`npm pack --dry-run\` lists \`README.md\` at the package root for all three
- [x] Master QA reviewed branch \`ed1549d\` — PASS
- [ ] Manual: after merge, confirm the release PR appears on \`main\`
- [ ] Manual: after merging the release PR, verify all three packages publish to npm with README rendered on the package page