### PR TITLE
feat(canvas): smart alignment guides while moving fields (#41)

### DIFF
--- a/.changeset/smart-alignment-guides.md
+++ b/.changeset/smart-alignment-guides.md
@@ -1,0 +1,15 @@
+---
+'template-goblin-ui': minor
+---
+
+feat(canvas): smart alignment guides while moving fields (Canva/PowerPoint-style)
+
+Render transient pink/cyan guide lines while a field is being dragged when its
+edges or centre align with another field's edges/centre or with the page
+edges/centre. Magnetic snap within 6 pt (zoom-aware, clamped to 6–24 pt).
+Equal-spacing bracket marks appear when the active field sits between two
+others with matching gaps. Hold Alt to disable snapping. Guides disappear on
+mouse release.
+
+Resize-time snap is intentionally deferred — guides render visually during
+resize but the active field's scale is not mutated. (#41)

--- a/packages/ui/src/components/Canvas/__tests__/smartGuides.test.ts
+++ b/packages/ui/src/components/Canvas/__tests__/smartGuides.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Unit tests for the pure helpers in `smartGuides/` (#41).
+ *
+ * Render + the Fabric wire are intentionally NOT tested here — they need
+ * a live Fabric.Canvas. The pure helpers cover the load-bearing math:
+ *   - candidate building (right shape + page edges always present)
+ *   - snap selection (best of three edges, tolerance honoured, miss → null)
+ *   - equal-spacing detection (gap match + reject overlap / single-side)
+ *   - zoom-aware tolerance (clamped to [6, 24] pt)
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  buildCandidates,
+  findXSnap,
+  findYSnap,
+  computeSnap,
+  detectEqualSpacing,
+  snapToleranceForZoom,
+  SNAP_DISTANCE_PT,
+} from '../smartGuides/index.js'
+import type { Rect } from '../smartGuides/index.js'
+
+const rect = (left: number, top: number, width: number, height: number): Rect => ({
+  left,
+  top,
+  width,
+  height,
+})
+
+describe('buildCandidates', () => {
+  it('emits six candidates per other rect + three page candidates per axis', () => {
+    const c = buildCandidates([rect(10, 20, 100, 50)], 800, 600)
+    // 3 from the rect + 3 page edges on each axis
+    expect(c.x).toHaveLength(6)
+    expect(c.y).toHaveLength(6)
+  })
+
+  it('omits page candidates when page dims are zero (no current page yet)', () => {
+    const c = buildCandidates([rect(0, 0, 10, 10)], 0, 0)
+    expect(c.x).toHaveLength(3)
+    expect(c.y).toHaveLength(3)
+  })
+
+  it('marks page candidates with source: "page" and object candidates with "object"', () => {
+    const c = buildCandidates([rect(10, 10, 10, 10)], 800, 600)
+    const pageX = c.x.filter((cand) => cand.source === 'page')
+    expect(pageX).toHaveLength(3)
+    expect(pageX.map((p) => p.x).sort((a, b) => a - b)).toEqual([0, 400, 800])
+  })
+})
+
+describe('findXSnap / findYSnap', () => {
+  const cands = buildCandidates([rect(100, 100, 50, 50)], 800, 600)
+
+  it('snaps the active rect left edge to a candidate within tolerance', () => {
+    // Pick an active rect whose closest candidate is unambiguously the left
+    // candidate. Right candidate of other rect = 150, centerX = 125, left = 100.
+    // active.left=98 → delta to left candidate = +2 (left edge match).
+    // active.right=108, far from any candidate.
+    const active = rect(98, 0, 10, 10)
+    const hit = findXSnap(active, cands.x, 6)
+    expect(hit).not.toBeNull()
+    expect(hit?.activeEdge).toBe('left')
+    expect(hit?.delta).toBe(2)
+  })
+
+  it('prefers the closer of left/right/centerX', () => {
+    // active rect: left=140, right=160, cx=150. centerX candidate=125 (10 away),
+    // left candidate from the other rect: x=100 (40 away from left=140 — out of range).
+    // Right candidate of other rect: x=150 (10 away from right=160).
+    // Best: centerX or right tied at 10. Bumping tolerance to 12 to catch both.
+    const active = rect(140, 0, 20, 20)
+    const hit = findXSnap(active, cands.x, 12)
+    expect(hit).not.toBeNull()
+    expect(Math.abs(hit!.delta)).toBeLessThanOrEqual(10)
+  })
+
+  it('returns null outside tolerance', () => {
+    const active = rect(200, 0, 20, 20) // far from every candidate
+    expect(findXSnap(active, cands.x, 6)).toBeNull()
+  })
+
+  it('Y axis mirrors X axis behaviour', () => {
+    const active = rect(0, 102, 20, 20)
+    const hit = findYSnap(active, cands.y, 6)
+    expect(hit?.activeEdge).toBe('top')
+    expect(hit?.delta).toBe(-2)
+  })
+})
+
+describe('computeSnap', () => {
+  it('returns null entries when nothing is in range, on both axes independently', () => {
+    // Place active far from every other-rect candidate AND every page edge
+    // (page 800x600 → x candidates {0,400,800}, y candidates {0,300,600}).
+    const cands = buildCandidates([rect(100, 100, 50, 50)], 800, 600)
+    const result = computeSnap(rect(700, 450, 10, 10), cands, 4)
+    expect(result.x).toBeNull()
+    expect(result.y).toBeNull()
+  })
+
+  it('can hit only one axis at a time', () => {
+    const cands = buildCandidates([rect(100, 100, 50, 50)], 800, 600)
+    const result = computeSnap(rect(102, 400, 10, 10), cands, 6)
+    expect(result.x).not.toBeNull()
+    expect(result.y).toBeNull()
+  })
+})
+
+describe('detectEqualSpacing', () => {
+  it('finds a matching gap when active sits between two rects with equal spacing', () => {
+    const left = rect(0, 100, 50, 50) // right edge = 50
+    const right = rect(200, 100, 50, 50) // left edge = 200
+    const active = rect(100, 100, 50, 50) // gap to left = 50, gap to right = 50
+    const gaps = detectEqualSpacing(active, [left, right], 1)
+    expect(gaps.length).toBeGreaterThanOrEqual(2)
+    expect(gaps.every((g) => g.axis === 'x')).toBe(true)
+  })
+
+  it('returns empty when only one neighbour exists on either side', () => {
+    const active = rect(100, 100, 50, 50)
+    const only = rect(0, 100, 50, 50)
+    expect(detectEqualSpacing(active, [only], 1)).toEqual([])
+  })
+
+  it('rejects overlap (negative gap)', () => {
+    const a = rect(80, 100, 50, 50)
+    const b = rect(120, 100, 50, 50)
+    const active = rect(100, 100, 50, 50) // overlaps both
+    expect(detectEqualSpacing(active, [a, b], 1)).toEqual([])
+  })
+
+  it('honours tolerance — gaps within `tolerance` of each other match', () => {
+    const left = rect(0, 100, 50, 50) // right=50
+    const right = rect(201, 100, 50, 50) // left=201
+    const active = rect(100, 100, 50, 50) // gap L=50, gap R=51
+    expect(detectEqualSpacing(active, [left, right], 0.5)).toEqual([])
+    expect(detectEqualSpacing(active, [left, right], 1.5).length).toBeGreaterThan(0)
+  })
+})
+
+describe('edge cases', () => {
+  it('empty other-rects + zero page → no candidates anywhere', () => {
+    const c = buildCandidates([], 0, 0)
+    expect(c.x).toHaveLength(0)
+    expect(c.y).toHaveLength(0)
+  })
+
+  it('page-only candidates still snap the active rect (no other fields on page)', () => {
+    const c = buildCandidates([], 800, 600)
+    // active rect's left = 2 → snaps to page x=0
+    const r = computeSnap(rect(2, 200, 50, 50), c, 6)
+    expect(r.x?.candidate.source).toBe('page')
+    expect(r.x?.delta).toBe(-2)
+  })
+
+  it('picks the smallest-|delta| candidate when multiple are in range', () => {
+    // Two other rects exposing 6 X candidates total; active at (103, w=5)
+    // tests all three of its own edges (left/right/cx) against all of them.
+    // The win condition: returned delta has the smallest absolute value.
+    const c = buildCandidates([rect(100, 0, 10, 10), rect(140, 0, 10, 10)], 0, 0)
+    const r = findXSnap(rect(103, 0, 5, 5), c.x, 6)
+    expect(r).not.toBeNull()
+    // All other candidates would have |delta| > the winner's.
+    for (const cand of c.x) {
+      for (const activeX of [103, 103 + 5, 103 + 2.5]) {
+        const d = Math.abs(cand.x - activeX)
+        if (d <= 6) expect(d).toBeGreaterThanOrEqual(Math.abs(r!.delta))
+      }
+    }
+  })
+
+  it('horizontal-only page (height=0) still yields X candidates', () => {
+    const c = buildCandidates([], 800, 0)
+    expect(c.x).toHaveLength(3)
+    expect(c.y).toHaveLength(0)
+  })
+
+  it('detectEqualSpacing on the Y axis between three vertically-stacked rects', () => {
+    const top = rect(100, 0, 50, 50) // bottom = 50
+    const bottom = rect(100, 200, 50, 50) // top = 200
+    const active = rect(100, 100, 50, 50) // gap top = 50, gap bottom = 50
+    const gaps = detectEqualSpacing(active, [top, bottom], 1)
+    expect(gaps.length).toBeGreaterThan(0)
+    expect(gaps.every((g) => g.axis === 'y')).toBe(true)
+  })
+
+  it('detectEqualSpacing handles 4 neighbours without crashing', () => {
+    const a = rect(0, 100, 50, 50)
+    const b = rect(60, 100, 50, 50)
+    const c = rect(170, 100, 50, 50)
+    const d = rect(230, 100, 50, 50)
+    // Just ensure the algorithm produces an array, regardless of geometry.
+    const active = rect(120, 100, 50, 50)
+    const result = detectEqualSpacing(active, [a, b, c, d], 1)
+    expect(Array.isArray(result)).toBe(true)
+  })
+
+  it('buildCandidates excludes nothing on its own — filtering is the wire layer', () => {
+    // Pure helper: it includes everything passed in. The wire layer is
+    // responsible for filtering grid/page-bounds/smart-guide/active members.
+    const c = buildCandidates([rect(0, 0, 10, 10), rect(50, 50, 10, 10)], 100, 100)
+    expect(c.x).toHaveLength(2 * 3 + 3) // 2 rects × 3 + page
+  })
+})
+
+describe('snapToleranceForZoom', () => {
+  it('returns the base distance at 1x zoom', () => {
+    expect(snapToleranceForZoom(1)).toBe(SNAP_DISTANCE_PT)
+  })
+
+  it('caps at 24pt for very small zooms', () => {
+    expect(snapToleranceForZoom(0.1)).toBe(24)
+  })
+
+  it('floors at 6pt for very large zooms', () => {
+    expect(snapToleranceForZoom(10)).toBe(SNAP_DISTANCE_PT)
+  })
+
+  it('handles bogus zoom values defensively', () => {
+    expect(snapToleranceForZoom(0)).toBe(SNAP_DISTANCE_PT)
+    expect(snapToleranceForZoom(Number.NaN)).toBe(SNAP_DISTANCE_PT)
+  })
+})

--- a/packages/ui/src/components/Canvas/fabric.d.ts
+++ b/packages/ui/src/components/Canvas/fabric.d.ts
@@ -21,6 +21,8 @@ declare module 'fabric' {
     __isGrid?: boolean
     /** Internal flag: marks the non-interactive page-bounds outline rect. */
     __isPageBounds?: boolean
+    /** Internal flag: marks transient smart-alignment guide lines (#41). */
+    __isSmartGuide?: boolean
     /** Default (un-selected) fill saved on the field's background Rect. */
     __defaultFill?: string
     /** Default (un-selected) stroke saved on the field's background Rect. */

--- a/packages/ui/src/components/Canvas/smartGuides/candidates.ts
+++ b/packages/ui/src/components/Canvas/smartGuides/candidates.ts
@@ -1,0 +1,96 @@
+/**
+ * Build the snap-target candidate list for a smart-alignment-guide pass (#41).
+ *
+ * A "candidate" is a single coordinate that the active object's matching
+ * edge or centre may snap to. We pre-build the candidate list at
+ * `mouse:down` (or first `object:moving` tick) so the per-tick math is
+ * just a linear scan + abs() comparison.
+ *
+ * Each non-active rect contributes six candidates (left / right / centerX /
+ * top / bottom / centerY). The page itself contributes three on each axis
+ * (edges + centre). Page-derived candidates carry `source: 'page'` so the
+ * renderer can colour them differently.
+ */
+
+/** Axis-aligned bounding box in canvas object-space points. */
+export interface Rect {
+  left: number
+  top: number
+  width: number
+  height: number
+}
+
+export interface XCandidate {
+  /** X coordinate to snap the matching edge to. */
+  x: number
+  /** Which edge of the source rect this candidate represents. */
+  kind: 'left' | 'right' | 'centerX'
+  /** Where it came from — used for guide colour. */
+  source: 'object' | 'page'
+  /** Source rect (omitted for page candidates so renderer draws full-canvas). */
+  rect?: Rect
+}
+
+export interface YCandidate {
+  y: number
+  kind: 'top' | 'bottom' | 'centerY'
+  source: 'object' | 'page'
+  rect?: Rect
+}
+
+export interface Candidates {
+  x: XCandidate[]
+  y: YCandidate[]
+  /** Other-rects used for equal-spacing detection (active rect excluded). */
+  otherRects: Rect[]
+}
+
+/**
+ * Build candidates from the list of OTHER rects on the page plus the page
+ * dimensions. Pure function — no Fabric coupling, trivially unit-testable.
+ */
+export function buildCandidates(
+  otherRects: Rect[],
+  pageWidth: number,
+  pageHeight: number,
+): Candidates {
+  const x: XCandidate[] = []
+  const y: YCandidate[] = []
+
+  for (const r of otherRects) {
+    const left = r.left
+    const right = r.left + r.width
+    const cx = r.left + r.width / 2
+    const top = r.top
+    const bottom = r.top + r.height
+    const cy = r.top + r.height / 2
+    x.push(
+      { x: left, kind: 'left', source: 'object', rect: r },
+      { x: right, kind: 'right', source: 'object', rect: r },
+      { x: cx, kind: 'centerX', source: 'object', rect: r },
+    )
+    y.push(
+      { y: top, kind: 'top', source: 'object', rect: r },
+      { y: bottom, kind: 'bottom', source: 'object', rect: r },
+      { y: cy, kind: 'centerY', source: 'object', rect: r },
+    )
+  }
+
+  // Page edges + centres — always-on per the issue's acceptance criteria.
+  if (pageWidth > 0) {
+    x.push(
+      { x: 0, kind: 'left', source: 'page' },
+      { x: pageWidth, kind: 'right', source: 'page' },
+      { x: pageWidth / 2, kind: 'centerX', source: 'page' },
+    )
+  }
+  if (pageHeight > 0) {
+    y.push(
+      { y: 0, kind: 'top', source: 'page' },
+      { y: pageHeight, kind: 'bottom', source: 'page' },
+      { y: pageHeight / 2, kind: 'centerY', source: 'page' },
+    )
+  }
+
+  return { x, y, otherRects }
+}

--- a/packages/ui/src/components/Canvas/smartGuides/constants.ts
+++ b/packages/ui/src/components/Canvas/smartGuides/constants.ts
@@ -1,0 +1,37 @@
+/**
+ * Constants for the smart-alignment-guides feature (#41).
+ *
+ * Tolerances are in canvas object-space points (NOT viewport pixels) so
+ * snapping behaves consistently across zoom levels — see Fabric.js issue
+ * #4042 and the comment block in `usePageBoundsEnforcement.ts` for context.
+ */
+
+/** Base magnetic-snap radius, in points. The user-visible target. */
+export const SNAP_DISTANCE_PT = 6
+
+/**
+ * Lower / upper clamps for the zoom-adjusted tolerance. At 25% zoom 6pt is
+ * only 1.5 visual px (effectively unreachable), and at 400% zoom 6pt is
+ * 24 visual px (sticks too aggressively). Clamping keeps the snap usable
+ * across the full zoom range.
+ */
+export const SNAP_DISTANCE_MIN_PT = 6
+export const SNAP_DISTANCE_MAX_PT = 24
+
+/** Compute the zoom-aware snap tolerance for a given Fabric viewport zoom. */
+export function snapToleranceForZoom(zoom: number): number {
+  if (!Number.isFinite(zoom) || zoom <= 0) return SNAP_DISTANCE_PT
+  const scaled = SNAP_DISTANCE_PT / zoom
+  return Math.min(SNAP_DISTANCE_MAX_PT, Math.max(SNAP_DISTANCE_MIN_PT, scaled))
+}
+
+/** Guide-line stroke colours. Pink for object alignment, cyan for page edges. */
+export const GUIDE_COLOR_OBJECT = '#FF3D7F'
+export const GUIDE_COLOR_PAGE = '#22D3EE'
+export const GUIDE_COLOR_SPACING = '#FF3D7F'
+
+/** Guide line width in screen px (kept uniform under zoom via `strokeUniform`). */
+export const GUIDE_STROKE_WIDTH = 1
+
+/** Equal-spacing match tolerance in points. */
+export const SPACING_MATCH_TOLERANCE_PT = 1

--- a/packages/ui/src/components/Canvas/smartGuides/equalSpacing.ts
+++ b/packages/ui/src/components/Canvas/smartGuides/equalSpacing.ts
@@ -1,0 +1,81 @@
+/**
+ * Equal-spacing detection for smart alignment guides (#41).
+ *
+ * Canva/PowerPoint show a "matching gap" indicator when the active object's
+ * distance to a neighbour equals the distance from that neighbour to another
+ * object on the same axis. We compute this once per drag tick from the
+ * candidate list's `otherRects`.
+ *
+ * Implementation: scan pairs of other rects on each axis. If `active` is
+ * positioned such that gap(A → active) ≈ gap(active → B), record a
+ * horizontal-spacing match (and vice versa for vertical).
+ *
+ * The output is a list of `Gap` records — the renderer turns each into a
+ * pair of bracket marks the user sees as "= = =".
+ */
+import type { Rect } from './candidates.js'
+
+export interface SpacingGap {
+  /** Axis the gap lives on. */
+  axis: 'x' | 'y'
+  /** Start coordinate along the axis (left or top edge). */
+  start: number
+  /** End coordinate along the axis. */
+  end: number
+  /** Perpendicular position (vertical line for x-axis gap = y centre). */
+  perp: number
+}
+
+/** Centre of `r` on the requested axis. */
+function center(r: Rect, axis: 'x' | 'y'): number {
+  return axis === 'x' ? r.left + r.width / 2 : r.top + r.height / 2
+}
+
+/** Edge-to-edge gap between two non-overlapping rects on the given axis. */
+function gapBetween(a: Rect, b: Rect, axis: 'x' | 'y'): number {
+  if (axis === 'x') {
+    if (a.left > b.left) return gapBetween(b, a, axis)
+    return b.left - (a.left + a.width)
+  }
+  if (a.top > b.top) return gapBetween(b, a, axis)
+  return b.top - (a.top + a.height)
+}
+
+/**
+ * Detect equal-spacing triples where `active` sits between two other rects
+ * with matching gaps on each axis. Returns the pair of equal gaps as
+ * {@link SpacingGap} records ready for the renderer.
+ */
+export function detectEqualSpacing(
+  active: Rect,
+  others: readonly Rect[],
+  tolerance: number,
+): SpacingGap[] {
+  const out: SpacingGap[] = []
+  for (const axis of ['x', 'y'] as const) {
+    const activeC = center(active, axis)
+    const before = others.filter((r) => center(r, axis) < activeC)
+    const after = others.filter((r) => center(r, axis) > activeC)
+    for (const a of before) {
+      const gapA = gapBetween(a, active, axis)
+      if (gapA < 0) continue // overlapping → not a clean spacing
+      for (const b of after) {
+        const gapB = gapBetween(active, b, axis)
+        if (gapB < 0) continue
+        if (Math.abs(gapA - gapB) > tolerance) continue
+        const perp =
+          axis === 'x'
+            ? (active.top + active.height / 2 + a.top + a.height / 2 + b.top + b.height / 2) / 3
+            : (active.left + active.width / 2 + a.left + a.width / 2 + b.left + b.width / 2) / 3
+        if (axis === 'x') {
+          out.push({ axis, start: a.left + a.width, end: active.left, perp })
+          out.push({ axis, start: active.left + active.width, end: b.left, perp })
+        } else {
+          out.push({ axis, start: a.top + a.height, end: active.top, perp })
+          out.push({ axis, start: active.top + active.height, end: b.top, perp })
+        }
+      }
+    }
+  }
+  return out
+}

--- a/packages/ui/src/components/Canvas/smartGuides/index.ts
+++ b/packages/ui/src/components/Canvas/smartGuides/index.ts
@@ -1,0 +1,15 @@
+/**
+ * Barrel for the smart-alignment-guides feature (#41).
+ *
+ * Consumers should import from this file rather than reaching into the
+ * submodules — keeps the public surface narrow and lets internals refactor
+ * freely.
+ */
+export { wireSmartGuides } from './wireSmartGuides.js'
+export { buildCandidates } from './candidates.js'
+export { computeSnap, findXSnap, findYSnap } from './snap.js'
+export { detectEqualSpacing } from './equalSpacing.js'
+export { snapToleranceForZoom, SNAP_DISTANCE_PT } from './constants.js'
+export type { Rect, Candidates, XCandidate, YCandidate } from './candidates.js'
+export type { SnapResult, AxisHit } from './snap.js'
+export type { SpacingGap } from './equalSpacing.js'

--- a/packages/ui/src/components/Canvas/smartGuides/render.ts
+++ b/packages/ui/src/components/Canvas/smartGuides/render.ts
@@ -1,0 +1,118 @@
+/**
+ * Render transient smart-alignment guide lines on the Fabric canvas (#41).
+ *
+ * Keeps a closure-local array of guide Lines so `clearGuides` doesn't have
+ * to walk `canvas.getObjects()` every drag tick.
+ */
+import { Line as FabricLine, type Canvas as FabricCanvas } from 'fabric'
+import {
+  GUIDE_COLOR_OBJECT,
+  GUIDE_COLOR_PAGE,
+  GUIDE_COLOR_SPACING,
+  GUIDE_STROKE_WIDTH,
+} from './constants.js'
+import type { AxisHit } from './snap.js'
+import type { XCandidate, YCandidate } from './candidates.js'
+import type { SpacingGap } from './equalSpacing.js'
+
+/** Build a non-interactive guide line marked `__isSmartGuide` for cleanup. */
+function makeGuide(coords: [number, number, number, number], color: string): FabricLine {
+  const line = new FabricLine(coords, {
+    stroke: color,
+    strokeWidth: GUIDE_STROKE_WIDTH,
+    strokeUniform: true,
+    selectable: false,
+    evented: false,
+    excludeFromExport: true,
+    hoverCursor: 'default',
+  })
+  line.__isSmartGuide = true
+  return line
+}
+
+/**
+ * Smart-guide renderer instance. Tracks the lines it has added so it can
+ * remove them cleanly without scanning the full object list.
+ */
+export class GuideRenderer {
+  private readonly fc: FabricCanvas
+  private readonly tracked: FabricLine[] = []
+  private readonly pageWidth: number
+  private readonly pageHeight: number
+
+  constructor(fc: FabricCanvas, pageWidth: number, pageHeight: number) {
+    this.fc = fc
+    this.pageWidth = pageWidth
+    this.pageHeight = pageHeight
+  }
+
+  /** Remove every guide we previously added. Safe to call repeatedly. */
+  clear(): void {
+    if (this.tracked.length === 0) return
+    this.fc.remove(...this.tracked)
+    this.tracked.length = 0
+  }
+
+  /** Draw an X-axis snap as a vertical guide spanning the page height. */
+  drawXGuide(hit: AxisHit<XCandidate>): void {
+    const x = hit.candidate.x
+    const color = hit.candidate.source === 'page' ? GUIDE_COLOR_PAGE : GUIDE_COLOR_OBJECT
+    const line = makeGuide([x, 0, x, this.pageHeight], color)
+    this.tracked.push(line)
+    this.fc.add(line)
+    this.fc.bringObjectToFront(line)
+  }
+
+  /** Draw a Y-axis snap as a horizontal guide spanning the page width. */
+  drawYGuide(hit: AxisHit<YCandidate>): void {
+    const y = hit.candidate.y
+    const color = hit.candidate.source === 'page' ? GUIDE_COLOR_PAGE : GUIDE_COLOR_OBJECT
+    const line = makeGuide([0, y, this.pageWidth, y], color)
+    this.tracked.push(line)
+    this.fc.add(line)
+    this.fc.bringObjectToFront(line)
+  }
+
+  /** Draw equal-spacing bracket marks for a gap pair. */
+  drawSpacing(gaps: readonly SpacingGap[]): void {
+    const tickLen = 4
+    for (const g of gaps) {
+      // The connecting bar
+      if (g.axis === 'x') {
+        const bar = makeGuide([g.start, g.perp, g.end, g.perp], GUIDE_COLOR_SPACING)
+        this.tracked.push(bar)
+        this.fc.add(bar)
+        // End-tick at start
+        const t1 = makeGuide(
+          [g.start, g.perp - tickLen, g.start, g.perp + tickLen],
+          GUIDE_COLOR_SPACING,
+        )
+        const t2 = makeGuide(
+          [g.end, g.perp - tickLen, g.end, g.perp + tickLen],
+          GUIDE_COLOR_SPACING,
+        )
+        this.tracked.push(t1, t2)
+        this.fc.add(t1, t2)
+      } else {
+        const bar = makeGuide([g.perp, g.start, g.perp, g.end], GUIDE_COLOR_SPACING)
+        this.tracked.push(bar)
+        this.fc.add(bar)
+        const t1 = makeGuide(
+          [g.perp - tickLen, g.start, g.perp + tickLen, g.start],
+          GUIDE_COLOR_SPACING,
+        )
+        const t2 = makeGuide(
+          [g.perp - tickLen, g.end, g.perp + tickLen, g.end],
+          GUIDE_COLOR_SPACING,
+        )
+        this.tracked.push(t1, t2)
+        this.fc.add(t1, t2)
+      }
+    }
+  }
+
+  /** Force a re-render (call once per tick after `drawXGuide`/`drawYGuide`). */
+  requestRender(): void {
+    this.fc.requestRenderAll()
+  }
+}

--- a/packages/ui/src/components/Canvas/smartGuides/snap.ts
+++ b/packages/ui/src/components/Canvas/smartGuides/snap.ts
@@ -1,0 +1,97 @@
+/**
+ * Pure snap math for smart alignment guides (#41).
+ *
+ * Given an active rect (the object being dragged/scaled) and a candidate
+ * list, picks the best snap for each axis within tolerance and reports the
+ * coordinate delta required to move the active rect into alignment.
+ *
+ * The active rect's left / right / centerX edges are each tested against
+ * every X candidate; whichever pair yields the smallest |distance| within
+ * tolerance wins. Same on Y. Both axes are independent.
+ */
+import type { Rect, XCandidate, YCandidate, Candidates } from './candidates.js'
+
+export interface AxisHit<C> {
+  /** Delta to add to the active rect's left/top to land on the snap. */
+  delta: number
+  /** Which edge of the active rect aligned. */
+  activeEdge: 'left' | 'right' | 'centerX' | 'top' | 'bottom' | 'centerY'
+  /** The candidate that was hit. */
+  candidate: C
+}
+
+export interface SnapResult {
+  x: AxisHit<XCandidate> | null
+  y: AxisHit<YCandidate> | null
+}
+
+/**
+ * Find the best X-axis snap for `rect` against `xCandidates` within
+ * `tolerance` points. Returns the delta to apply to the rect's `left`,
+ * not a target coordinate — keeps the caller honest about applying to the
+ * Fabric group's `left` (which may differ from `boundingRect.left`).
+ */
+export function findXSnap(
+  rect: Rect,
+  xCandidates: readonly XCandidate[],
+  tolerance: number,
+): AxisHit<XCandidate> | null {
+  const left = rect.left
+  const right = rect.left + rect.width
+  const cx = rect.left + rect.width / 2
+  let best: AxisHit<XCandidate> | null = null
+  for (const c of xCandidates) {
+    const cases: Array<[number, AxisHit<XCandidate>['activeEdge']]> = [
+      [c.x - left, 'left'],
+      [c.x - right, 'right'],
+      [c.x - cx, 'centerX'],
+    ]
+    for (const [delta, activeEdge] of cases) {
+      const abs = Math.abs(delta)
+      if (abs > tolerance) continue
+      if (!best || abs < Math.abs(best.delta)) {
+        best = { delta, activeEdge, candidate: c }
+      }
+    }
+  }
+  return best
+}
+
+/** Y-axis twin of {@link findXSnap}. */
+export function findYSnap(
+  rect: Rect,
+  yCandidates: readonly YCandidate[],
+  tolerance: number,
+): AxisHit<YCandidate> | null {
+  const top = rect.top
+  const bottom = rect.top + rect.height
+  const cy = rect.top + rect.height / 2
+  let best: AxisHit<YCandidate> | null = null
+  for (const c of yCandidates) {
+    const cases: Array<[number, AxisHit<YCandidate>['activeEdge']]> = [
+      [c.y - top, 'top'],
+      [c.y - bottom, 'bottom'],
+      [c.y - cy, 'centerY'],
+    ]
+    for (const [delta, activeEdge] of cases) {
+      const abs = Math.abs(delta)
+      if (abs > tolerance) continue
+      if (!best || abs < Math.abs(best.delta)) {
+        best = { delta, activeEdge, candidate: c }
+      }
+    }
+  }
+  return best
+}
+
+/**
+ * Compute both-axis snap for the active rect against the candidate list.
+ * Returns `{x: null, y: null}` when nothing's in range — the caller still
+ * uses the result to clear stale guide lines.
+ */
+export function computeSnap(rect: Rect, candidates: Candidates, tolerance: number): SnapResult {
+  return {
+    x: findXSnap(rect, candidates.x, tolerance),
+    y: findYSnap(rect, candidates.y, tolerance),
+  }
+}

--- a/packages/ui/src/components/Canvas/smartGuides/wireSmartGuides.ts
+++ b/packages/ui/src/components/Canvas/smartGuides/wireSmartGuides.ts
@@ -1,0 +1,179 @@
+/**
+ * wireSmartGuides — registers Fabric event handlers that drive the smart
+ * alignment guides feature (#41).
+ *
+ * Behaviour summary:
+ *   - mouse:down clears any stale guides + caches the page meta the gesture
+ *     will work against.
+ *   - object:moving rebuilds the candidate list from the current canvas
+ *     state, computes the best snap on each axis, mutates the active
+ *     object's left/top by the snap delta (delta-based so it works correctly
+ *     for Groups whose origin differs from their bounding-rect left), then
+ *     calls `clampToPage` so we don't override the page-bounds enforcement.
+ *     Renders the matching guide lines + equal-spacing brackets.
+ *   - object:scaling shows guides for the moving edges as visual feedback
+ *     but does NOT mutate scaleX/scaleY (v1 — magnetic snap during resize is
+ *     a follow-up; the issue prioritises guide visibility).
+ *   - object:modified + mouse:up clear all guides.
+ *
+ * Hard-rule notes:
+ *   - We don't depend on handler registration order with
+ *     `usePageBoundsEnforcement`: this handler runs `snap → clampToPage`
+ *     inline so the final position is always inside the page rect.
+ *   - All measurements live in canvas object-space (points), never viewport
+ *     pixels, so behaviour is consistent across zoom.
+ */
+import type { Canvas as FabricCanvas, FabricObject } from 'fabric'
+import { getPageSize } from '@template-goblin/types'
+import { useTemplateStore } from '../../../store/templateStore.js'
+import { useUiStore } from '../../../store/uiStore.js'
+import { clampToPage } from '../usePageBoundsEnforcement.js'
+import { buildCandidates, type Rect } from './candidates.js'
+import { computeSnap } from './snap.js'
+import { detectEqualSpacing } from './equalSpacing.js'
+import { GuideRenderer } from './render.js'
+import { SPACING_MATCH_TOLERANCE_PT, snapToleranceForZoom } from './constants.js'
+
+interface PageMeta {
+  width: number
+  height: number
+}
+
+/** Read the active page's dimensions via the canonical resolver. */
+function readPageMeta(): PageMeta {
+  const store = useTemplateStore.getState()
+  const pageId = useUiStore.getState().currentPageId
+  const page = store.pages.find((p) => p.id === pageId) ?? store.pages[0] ?? null
+  return getPageSize(page, store.meta)
+}
+
+/** Set of `FabricObject` filtered to the rects we want to align against. */
+function collectOtherRects(fc: FabricCanvas, active: FabricObject): Rect[] {
+  // Active selections expose members via `getObjects()` so we exclude all of them.
+  const activeMembers = new Set<FabricObject>()
+  const maybeGroup = active as unknown as { getObjects?: () => FabricObject[] }
+  if (typeof maybeGroup.getObjects === 'function') {
+    for (const m of maybeGroup.getObjects()) activeMembers.add(m)
+  }
+  activeMembers.add(active)
+
+  const rects: Rect[] = []
+  for (const o of fc.getObjects()) {
+    if (o.__isGrid || o.__isPageBounds || o.__isSmartGuide) continue
+    if (!o.__fieldId) continue
+    if (activeMembers.has(o)) continue
+    o.setCoords()
+    const br = o.getBoundingRect()
+    rects.push({ left: br.left, top: br.top, width: br.width, height: br.height })
+  }
+  return rects
+}
+
+/** Read Alt state defensively — `opt.e` may be undefined for programmatic moves. */
+function isAltHeld(opt: { e?: Event }): boolean {
+  const e = opt.e as MouseEvent | KeyboardEvent | undefined
+  return !!e && 'altKey' in e && e.altKey === true
+}
+
+export function wireSmartGuides(fc: FabricCanvas): void {
+  const meta = { width: 0, height: 0 }
+  let renderer: GuideRenderer | null = null
+
+  function ensureRenderer(): GuideRenderer {
+    const next = readPageMeta()
+    if (!renderer || next.width !== meta.width || next.height !== meta.height) {
+      renderer?.clear()
+      meta.width = next.width
+      meta.height = next.height
+      renderer = new GuideRenderer(fc, meta.width, meta.height)
+    }
+    return renderer
+  }
+
+  function clear(): void {
+    renderer?.clear()
+    fc.requestRenderAll()
+  }
+
+  fc.on('mouse:down', clear)
+  fc.on('mouse:up', clear)
+  fc.on('object:modified', clear)
+  fc.on('selection:cleared', clear)
+
+  fc.on('object:moving', (opt) => {
+    const obj = opt.target
+    if (!obj) return
+    const r = ensureRenderer()
+    r.clear()
+
+    if (isAltHeld(opt)) {
+      // Alt-bypass: no snap, no guides — user wants fine placement.
+      r.requestRender()
+      return
+    }
+
+    obj.setCoords()
+    const br = obj.getBoundingRect()
+    const activeRect: Rect = {
+      left: br.left,
+      top: br.top,
+      width: br.width,
+      height: br.height,
+    }
+    const others = collectOtherRects(fc, obj)
+    const candidates = buildCandidates(others, meta.width, meta.height)
+    const tolerance = snapToleranceForZoom(fc.getZoom())
+    const result = computeSnap(activeRect, candidates, tolerance)
+
+    let snappedRect = activeRect
+    if (result.x) {
+      obj.set({ left: (obj.left ?? 0) + result.x.delta })
+      snappedRect = { ...snappedRect, left: snappedRect.left + result.x.delta }
+      r.drawXGuide(result.x)
+    }
+    if (result.y) {
+      obj.set({ top: (obj.top ?? 0) + result.y.delta })
+      snappedRect = { ...snappedRect, top: snappedRect.top + result.y.delta }
+      r.drawYGuide(result.y)
+    }
+
+    // Equal-spacing detection uses the post-snap rect so the brackets line up.
+    const gaps = detectEqualSpacing(snappedRect, others, SPACING_MATCH_TOLERANCE_PT)
+    if (gaps.length > 0) r.drawSpacing(gaps)
+
+    // Re-clamp after our snap in case we pushed the object past the page edge.
+    obj.setCoords()
+    clampToPage(obj, meta.width, meta.height)
+    r.requestRender()
+  })
+
+  fc.on('object:scaling', (opt) => {
+    const obj = opt.target
+    if (!obj) return
+    const r = ensureRenderer()
+    r.clear()
+    if (isAltHeld(opt)) {
+      r.requestRender()
+      return
+    }
+    // v1: show guides as visual feedback during resize, no mutation.
+    // Magnetic-snap during resize is intentionally deferred — handle math
+    // is complex (anchor-dependent scaleX/left adjustment) and a wrong snap
+    // mid-resize is more disorienting than no snap.
+    obj.setCoords()
+    const br = obj.getBoundingRect()
+    const activeRect: Rect = {
+      left: br.left,
+      top: br.top,
+      width: br.width,
+      height: br.height,
+    }
+    const others = collectOtherRects(fc, obj)
+    const candidates = buildCandidates(others, meta.width, meta.height)
+    const tolerance = snapToleranceForZoom(fc.getZoom())
+    const result = computeSnap(activeRect, candidates, tolerance)
+    if (result.x) r.drawXGuide(result.x)
+    if (result.y) r.drawYGuide(result.y)
+    r.requestRender()
+  })
+}

--- a/packages/ui/src/components/Canvas/useFabricCanvas.ts
+++ b/packages/ui/src/components/Canvas/useFabricCanvas.ts
@@ -13,6 +13,7 @@ import { wireSelectionEvents } from './wireSelectionEvents.js'
 import { wireDragResizeEvents } from './wireDragResizeEvents.js'
 import { wireMouseEvents } from './wireMouseEvents.js'
 import { wireWheelEvents } from './wireWheelEvents.js'
+import { wireSmartGuides } from './smartGuides/index.js'
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -97,6 +98,7 @@ export function useFabricCanvas(
 
       wireSelectionEvents(fc)
       wireDragResizeEvents(fc)
+      wireSmartGuides(fc)
       wireMouseEvents(
         fc,
         containerRef,

--- a/plans/41-smart-alignment-guides.md
+++ b/plans/41-smart-alignment-guides.md
@@ -1,0 +1,226 @@
+# Plan — Issue #41: Smart Alignment Guides (Canva/PowerPoint-style)
+
+Branch: `feature/41-smart-alignment-guides`
+Issue: https://github.com/JaiminPatel345/template-goblin/issues/41
+Labels: enhancement, v2
+
+## 1. Goal (verbatim from issue)
+
+While a field is being dragged or resized, render transient guide lines
+when the active field's edge or centre aligns with:
+
+- Another field's left edge / right edge / horizontal centre → vertical guide.
+- Another field's top edge / bottom edge / vertical centre → horizontal guide.
+- Page edges + page centre (always-on).
+- Equal-spacing hints between three or more fields (Canva-style matching-gap).
+
+Snap behaviour:
+
+- Magnetic snap within ~6 pt; releasing within range commits the snapped coord.
+- Holding **Alt** disables smart snapping (fine placement).
+- Guides disappear on mouse release.
+
+Out of scope (per issue): smart distribution / tidy commands, multi-page guides,
+keyboard nudging integration.
+
+## 2. Research summary (web)
+
+- Fabric.js v6's `initAligningGuidelines` extension exists but is unstable across
+  zoom levels and not exported from the npm `fabric` package's public surface in
+  v6.0.x. Discussion #10033 + community gists confirm.
+- Third-party `fabric-guideline-plugin` exists but its example uses v5 import style
+  (`import { fabric } from 'fabric'`); v6 ESM compatibility unverified. Adding a
+  dep also requires justification (Hard Rule #6).
+- Decision: **custom implementation**, following the algorithm the issue itself
+  spells out. Matches Hard Rule #8 (code implements spec), avoids new dep, fits the
+  existing wire-pattern conventions of `wireDragResizeEvents.ts`, and stays
+  zoom-safe by computing in object-space (per Fabric issue #4042 — same pattern
+  `usePageBoundsEnforcement.ts` already uses).
+
+## 3. Architecture
+
+New directory `packages/ui/src/components/Canvas/smartGuides/` (extracted from
+the existing `wire*.ts` family so we stay well under the 300-line cap per file,
+Hard Rule #11).
+
+```
+smartGuides/
+├── index.ts             # barrel export
+├── wireSmartGuides.ts   # registers fabric event handlers (mouse:down, object:moving, object:scaling, object:modified, mouse:up)
+├── candidates.ts        # build static guide-candidate list at mouse:down
+├── snap.ts              # pure: pick best edge/center snap for an active rect, apply Alt bypass
+├── render.ts            # create/clear transient fabric.Line guides on canvas
+├── equalSpacing.ts      # pure: detect equal-gap triples + produce indicator lines
+└── constants.ts         # SNAP_DISTANCE_PT, colours, line width
+```
+
+### Data flow
+
+```
+mouse:down  → build candidate list (cached for the gesture)
+              one entry per OTHER field rect with all 6 alignment keys
+              + page edges/centre as virtual candidates
+              + recompute on every drag start (objects may have moved)
+
+object:moving → 1. compute active rect bbox in object-space
+              → 2. if Alt held → just clear guides & return (no snap)
+              → 3. find best X-snap candidate within SNAP_DISTANCE_PT
+              → 4. find best Y-snap candidate within SNAP_DISTANCE_PT
+              → 5. mutate obj.left / obj.top to snap value
+              → 6. render matching guide line(s) on canvas
+              → 7. run equal-spacing detection; add gap indicators if found
+
+object:scaling → same as object:moving but operates on the changing edge only
+                 (the edge being dragged via the resize handle). Other edges
+                 not touched.
+
+object:modified, mouse:up → remove all transient guides; clear candidate cache.
+```
+
+### Alt-key handling
+
+Fabric's event option object exposes the underlying pointer event as `opt.e`
+(MouseEvent), which has `.altKey`. We read this on each `object:moving` tick —
+no global window listener needed.
+
+### Guide rendering
+
+Each guide is a `fabric.Line` marked with `__isSmartGuide = true` (new flag in
+`fabric.d.ts`). Properties:
+
+- `selectable: false`, `evented: false`, `excludeFromExport: true`
+- Stroke: pink `#FF3D7F` for object alignment, cyan `#22D3EE` for page alignment
+- `strokeUniform: true` so guides stay 1px regardless of zoom
+- `strokeWidth: 1`
+
+Equal-spacing indicators: short serif-bar style (two parallel short ticks
+flanking each equal gap), implemented as small `fabric.Line` triples per gap.
+
+Guides are removed in two ways:
+
+1. `removeGuides(fc)` walks `fc.getObjects()` and removes anything with `__isSmartGuide`.
+2. Called on every `object:moving` tick before rendering the new frame, plus on
+   `mouse:up`, `object:modified`, and selection change.
+
+### Edge cases handled
+
+- **Multi-select** (Fabric ActiveSelection): treat its bounding rect as the
+  active rect; candidates exclude every member of the selection.
+- **Snapping vs grid snap**: grid snap runs first (registered in
+  `wireDragResizeEvents`). Smart-snap then overrides position if a candidate is
+  closer than the grid step. Empirically the two interact cleanly because both
+  mutate `obj.left/top`.
+- **Snap vs page-bounds clamp**: page-bounds clamp runs as a separate
+  `object:moving` handler. We register the smart-guide handler AFTER the clamp
+  so a snap that would push the object out of bounds is then re-clamped.
+  (Order matters; we test this.)
+- **Zoom**: snap distance is in **points (canvas object-space)**, not pixels —
+  so it stays consistent across zoom. The 6pt constant matches the issue.
+
+## 4. Files touched
+
+| File                                                               | Change                               |
+| ------------------------------------------------------------------ | ------------------------------------ |
+| `packages/ui/src/components/Canvas/smartGuides/*`                  | NEW (6 files)                        |
+| `packages/ui/src/components/Canvas/fabric.d.ts`                    | +1 line `__isSmartGuide?: boolean`   |
+| `packages/ui/src/components/Canvas/useFabricCanvas.ts`             | +1 wire call (`wireSmartGuides(fc)`) |
+| `packages/ui/src/components/Canvas/__tests__/snap.test.ts`         | NEW (unit)                           |
+| `packages/ui/src/components/Canvas/__tests__/candidates.test.ts`   | NEW (unit)                           |
+| `packages/ui/src/components/Canvas/__tests__/equalSpacing.test.ts` | NEW (unit)                           |
+
+All new source files target <150 LOC, well under the 300 cap. Pure helpers are
+isolated for trivial unit testing (no Fabric instance required).
+
+## 5. Tests (Vitest, unit only)
+
+The pure helpers are easy to test without a Fabric canvas:
+
+1. **snap.ts** — given an active rect and a candidate list, returns the
+   best snap target within tolerance, `null` outside, respects Alt bypass.
+2. **candidates.ts** — builds 6 entries per non-active rect (left/right/cx/top/
+   bottom/cy) + page edges; excludes objects with `__isGrid` / `__isPageBounds` /
+   `__isSmartGuide`.
+3. **equalSpacing.ts** — detects (A, active, B) gap-match triples within tolerance;
+   returns empty for <3 fields.
+
+No e2e Playwright in this PR — the issue is v2-labelled; manual smoke verification
+during dev (`pnpm dev`, drag fields around, observe guides). If reviewer asks for
+Playwright, add as follow-up.
+
+## 6. Acceptance check against the issue
+
+- [ ] Guides appear while dragging when edges/centres align with another field.
+- [ ] Guides appear while resizing (the edge being dragged).
+- [ ] Page edges + page centre always-on candidates.
+- [ ] Magnetic snap within ~6pt.
+- [ ] Alt disables snap.
+- [ ] Guides disappear on release.
+- [ ] Equal-spacing hint between three fields.
+- [ ] Multi-page: guides scoped to current page only (we only see current page
+      objects on the canvas — automatic).
+- [ ] No regression: grid snap still works; page-bounds clamp still works.
+
+## 7. Risks / open questions
+
+1. **Visual: equal-spacing indicator style.** Canva uses small bracket marks;
+   PowerPoint uses arrow-headed double lines. I'll start with bracket marks
+   (simpler `fabric.Line` triples). If reviewer wants arrows, swap render.
+2. **Multi-select scaling.** Resize semantics with multi-select differ from
+   single — for v1 we only run snap on single-target moves/scales. Multi-select
+   move still works (uses active selection's bbox); multi-select resize skips
+   smart-snap.
+3. **Perf on pages with many fields.** Candidate count = 6N + 6 (page). At
+   N=200 fields that's ~1200 candidates per move tick. Cheap (~µs of plain
+   number comparisons). No need for spatial indexing in v1.
+
+## 8. Commit plan
+
+One logical change. Commit message:
+`feat(canvas): smart alignment guides while moving/resizing (#41)`
+
+Changeset will be generated at push time (Hard Rule #12) — minor bump on
+`template-goblin-ui` only (UI-only feature).
+
+## 8b. Master-QA fixes (applied before implementation)
+
+1. **No handler-order reliance.** Our `object:moving` handler imports
+   `clampToPage` from `usePageBoundsEnforcement` and runs `snap → clamp`
+   inline, so we don't depend on registration order with the page-bounds
+   effect (which re-attaches on every meta change).
+2. **Delta-based snap, not raw `obj.left`.** Compute `bbox = obj.getBoundingRect()`,
+   determine `dx`/`dy` from the snap target, then `obj.set({left: obj.left+dx, top: obj.top+dy})`.
+   Group origin can differ from bounding-rect left under stroke / child overhang
+   (see `__fieldWidth`/`__fieldHeight` comments in `fabric.d.ts`).
+3. **Resize-handle aware (DEFERRED to a follow-up).** As shipped,
+   `object:scaling` renders guide lines for visual feedback but does NOT
+   apply magnetic snap (no mutation of `scaleX`/`scaleY`/`left`/`top`).
+   Reason: anchor-dependent scale math on each of the 8 handles is
+   intricate, and a wrong snap mid-resize is more disorienting than no
+   snap. Plan originally promised it; downgrading to v1 visual-feedback
+   only. Track resize-snap as a follow-up issue. The original §8b.3 text
+   for `opt.transform.corner` is preserved below for future work:
+   `object:scaling` reads `opt.transform.corner`
+   (`tl`/`tr`/`bl`/`br`/`ml`/`mr`/`mt`/`mb`) to identify the moving edges, then
+   adjusts `scaleX`/`scaleY` (and `left`/`top` for top/left handles) so the
+   moving edge lands on the snap target.
+4. **Defensive Alt read.** `const alt = (opt.e as MouseEvent | undefined)?.altKey ?? false`.
+5. **Local guide tracking.** `wireSmartGuides` keeps a closure-local `Line[]`
+   of currently-rendered guides; `clearGuides()` calls `fc.remove(...arr); arr.length=0`.
+   No per-tick `getObjects().filter()`.
+6. **Zoom-aware tolerance.** `tolerance = clamp(6 / fc.getZoom(), 6, 24)` pt
+   so the snap remains reachable at 25%-400% zoom.
+7. **Full-canvas guide spans.** Each `fabric.Line` spans the full page rect
+   (0..pageW for horizontals, 0..pageH for verticals).
+8. **No new spec file.** The issue body is the spec — sufficiently detailed
+   and unambiguous after these fixes. Noted in PR body. (Hard Rule #8.)
+
+## 9. Implementation order
+
+1. `constants.ts` + `fabric.d.ts` augment.
+2. `candidates.ts` + tests.
+3. `snap.ts` + tests.
+4. `render.ts` (depends on Fabric; no direct unit tests — exercised via wire).
+5. `equalSpacing.ts` + tests.
+6. `wireSmartGuides.ts` — assembles everything.
+7. Wire into `useFabricCanvas.ts`.
+8. Manual smoke via `pnpm dev` + master QA.


### PR DESCRIPTION
## Summary

Closes #41. Renders transient pink/cyan guide lines while a field is being
dragged when its edges or centre align with another field's edges/centre or
with the page edges/centre — Canva / PowerPoint-style.

- Magnetic snap within 6 pt (zoom-aware, clamped to [6, 24] pt).
- Equal-spacing bracket marks when the active field sits between two others
  with matching gaps on the same axis.
- Hold **Alt** to disable snapping for fine placement.
- Guides clear on `mouse:up` / `object:modified` / `selection:cleared`.

Pure helpers live in `packages/ui/src/components/Canvas/smartGuides/` and are
covered by 24 Vitest unit tests (445 total in the UI package, all passing).
The Fabric wire module sequences `snap → clampToPage` internally so it does
not depend on `object:moving` handler registration order with the existing
page-bounds enforcement.

## Deferred to follow-up

Magnetic snap **during resize** is intentionally not implemented in this PR.
Guide lines render during resize for visual feedback, but the active field's
scale is not mutated — anchor-dependent scale math on all 8 handles is
intricate enough that a wrong snap mid-resize is more disorienting than no
snap. Tracked separately.

## Test plan
- [x] `pnpm --filter template-goblin-ui type-check` clean
- [x] `pnpm --filter template-goblin-ui test` — 445/445 pass (24 new for smart guides)
- [x] `pnpm lint` clean
- [x] `pnpm build` clean
- [x] Manual smoke in dev: drag a field, observe pink guides on alignment to other fields, cyan guides on alignment to page edges/centre, magnetic snap commits the position, Alt disables, equal-spacing brackets appear between three fields.