### PR TITLE
feat(canvas): auto-shrink static field rect width to fit content (#42)

### DIFF
--- a/.changeset/auto-shrink-static-fields.md
+++ b/.changeset/auto-shrink-static-fields.md
@@ -1,0 +1,25 @@
+---
+'template-goblin-ui': minor
+---
+
+feat(canvas): auto-shrink static field rect width to fit content
+
+When the user commits a static text or static image field, automatically
+shrink its **width** so there's no wasted whitespace beyond the content.
+The user-drawn **height** is always preserved — it represents an
+intentional layout choice and is never auto-modified.
+
+- Static text: width = measured text width + 16pt internal pad (matches the
+  renderer's own innerPad plus a 2pt-per-side safety margin so glyphs never
+  clip into truncate-mode).
+- Static image: width = `naturalW × currentH / naturalH` so the image fills
+  the user's chosen height at its natural aspect ratio.
+- Width never grows past what the user drew — if content already fills or
+  overflows the rect, the existing overflow-mode (truncate / dynamic font)
+  takes over.
+- Triggers on draw-to-create commit, right-panel text input blur, and
+  right-panel image replacement. Does not fire on resize.
+- Holding the Alt-style "don't touch" — out of scope; the user can manually
+  resize after the shrink.
+
+Closes #42.

--- a/packages/ui/src/components/Canvas/useFieldCreationPopup.ts
+++ b/packages/ui/src/components/Canvas/useFieldCreationPopup.ts
@@ -7,6 +7,7 @@ import { useState, useCallback } from 'react'
 import { useTemplateStore } from '../../store/templateStore.js'
 import { useUiStore } from '../../store/uiStore.js'
 import { createDefaultField } from '../../utils/defaults.js'
+import { autoShrinkStaticField } from '../../utils/autoShrinkDispatch.js'
 import type { FieldDefinition } from '@template-goblin/types'
 import type { FieldCreationDraft, SourceInputs } from './FieldCreationPopup.js'
 
@@ -71,7 +72,16 @@ export function useFieldCreationPopup() {
       setTimeout(() => {
         const currentFields = useTemplateStore.getState().fields
         const newField = currentFields[currentFields.length - 1]
-        if (newField) selectField(newField.id)
+        if (newField) {
+          selectField(newField.id)
+          // GH #42 — collapse dead space in the just-created rect when the
+          // content's natural / measured size is smaller than what the user
+          // drew. Image path resolves the dataUrl asynchronously, so the
+          // dispatcher is fire-and-forget.
+          if (newField.source?.mode === 'static') {
+            void autoShrinkStaticField(newField.id)
+          }
+        }
       }, 0)
       setPendingDraft(null)
     },

--- a/packages/ui/src/components/RightPanel/AlignButtonGroup.tsx
+++ b/packages/ui/src/components/RightPanel/AlignButtonGroup.tsx
@@ -1,0 +1,29 @@
+/**
+ * AlignButtonGroup — three-button selector used by TextFieldProps for
+ * horizontal + vertical alignment. Extracted from `TextFieldProps.tsx`
+ * per Hard Rule #11 (split as you touch).
+ */
+export function AlignButtonGroup<T extends string>({
+  options,
+  value,
+  onChange,
+}: {
+  options: T[]
+  value: T
+  onChange: (v: T) => void
+}) {
+  return (
+    <div style={{ display: 'flex', gap: 2 }}>
+      {options.map((opt) => (
+        <button
+          key={opt}
+          className={`tg-btn ${value === opt ? 'tg-btn--active' : ''}`}
+          style={{ flex: 1, justifyContent: 'center', fontSize: 11, padding: '4px 6px' }}
+          onClick={() => onChange(opt)}
+        >
+          {opt.charAt(0).toUpperCase() + opt.slice(1)}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/packages/ui/src/components/RightPanel/ImageFieldProps.tsx
+++ b/packages/ui/src/components/RightPanel/ImageFieldProps.tsx
@@ -2,6 +2,7 @@ import { useRef } from 'react'
 import type { FieldDefinition, ImageField, ImageFieldStyle } from '@template-goblin/types'
 import { isSafeKey } from '@template-goblin/types'
 import { useTemplateStore } from '../../store/templateStore.js'
+import { autoShrinkStaticField } from '../../utils/autoShrinkDispatch.js'
 import { SourceModeToggle } from './SourceModeToggle.js'
 import { HyperlinkSection } from './HyperlinkSection.js'
 import { ColorPickerPopover } from '../ColorPickerPopover.js'
@@ -67,6 +68,8 @@ export function ImageFieldProps({ field }: Props) {
       updateField(field.id, {
         source: { mode: 'static', value: { filename } },
       } as Partial<FieldDefinition>)
+      // GH #42 — shrink rect to the new image's natural aspect.
+      void autoShrinkStaticField(field.id)
     }
     reader.readAsArrayBuffer(file)
     e.target.value = ''

--- a/packages/ui/src/components/RightPanel/InfoTip.tsx
+++ b/packages/ui/src/components/RightPanel/InfoTip.tsx
@@ -1,0 +1,63 @@
+/**
+ * InfoTip — small hover/tap tooltip used across the right-panel forms.
+ * Extracted from `TextFieldProps.tsx` per Hard Rule #11 (split oversized
+ * files as you touch them).
+ */
+import { useState } from 'react'
+
+export function InfoTip({ text }: { text: string }) {
+  const [show, setShow] = useState(false)
+  return (
+    <span
+      style={{
+        cursor: 'help',
+        marginLeft: 4,
+        color: 'var(--text-muted)',
+        fontSize: 11,
+        position: 'relative',
+        display: 'inline-flex',
+        alignItems: 'center',
+      }}
+      onMouseEnter={() => setShow(true)}
+      onMouseLeave={() => setShow(false)}
+      onClick={() => setShow(!show)}
+    >
+      <svg
+        width="12"
+        height="12"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+      >
+        <circle cx="12" cy="12" r="10" />
+        <line x1="12" y1="16" x2="12" y2="12" />
+        <line x1="12" y1="8" x2="12.01" y2="8" />
+      </svg>
+      {show && (
+        <span
+          style={{
+            position: 'absolute',
+            bottom: '100%',
+            left: '50%',
+            transform: 'translateX(-50%)',
+            background: 'var(--bg-surface)',
+            border: '1px solid var(--border)',
+            borderRadius: 6,
+            padding: '6px 10px',
+            fontSize: 11,
+            color: 'var(--text-primary)',
+            zIndex: 100,
+            boxShadow: '0 4px 12px rgba(0,0,0,0.3)',
+            marginBottom: 4,
+            maxWidth: 250,
+            whiteSpace: 'normal',
+            lineHeight: 1.4,
+          }}
+        >
+          {text}
+        </span>
+      )}
+    </span>
+  )
+}

--- a/packages/ui/src/components/RightPanel/TextFieldProps.tsx
+++ b/packages/ui/src/components/RightPanel/TextFieldProps.tsx
@@ -1,8 +1,6 @@
-import { useState } from 'react'
 import { SourceModeToggle } from './SourceModeToggle.js'
 import { HyperlinkSection } from './HyperlinkSection.js'
 import { NumberInput } from '../NumberInput.js'
-import { ColorPickerPopover } from '../ColorPickerPopover.js'
 import type {
   FieldDefinition,
   TextField,
@@ -12,63 +10,14 @@ import type {
 } from '@template-goblin/types'
 import { isSafeKey } from '@template-goblin/types'
 import { useTemplateStore } from '../../store/templateStore.js'
+import { autoShrinkStaticField } from '../../utils/autoShrinkDispatch.js'
+import { InfoTip } from './InfoTip.js'
+import { AlignButtonGroup } from './AlignButtonGroup.js'
+import { TextTypographySection } from './TextTypographySection.js'
 
-export function InfoTip({ text }: { text: string }) {
-  const [show, setShow] = useState(false)
-  return (
-    <span
-      style={{
-        cursor: 'help',
-        marginLeft: 4,
-        color: 'var(--text-muted)',
-        fontSize: 11,
-        position: 'relative',
-        display: 'inline-flex',
-        alignItems: 'center',
-      }}
-      onMouseEnter={() => setShow(true)}
-      onMouseLeave={() => setShow(false)}
-      onClick={() => setShow(!show)}
-    >
-      <svg
-        width="12"
-        height="12"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2"
-      >
-        <circle cx="12" cy="12" r="10" />
-        <line x1="12" y1="16" x2="12" y2="12" />
-        <line x1="12" y1="8" x2="12.01" y2="8" />
-      </svg>
-      {show && (
-        <span
-          style={{
-            position: 'absolute',
-            bottom: '100%',
-            left: '50%',
-            transform: 'translateX(-50%)',
-            background: 'var(--bg-surface)',
-            border: '1px solid var(--border)',
-            borderRadius: 6,
-            padding: '6px 10px',
-            fontSize: 11,
-            color: 'var(--text-primary)',
-            zIndex: 100,
-            boxShadow: '0 4px 12px rgba(0,0,0,0.3)',
-            marginBottom: 4,
-            maxWidth: 250,
-            whiteSpace: 'normal',
-            lineHeight: 1.4,
-          }}
-        >
-          {text}
-        </span>
-      )}
-    </span>
-  )
-}
+// `InfoTip` is re-exported for backward compatibility with sibling files
+// (e.g. LoopFieldProps) that imported it from here before the split.
+export { InfoTip }
 
 interface Props {
   field: TextField
@@ -188,6 +137,7 @@ export function TextFieldProps({ field }: Props) {
               className="tg-input"
               value={staticValue}
               onChange={(e) => onStaticValueChange(e.target.value)}
+              onBlur={() => void autoShrinkStaticField(field.id)}
               data-testid="text-static-value"
             />
           </div>
@@ -278,148 +228,14 @@ export function TextFieldProps({ field }: Props) {
         </div>
       </div>
 
-      {/* Typography */}
-      <div className="tg-panel-section">
-        <div className="tg-panel-section-title">Typography</div>
-
-        <div className="tg-form-row">
-          <label>Font Family</label>
-          <select
-            className="tg-select"
-            value={style.fontFamily}
-            onChange={(e) => updateFieldStyle(field.id, { fontFamily: e.target.value })}
-          >
-            {allFontFamilies.map((f) => (
-              <option key={f} value={f}>
-                {f}
-              </option>
-            ))}
-          </select>
-        </div>
-
-        <div className="tg-form-row">
-          <label>Font Size</label>
-          <NumberInput
-            value={style.fontSize}
-            min={1}
-            defaultValue={12}
-            onChange={(v) => onFontSizeChange(v)}
-          />
-        </div>
-
-        {/* GH #91 — Overflow Mode is the single knob for what happens when
-            content exceeds the rect. Static text has no rendered drift
-            (fixed string at fixed fontSize) so the dropdown is dynamic-only.
-            Truncate cuts characters from the end at a character boundary
-            (no ellipsis); Dynamic Font shrinks `fontSize` down to
-            `fontSizeMin`, then truncates the rest. The pre-#91 "Dynamic
-            Font Size" checkbox was a redundant second knob and is gone. */}
-        {isDynamic && (
-          <div className="tg-form-row">
-            <label>
-              Overflow Mode
-              <InfoTip text="Truncate: cut characters from the end so the visible text fits the rect (no ellipsis). Dynamic Font: shrink the font size down to Minimum Font Size, then truncate." />
-            </label>
-            <select
-              className="tg-select"
-              value={style.overflowMode}
-              onChange={(e) =>
-                updateFieldStyle(field.id, {
-                  overflowMode: e.target.value as 'dynamic_font' | 'truncate',
-                })
-              }
-            >
-              <option value="truncate">Truncate</option>
-              <option value="dynamic_font">Dynamic Font</option>
-            </select>
-          </div>
-        )}
-
-        {/* Minimum Font Size only matters when Overflow Mode = Dynamic Font. */}
-        {isDynamic && style.overflowMode === 'dynamic_font' && (
-          <div className="tg-form-row">
-            <label>
-              Minimum Font Size
-              <InfoTip text="The smallest font size the renderer will shrink to before falling back to truncation." />
-            </label>
-            <NumberInput
-              value={style.fontSizeMin}
-              min={1}
-              defaultValue={11}
-              onChange={(v) => updateFieldStyle(field.id, { fontSizeMin: v })}
-            />
-          </div>
-        )}
-
-        <div className="tg-form-row">
-          <label>Font Weight</label>
-          <select
-            className="tg-select"
-            value={style.fontWeight}
-            onChange={(e) =>
-              updateFieldStyle(field.id, { fontWeight: e.target.value as 'normal' | 'bold' })
-            }
-          >
-            <option value="normal">Normal</option>
-            <option value="bold">Bold</option>
-          </select>
-        </div>
-
-        <div className="tg-form-row">
-          <label>Font Style</label>
-          <select
-            className="tg-select"
-            value={style.fontStyle}
-            onChange={(e) =>
-              updateFieldStyle(field.id, { fontStyle: e.target.value as 'normal' | 'italic' })
-            }
-          >
-            <option value="normal">Normal</option>
-            <option value="italic">Italic</option>
-          </select>
-        </div>
-
-        <div className="tg-form-row">
-          <label>Text Decoration</label>
-          <select
-            className="tg-select"
-            // The displayed value collapses fontWeight=bold into the
-            // dropdown so the user has a single "format" picker. When the
-            // user changes the value, we write to fontWeight or
-            // textDecoration accordingly so each store field still stays
-            // single-purposed (no schema change).
-            value={style.fontWeight === 'bold' ? 'bold' : style.textDecoration}
-            onChange={(e) => {
-              const v = e.target.value
-              if (v === 'bold') {
-                updateFieldStyle(field.id, {
-                  fontWeight: 'bold',
-                  textDecoration: 'none',
-                })
-              } else {
-                updateFieldStyle(field.id, {
-                  fontWeight: 'normal',
-                  textDecoration: v as 'none' | 'underline' | 'line-through',
-                })
-              }
-            }}
-          >
-            <option value="none">None</option>
-            <option value="underline">Underline</option>
-            <option value="line-through">Line Through</option>
-            <option value="bold">Bold</option>
-          </select>
-        </div>
-
-        <div className="tg-form-row">
-          <label>Text Color</label>
-          <ColorPickerPopover
-            value={style.color}
-            onChange={(c) => updateFieldStyle(field.id, { color: c })}
-            ariaLabel="Text color"
-          />
-        </div>
-      </div>
+      <TextTypographySection
+        field={field}
+        style={style}
+        isDynamic={isDynamic}
+        allFontFamilies={allFontFamilies}
+        onFontSizeChange={onFontSizeChange}
+        updateFieldStyle={updateFieldStyle}
+      />
 
       {/* Alignment */}
       <div className="tg-panel-section">
@@ -448,30 +264,5 @@ export function TextFieldProps({ field }: Props) {
       </div>
       <HyperlinkSection field={field} />
     </>
-  )
-}
-
-function AlignButtonGroup<T extends string>({
-  options,
-  value,
-  onChange,
-}: {
-  options: T[]
-  value: T
-  onChange: (v: T) => void
-}) {
-  return (
-    <div style={{ display: 'flex', gap: 2 }}>
-      {options.map((opt) => (
-        <button
-          key={opt}
-          className={`tg-btn ${value === opt ? 'tg-btn--active' : ''}`}
-          style={{ flex: 1, justifyContent: 'center', fontSize: 11, padding: '4px 6px' }}
-          onClick={() => onChange(opt)}
-        >
-          {opt.charAt(0).toUpperCase() + opt.slice(1)}
-        </button>
-      ))}
-    </div>
   )
 }

--- a/packages/ui/src/components/RightPanel/TextTypographySection.tsx
+++ b/packages/ui/src/components/RightPanel/TextTypographySection.tsx
@@ -1,0 +1,169 @@
+/**
+ * TextTypographySection — Font family / size / weight / style / decoration /
+ * colour plus dynamic-only Overflow Mode + Min Font controls. Extracted from
+ * `TextFieldProps.tsx` per Hard Rule #11 (split as you touch).
+ */
+import type { TextField, TextFieldStyle } from '@template-goblin/types'
+import { NumberInput } from '../NumberInput.js'
+import { ColorPickerPopover } from '../ColorPickerPopover.js'
+import { InfoTip } from './InfoTip.js'
+
+interface Props {
+  field: TextField
+  style: TextFieldStyle
+  isDynamic: boolean
+  allFontFamilies: string[]
+  onFontSizeChange: (fontSize: number) => void
+  updateFieldStyle: (id: string, patch: Partial<TextFieldStyle>) => void
+}
+
+export function TextTypographySection({
+  field,
+  style,
+  isDynamic,
+  allFontFamilies,
+  onFontSizeChange,
+  updateFieldStyle,
+}: Props) {
+  return (
+    <div className="tg-panel-section">
+      <div className="tg-panel-section-title">Typography</div>
+
+      <div className="tg-form-row">
+        <label>Font Family</label>
+        <select
+          className="tg-select"
+          value={style.fontFamily}
+          onChange={(e) => updateFieldStyle(field.id, { fontFamily: e.target.value })}
+        >
+          {allFontFamilies.map((f) => (
+            <option key={f} value={f}>
+              {f}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="tg-form-row">
+        <label>Font Size</label>
+        <NumberInput
+          value={style.fontSize}
+          min={1}
+          defaultValue={12}
+          onChange={(v) => onFontSizeChange(v)}
+        />
+      </div>
+
+      {/* GH #91 — Overflow Mode is the single knob for what happens when
+          content exceeds the rect. Static text has no rendered drift
+          (fixed string at fixed fontSize) so the dropdown is dynamic-only.
+          Truncate cuts characters from the end at a character boundary
+          (no ellipsis); Dynamic Font shrinks `fontSize` down to
+          `fontSizeMin`, then truncates the rest. */}
+      {isDynamic && (
+        <div className="tg-form-row">
+          <label>
+            Overflow Mode
+            <InfoTip text="Truncate: cut characters from the end so the visible text fits the rect (no ellipsis). Dynamic Font: shrink the font size down to Minimum Font Size, then truncate." />
+          </label>
+          <select
+            className="tg-select"
+            value={style.overflowMode}
+            onChange={(e) =>
+              updateFieldStyle(field.id, {
+                overflowMode: e.target.value as 'dynamic_font' | 'truncate',
+              })
+            }
+          >
+            <option value="truncate">Truncate</option>
+            <option value="dynamic_font">Dynamic Font</option>
+          </select>
+        </div>
+      )}
+
+      {/* Minimum Font Size only matters when Overflow Mode = Dynamic Font. */}
+      {isDynamic && style.overflowMode === 'dynamic_font' && (
+        <div className="tg-form-row">
+          <label>
+            Minimum Font Size
+            <InfoTip text="The smallest font size the renderer will shrink to before falling back to truncation." />
+          </label>
+          <NumberInput
+            value={style.fontSizeMin}
+            min={1}
+            defaultValue={11}
+            onChange={(v) => updateFieldStyle(field.id, { fontSizeMin: v })}
+          />
+        </div>
+      )}
+
+      <div className="tg-form-row">
+        <label>Font Weight</label>
+        <select
+          className="tg-select"
+          value={style.fontWeight}
+          onChange={(e) =>
+            updateFieldStyle(field.id, { fontWeight: e.target.value as 'normal' | 'bold' })
+          }
+        >
+          <option value="normal">Normal</option>
+          <option value="bold">Bold</option>
+        </select>
+      </div>
+
+      <div className="tg-form-row">
+        <label>Font Style</label>
+        <select
+          className="tg-select"
+          value={style.fontStyle}
+          onChange={(e) =>
+            updateFieldStyle(field.id, { fontStyle: e.target.value as 'normal' | 'italic' })
+          }
+        >
+          <option value="normal">Normal</option>
+          <option value="italic">Italic</option>
+        </select>
+      </div>
+
+      <div className="tg-form-row">
+        <label>Text Decoration</label>
+        <select
+          className="tg-select"
+          // The displayed value collapses fontWeight=bold into the dropdown
+          // so the user has a single "format" picker. When the user changes
+          // the value, we write to fontWeight or textDecoration accordingly
+          // so each store field still stays single-purposed.
+          value={style.fontWeight === 'bold' ? 'bold' : style.textDecoration}
+          onChange={(e) => {
+            const v = e.target.value
+            if (v === 'bold') {
+              updateFieldStyle(field.id, {
+                fontWeight: 'bold',
+                textDecoration: 'none',
+              })
+            } else {
+              updateFieldStyle(field.id, {
+                fontWeight: 'normal',
+                textDecoration: v as 'none' | 'underline' | 'line-through',
+              })
+            }
+          }}
+        >
+          <option value="none">None</option>
+          <option value="underline">Underline</option>
+          <option value="line-through">Line Through</option>
+          <option value="bold">Bold</option>
+        </select>
+      </div>
+
+      <div className="tg-form-row">
+        <label>Text Color</label>
+        <ColorPickerPopover
+          value={style.color}
+          onChange={(c) => updateFieldStyle(field.id, { color: c })}
+          ariaLabel="Text color"
+        />
+      </div>
+    </div>
+  )
+}

--- a/packages/ui/src/utils/__tests__/autoShrink.test.ts
+++ b/packages/ui/src/utils/__tests__/autoShrink.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Unit tests for the auto-shrink helpers (#42).
+ *
+ * `fitStaticImageRect` is fully pure — easy to exercise.
+ * `measureStaticTextRect` uses the off-screen `<canvas>` 2D context; vitest's
+ * jsdom env provides a stub `getContext('2d')` with deterministic
+ * `measureText` (returns `text.length * 8` for the default font), which is
+ * stable enough to assert the helper's branching logic.
+ */
+import { describe, it, expect } from 'vitest'
+import { fitStaticImageRect, measureStaticTextRect } from '../autoShrink.js'
+
+describe('fitStaticImageRect', () => {
+  // User feedback on #42: height is the user's intentional choice, never
+  // auto-modified. Only width gets trimmed when the user drew wider than
+  // the image's natural aspect at the chosen height.
+  it('trims width to natural aspect when rect is wider than the image aspect', () => {
+    // Image 100x100. User drew 200x100 → too wide.
+    // widthAtCurrentHeight = 100 * 100 / 100 = 100 → trim width to 100.
+    const r = fitStaticImageRect(200, 100, 100, 100)
+    expect(r.width).toBe(100)
+    expect(r.height).toBe(100)
+  })
+
+  it('keeps height unchanged even when rect is taller than the image aspect', () => {
+    // widthAtCurrentHeight = 100 * 200 / 100 = 200 > currentW=100, so width
+    // is unchanged too (never grow). Height preserved as user's choice.
+    const r = fitStaticImageRect(100, 200, 100, 100)
+    expect(r.width).toBe(100)
+    expect(r.height).toBe(200)
+  })
+
+  it('keeps the rect when natural aspect matches exactly at the user height', () => {
+    // widthAtCurrentHeight = 200 * 75 / 100 = 150 — same as currentW.
+    const r = fitStaticImageRect(150, 75, 200, 100)
+    expect(r.width).toBe(150)
+    expect(r.height).toBe(75)
+  })
+
+  it('does not modify height when image aspect would suggest a smaller height', () => {
+    // Image 1920x1080 (16:9). User drew 400x300 (4:3, taller-than-aspect).
+    // widthAtCurrentHeight = 1920 * 300 / 1080 = 533.3 > currentW=400 →
+    // never grow, width unchanged. Height preserved (300).
+    const r = fitStaticImageRect(400, 300, 1920, 1080)
+    expect(r.width).toBe(400)
+    expect(r.height).toBe(300)
+  })
+
+  it('trims width on a tall-narrow image inside a wider rect', () => {
+    // Image 100x400. User drew 200x400.
+    // widthAtCurrentHeight = 100 * 400 / 400 = 100 → trim width to 100.
+    const r = fitStaticImageRect(200, 400, 100, 400)
+    expect(r.width).toBe(100)
+    expect(r.height).toBe(400)
+  })
+
+  it('never grows the rect on either axis', () => {
+    // Image 1000x500 in rect 50x10. widthAtCurrentHeight = 1000 * 10 / 500
+    // = 20 → shrink width to 20. Height stays 10.
+    const r = fitStaticImageRect(50, 10, 1000, 500)
+    expect(r.width).toBe(20)
+    expect(r.height).toBe(10)
+  })
+
+  it('rejects bogus inputs', () => {
+    expect(fitStaticImageRect(0, 100, 100, 100)).toEqual({ width: 0, height: 100 })
+    expect(fitStaticImageRect(100, 100, 0, 100)).toEqual({ width: 100, height: 100 })
+    expect(fitStaticImageRect(100, 100, NaN, 100)).toEqual({ width: 100, height: 100 })
+  })
+})
+
+describe('measureStaticTextRect', () => {
+  // jsdom's <canvas> doesn't ship a 2D context (`getContext('2d')` returns
+  // null), so live measurement is unverifiable in unit tests — we cover the
+  // degraded path + every input-validation branch. Live behaviour is
+  // covered by manual smoke + production browser.
+  //
+  // Critical invariant for every case: result.height === currentH. Height
+  // is never modified by this helper (user feedback on #42).
+
+  it('preserves height on empty text (and returns rect unchanged)', () => {
+    const r = measureStaticTextRect('', 'Helvetica', 12, 1.2, 300, 100)
+    expect(r).toEqual({ width: 300, height: 100 })
+  })
+
+  it('preserves height on non-positive dimensions', () => {
+    const r = measureStaticTextRect('hi', 'Helvetica', 12, 1.2, 0, 100)
+    expect(r).toEqual({ width: 0, height: 100 })
+    const r2 = measureStaticTextRect('hi', 'Helvetica', 12, 1.2, 100, 0)
+    expect(r2).toEqual({ width: 100, height: 0 })
+  })
+
+  it('preserves height on non-positive fontSize', () => {
+    const r = measureStaticTextRect('hi', 'Helvetica', 0, 1.2, 100, 100)
+    expect(r).toEqual({ width: 100, height: 100 })
+  })
+
+  it('preserves height even when DOM measurement degrades (jsdom path)', () => {
+    // In jsdom, getMeasureCtx() returns null → helper returns input rect.
+    // The critical property is that height is preserved.
+    const r = measureStaticTextRect('hello world', 'Helvetica', 12, 1.2, 500, 500)
+    expect(r.height).toBe(500)
+  })
+
+  it('accepts custom options without throwing and preserves height', () => {
+    expect(() =>
+      measureStaticTextRect('a', 'Helvetica', 12, 1.2, 100, 100, {
+        innerPad: 0,
+        minW: 1,
+      }),
+    ).not.toThrow()
+    const r = measureStaticTextRect('a', 'Helvetica', 12, 1.2, 100, 100, {
+      innerPad: 0,
+      minW: 1,
+    })
+    expect(r.height).toBe(100)
+  })
+})

--- a/packages/ui/src/utils/autoShrink.ts
+++ b/packages/ui/src/utils/autoShrink.ts
@@ -1,0 +1,137 @@
+/**
+ * Auto-shrink helpers for static field rects (#42).
+ *
+ * Static content has a known rendered size at design time — image natural
+ * dimensions, text width/height at the current font. When the user draws a
+ * larger rect than the content occupies the surplus is wasted whitespace.
+ * These helpers compute the smallest rect that still contains the content,
+ * but they NEVER grow beyond what the user drew (the issue's hard constraint).
+ *
+ * Both helpers are pure: no Fabric, no store. Caller is responsible for
+ * dispatching the resulting `{width, height}` via `updateField`.
+ */
+
+/**
+ * Default horizontal padding (per side) when computing the shrunk text
+ * width.
+ *
+ * MUST be ≥ the renderer's own innerPad (`pushTextLabel.ts:61` uses 6pt
+ * on each side, so effective text width = rect_w − 12). If our shrunk
+ * rect is exactly `naturalTextWidth + 6*2`, the renderer's labelW lands
+ * at naturalTextWidth and any rounding / sub-pixel hinting tips it into
+ * truncate-mode. We add 2pt safety per side on top, giving 8 = 6 + 2.
+ */
+const DEFAULT_INNER_PAD = 8
+const DEFAULT_MIN_W = 10
+
+/** Shared 2D context for off-screen text measurement. */
+let _ctx: CanvasRenderingContext2D | null = null
+function getMeasureCtx(): CanvasRenderingContext2D | null {
+  if (typeof document === 'undefined') return null
+  if (_ctx) return _ctx
+  const cv = document.createElement('canvas')
+  _ctx = cv.getContext('2d')
+  return _ctx
+}
+
+/**
+ * Shrink a static image's rect on the WIDTH axis only, preserving the
+ * user-drawn height. User feedback on #42: "height must remain same as
+ * user draw" — height is an intentional layout choice, never auto-modified.
+ *
+ * Strategy: keep `currentH`; pick `width = naturalW × currentH / naturalH`
+ * (the width that gives the image its natural aspect at the user's height).
+ * If that's bigger than the user's rect (user drew narrower than aspect),
+ * leave the rect alone — never grow.
+ */
+export function fitStaticImageRect(
+  currentW: number,
+  currentH: number,
+  naturalW: number,
+  naturalH: number,
+): { width: number; height: number } {
+  if (
+    currentW <= 0 ||
+    currentH <= 0 ||
+    naturalW <= 0 ||
+    naturalH <= 0 ||
+    !Number.isFinite(currentW) ||
+    !Number.isFinite(currentH) ||
+    !Number.isFinite(naturalW) ||
+    !Number.isFinite(naturalH)
+  ) {
+    return { width: currentW, height: currentH }
+  }
+  const widthAtCurrentHeight = (naturalW * currentH) / naturalH
+  if (widthAtCurrentHeight < currentW) {
+    return { width: widthAtCurrentHeight, height: currentH }
+  }
+  return { width: currentW, height: currentH }
+}
+
+export interface MeasureStaticTextRectOptions {
+  innerPad?: number
+  minW?: number
+  fontWeight?: 'normal' | 'bold'
+  fontStyle?: 'normal' | 'italic'
+}
+
+/**
+ * Shrink a static text rect on the WIDTH axis only, preserving the
+ * user-drawn height. User feedback on #42: the height represents the user's
+ * intentional layout choice and must never be auto-modified; only the empty
+ * space to the right of the text gets trimmed away.
+ *
+ * Strategy: measure the text at its natural single-line width (no wrap).
+ * If that natural width + pad fits inside the user's current width, trim
+ * width to that. If the natural width already meets or exceeds the user's
+ * rect, leave width alone — the existing overflow-mode (truncate / dynamic
+ * font) handles the over-set case.
+ *
+ * The measurement context's `font` is built with `fontWeight` + `fontStyle`
+ * so it matches `Textbox`'s own renderer (bold text is wider than normal at
+ * the same fontSize — getting this wrong is what caused "Jaimin" to render
+ * as "Jai" after a shrink: the helper measured at normal weight but the
+ * renderer drew at bold).
+ *
+ * Returns the input rect unchanged when the text is empty or when DOM
+ * measurement isn't available (SSR / tests without jsdom canvas).
+ */
+export function measureStaticTextRect(
+  text: string,
+  fontFamily: string,
+  fontSize: number,
+  // lineHeight kept for signature stability — height is no longer modified
+  // so the value is unused in the new implementation.
+  _lineHeight: number,
+  currentW: number,
+  currentH: number,
+  opts: MeasureStaticTextRectOptions = {},
+): { width: number; height: number } {
+  const innerPad = opts.innerPad ?? DEFAULT_INNER_PAD
+  const minW = opts.minW ?? DEFAULT_MIN_W
+  const fontWeight = opts.fontWeight ?? 'normal'
+  const fontStyle = opts.fontStyle ?? 'normal'
+
+  if (!text || currentW <= 0 || currentH <= 0 || fontSize <= 0) {
+    return { width: currentW, height: currentH }
+  }
+  const ctx = getMeasureCtx()
+  if (!ctx) return { width: currentW, height: currentH }
+
+  // CSS font shorthand: `<style> <weight> <size> <family>`. Skipping
+  // weight/style here is the bug that mismeasured bold text — keep this
+  // in sync with Textbox's options in `pushTextLabel.ts`.
+  ctx.font = `${fontStyle} ${fontWeight} ${fontSize}px ${fontFamily}`
+  const naturalW = ctx.measureText(text).width
+  // Ceil before adding pad so sub-pixel measurement doesn't strip a
+  // fraction of a glyph in the renderer pass.
+  const targetW = Math.max(minW, Math.ceil(naturalW) + innerPad * 2)
+
+  // Width never grows — leave the rect alone when the text already fills
+  // or overflows the user's rect (the user has chosen the wrap width).
+  if (targetW >= currentW) {
+    return { width: currentW, height: currentH }
+  }
+  return { width: targetW, height: currentH }
+}

--- a/packages/ui/src/utils/autoShrinkDispatch.ts
+++ b/packages/ui/src/utils/autoShrinkDispatch.ts
@@ -1,0 +1,120 @@
+/**
+ * Dispatcher that wires the pure auto-shrink helpers in `autoShrink.ts` to
+ * the template store (#42). Trigger sites (popup confirm, right-panel blur,
+ * right-panel image change) call `autoShrinkStaticField(fieldId)` and the
+ * dispatcher handles per-type measurement + `updateField` dispatch.
+ *
+ * Returns a Promise because the image path waits for the natural-size load.
+ * Callers can `void`-ignore it (popup, image picker) — the shrink is a UX
+ * nicety, not a correctness step.
+ */
+import { useTemplateStore } from '../store/templateStore.js'
+import { fitStaticImageRect, measureStaticTextRect } from './autoShrink.js'
+import type { TextField, ImageField } from '@template-goblin/types'
+
+/**
+ * Measure the field's static content and dispatch a shrink via `updateField`
+ * if the result is smaller than the current rect on either axis.
+ *
+ * No-ops on dynamic fields, table fields (out of scope per issue), missing
+ * field ids, and empty / unloaded content.
+ */
+export async function autoShrinkStaticField(fieldId: string): Promise<void> {
+  const store = useTemplateStore.getState()
+  const field = store.fields.find((f) => f.id === fieldId)
+  if (!field || field.source?.mode !== 'static') return
+
+  if (field.type === 'text') {
+    shrinkTextField(field as TextField)
+    return
+  }
+  if (field.type === 'image') {
+    try {
+      await shrinkImageField(field as ImageField)
+    } catch {
+      // Image decode failed or the buffer was unreadable — leave the rect.
+    }
+  }
+}
+
+function shrinkTextField(field: TextField): void {
+  if (field.source.mode !== 'static') return
+  const value = field.source.value
+  if (!value) return
+  const next = measureStaticTextRect(
+    value,
+    field.style.fontFamily,
+    field.style.fontSize,
+    field.style.lineHeight,
+    field.width,
+    field.height,
+    { fontWeight: field.style.fontWeight, fontStyle: field.style.fontStyle },
+  )
+  applyShrinkIfChanged(field.id, field.width, field.height, next)
+}
+
+async function shrinkImageField(field: ImageField): Promise<void> {
+  if (field.source.mode !== 'static') return
+  const value = field.source.value
+  // Solid-colour static fields have no natural dims — skip.
+  if (!('filename' in value) || !value.filename) return
+
+  // Two existing pipelines feed an image rect: the create-popup goes through
+  // `addStaticImage` (writes `staticImageDataUrls`), while the right-panel
+  // upload goes through `addPlaceholder` (writes only `placeholderBuffers`).
+  // We resolve from whichever is populated so both trigger sites work.
+  const src = resolveImageSrc(value.filename)
+  if (!src) return
+
+  let img: HTMLImageElement
+  try {
+    img = await loadImage(src.url)
+  } finally {
+    if (src.revoke) URL.revokeObjectURL(src.url)
+  }
+  if (!img.naturalWidth || !img.naturalHeight) return
+  const next = fitStaticImageRect(field.width, field.height, img.naturalWidth, img.naturalHeight)
+  applyShrinkIfChanged(field.id, field.width, field.height, next)
+}
+
+interface ImageSrc {
+  url: string
+  /** Whether to call `URL.revokeObjectURL` after the load resolves. */
+  revoke: boolean
+}
+
+function resolveImageSrc(filename: string): ImageSrc | null {
+  const state = useTemplateStore.getState()
+  const dataUrl = state.staticImageDataUrls?.get(filename)
+  if (dataUrl) return { url: dataUrl, revoke: false }
+  const buffer = state.staticImageBuffers?.get(filename) ?? state.placeholderBuffers?.get(filename)
+  if (!buffer) return null
+  const blob = new Blob([buffer])
+  return { url: URL.createObjectURL(blob), revoke: true }
+}
+
+function loadImage(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image()
+    img.onload = () => resolve(img)
+    img.onerror = () => reject(new Error('image decode failed'))
+    img.src = src
+  })
+}
+
+function applyShrinkIfChanged(
+  id: string,
+  currentW: number,
+  currentH: number,
+  next: { width: number; height: number },
+): void {
+  // Round to avoid jitter from sub-pixel measurement drift and only dispatch
+  // when the change is meaningful (≥ 1 pt on at least one axis).
+  const w = Math.round(next.width)
+  const h = Math.round(next.height)
+  if (Math.abs(w - currentW) < 1 && Math.abs(h - currentH) < 1) return
+  // Hard constraint: never grow. Belt-and-suspenders on the helper guarantee.
+  const finalW = Math.min(currentW, w)
+  const finalH = Math.min(currentH, h)
+  useTemplateStore.getState().updateField(id, { width: finalW, height: finalH })
+}

--- a/plans/42-auto-shrink-static-fields.md
+++ b/plans/42-auto-shrink-static-fields.md
@@ -1,0 +1,234 @@
+# Plan — Issue #42: Auto-shrink static field rect to fit content
+
+Branch: `feature/42-auto-shrink-static-fields`
+Issue: https://github.com/JaiminPatel345/template-goblin/issues/42
+Labels: enhancement, v2
+
+## 1. Goal (from issue)
+
+When a field has `source.mode === 'static'`, shrink its rect to the smallest
+size that still fully contains the content. **Only shrink — never grow.**
+
+- Static image: shrink to the image's natural aspect ratio.
+- Static text: shrink to measured text width + height (+ inner pad).
+- Dynamic fields: out of scope.
+
+## 2. Trigger sites (verbatim from issue, mapped to real files)
+
+| Trigger                         | File                                                         | Hook / method                                                               |
+| ------------------------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------- |
+| Draw-to-create confirm          | `packages/ui/src/components/Canvas/useFieldCreationPopup.ts` | `handlePopupConfirm`                                                        |
+| Mode toggle dynamic → static    | `packages/ui/src/store/templateStore.ts`                     | `setFieldMode`                                                              |
+| Right-panel static-text edit    | `packages/ui/src/components/RightPanel/TextFieldProps.tsx`   | `onStaticValueChange` (fires per-keystroke today — see Design Decisions §3) |
+| Right-panel static-image change | `packages/ui/src/components/RightPanel/ImageFieldProps.tsx`  | `onStaticImageChange` (file-picker `onFileChange`)                          |
+
+Issue explicitly notes: does NOT fire on resize.
+
+## 3. Design decisions (no real alternatives — see Hard Rule #19)
+
+These are decisions I'm making and recording for traceability. None has a
+non-obvious tradeoff; surfacing them in the plan so the reviewer can flag if
+they disagree.
+
+1. **`innerPad` for text:** `2 pt`. Small enough to feel snug but prevents
+   font-metric jitter (descenders / ascenders) clipping the rect edge. Text
+   fields carry no padding today (`TextField` in `defaults.ts` has no padding;
+   `paddingTop/Bottom/Left/Right` only exists on `CellStyle` for tables).
+   Avoids reusing the `CellStyle.paddingLeft = 4` since text rect ≠ table cell.
+2. **Minimums:** `MIN_RECT_W = MIN_RECT_H = 10 pt`. Prevents collapsing to
+   invisibility on empty / whitespace-only strings.
+3. **Right-panel text edit timing:** `onBlur` only, NOT per-keystroke.
+   Per-keystroke would jitter the rect as the user types — actively bad UX.
+   Onblur matches the popup-confirm "after committing the value" language
+   from the issue. Implementation: bind a separate `onBlur` handler on the
+   text input, no change to the existing per-keystroke `onChange`.
+4. **Image natural-size race:** `staticImageDataUrls` always has the data URL
+   once the image is added; we load an off-screen `Image` element, await
+   `decode()`, then dispatch the shrink. If the image is already cached in the
+   browser (very likely), decode resolves synchronously-ish on next microtask.
+   We don't block the popup-confirm UI — fire-and-forget the shrink.
+5. **Empty value / no image:** skip the shrink (no rect change). Specifically:
+   text shrink with `text === ''` returns the existing rect unchanged; image
+   shrink with no filename or unresolvable buffer skips too.
+6. **Position anchor on shrink:** top-left preserved. Issue's "trim right edge
+   / bottom edge" wording confirms this. `left`/`top` never change.
+7. **Hard constraint (issue):** never grow. Both helpers return
+   `{ width: min(measured, current), height: min(measured, current) }` so a
+   measurement larger than the user's rect produces a no-op.
+
+## 4. Architecture
+
+### New pure helpers — `packages/ui/src/utils/autoShrink.ts`
+
+```ts
+export function fitStaticImageRect(
+  currentW: number,
+  currentH: number,
+  naturalW: number,
+  naturalH: number,
+): { width: number; height: number }
+
+export function measureStaticTextRect(
+  text: string,
+  fontFamily: string,
+  fontSize: number,
+  lineHeight: number,
+  currentW: number,
+  currentH: number,
+  opts?: { innerPad?: number; minW?: number; minH?: number },
+): { width: number; height: number }
+```
+
+Text helper reuses the cached 2D context + `wrapToLines` pattern from
+`fitFontSize.ts`. Since `wrapToLines` is currently private, **extract it** to
+a shared module `packages/ui/src/components/Canvas/textMeasure.ts` and let
+both `fitFontSize` and the new shrink helper import it. (Hard Rule #11 — split
+when touching; the file is already ~80 LOC, well under the cap.)
+
+### Dispatch points
+
+- `useFieldCreationPopup.ts`: after `createDefaultField` + `addField`, if the
+  new field is static, run the shrink and follow up with `updateField`.
+- `templateStore.ts:setFieldMode`: after switching `mode` from dynamic →
+  static, run the shrink if the new static value is non-empty.
+- `TextFieldProps.tsx`: add `onBlur` to the textarea; on blur, run shrink.
+- `ImageFieldProps.tsx`: extend the file-picker handler; after
+  `addPlaceholder` + `updateField`, load the image and dispatch the shrink.
+
+No new dependencies.
+
+## 5. Files touched
+
+| File                                                         | Change                                                           |
+| ------------------------------------------------------------ | ---------------------------------------------------------------- |
+| `packages/ui/src/utils/autoShrink.ts`                        | NEW (~120 LOC) — pure helpers                                    |
+| `packages/ui/src/components/Canvas/textMeasure.ts`           | NEW (~40 LOC) — extracted `wrapToLines` + shared measure context |
+| `packages/ui/src/components/Canvas/fitFontSize.ts`           | -inner `wrapToLines` + import from `textMeasure.ts`              |
+| `packages/ui/src/components/Canvas/useFieldCreationPopup.ts` | +shrink dispatch after create                                    |
+| `packages/ui/src/store/templateStore.ts`                     | +shrink dispatch inside `setFieldMode` for dyn→static path       |
+| `packages/ui/src/components/RightPanel/TextFieldProps.tsx`   | +onBlur shrink                                                   |
+| `packages/ui/src/components/RightPanel/ImageFieldProps.tsx`  | +shrink after image pick                                         |
+| `packages/ui/src/utils/__tests__/autoShrink.test.ts`         | NEW unit tests                                                   |
+
+Every modified file stays under the 300-LOC cap (templateStore is already 992,
+flagged below).
+
+### Rule #11 risk
+
+`templateStore.ts` is **992 LOC** — already over the cap. Touching it for #42
+means we should split as we touch (rule explicitly says so). Approach: extract
+`setFieldMode`'s body (or the whole mode-toggle logic) into a new helper
+module `packages/ui/src/store/fieldModeMigration.ts` and call it from the
+slice. This isolates the shrink dispatch and removes load from templateStore.
+**This is in-scope for #42** — the rule mandates splitting on touch.
+
+## 6. Tests
+
+**Unit (Vitest):**
+
+- `fitStaticImageRect` — wider-than-natural shrinks width; taller-than-natural
+  shrinks height; matching aspect is no-op; oversized rect (smaller than
+  natural extent at given aspect) — no growth.
+- `measureStaticTextRect` — measured width applied; multi-line height applied;
+  text bigger than current rect → no-op; empty string → no-op; respects
+  `minW`/`minH`.
+
+**E2E (Playwright) — deferred to a follow-up.** Issue suggests E2E for each of
+the three trigger points; manual smoke + unit coverage is sufficient for the
+initial PR. E2E for the canvas drag-create flow is non-trivial setup; if
+reviewer wants it, file as #42-followup.
+
+## 7. Commit plan
+
+One commit:
+`feat(canvas): auto-shrink static field rect to fit its content (#42)`
+
+Changeset will be generated at push time (Hard Rule #12) — minor bump on
+`template-goblin-ui` only.
+
+## 8. Risks
+
+1. **Image decode timing.** If the image element fails to decode (corrupt buffer,
+   blocked data URL), the shrink silently no-ops. Acceptable — it's only a
+   visual nicety.
+2. **Per-keystroke vs onBlur** — see §3.3. Going with onBlur. If user actually
+   wants live-shrink during typing, swap a debounced `onChange` in.
+3. **Mode toggle on a freshly-converted dynamic→static field** with empty
+   value — we skip. The field stays at the user's authored size until they
+   add content, which then re-shrinks on next trigger. Documented in §3.5.
+4. **templateStore split** is a meaningful refactor (lots of touched
+   imports). Keeping the diff small: extract ONLY `setFieldMode` body and
+   any close siblings, leave the rest of the file alone for follow-ups.
+
+## 8c. Post-implementation semantic correction (user feedback)
+
+User feedback after first browser test: "you reducing height too much — when
+I say auto shrink that means … you never have to reduce height, height must
+remain same as user draw. you just have to shrink width." Then a second
+bug: "Jaimin" rendered as "Jai" because the renderer's own padding ate the
+helper's safety margin.
+
+Both fixed in the helpers (and tests):
+
+1. **Height is never modified.** `fitStaticImageRect` and
+   `measureStaticTextRect` now both return `height = currentH`. The image
+   helper's "trim bottom edge" branch is gone; the text helper no longer
+   computes wrapped height.
+2. **Width pad bumped to 8pt per side (16pt total).** `pushTextLabel.ts:61`
+   applies its own `innerPad = 6` on each side, so an effective text area
+   of `rect_w − 12`. Our helper now adds `6 + 2 = 8` per side so the
+   renderer always has at least 2pt of breathing room before truncate-mode
+   would activate.
+3. **Measurement context now sets `fontWeight` + `fontStyle`.** Bold text
+   is wider than normal at the same fontSize; measuring at normal weight
+   and rendering at bold was the root cause of "Jaimin" → "Jai" at bold
+   weight (or any weight mismatch). The dispatcher passes the resolved
+   weight + style through.
+4. **`Math.ceil(naturalW)` before adding pad** so sub-pixel measurement
+   never strips a fraction of a glyph in the renderer pass.
+
+## 9. Implementation order
+
+1. **Drop the `setFieldMode` (templateStore) trigger entirely.** The dyn→static
+   flip almost always lands the field at `emptyStaticValue` (empty string /
+   `{filename: ''}`), which our shrink helpers skip. The 1-of-4 case where the
+   prior placeholder is carried as the new static value is reliably covered by
+   the right-panel `onBlur` the moment the user next touches the value. Dropping
+   this dispatch avoids touching the 992-LOC `templateStore.ts` for a feature
+   that doesn't need it (resolves the Rule #15 vs #11 tension cited by QA).
+2. **Drop the `textMeasure.ts` extraction.** `fitFontSize.ts` is 78 LOC, nowhere
+   near the cap. Inline `wrapToLines` in `autoShrink.ts` (17 LOC copy) — smaller
+   diff, no shared-helper churn.
+3. **Defer E2E.** Issue calls for E2E per trigger; this PR ships unit coverage
+   - manual smoke only. Will file a follow-up issue for the E2E specs once
+     #42 lands. Documented as a known deviation.
+4. **Popup-confirm dispatch ordering.** `handlePopupConfirm` in
+   `useFieldCreationPopup.ts` defers the post-create work in a `setTimeout(0)`.
+   We dispatch the shrink inside the SAME `setTimeout` body (after `addField`
+   returns the id), so the create + shrink land in a single React render
+   pass rather than two flickers.
+5. **Wording:** the right-panel text input is an `<input>`, not a `<textarea>`.
+   onBlur fires on focus-leave — reachable.
+
+### Updated file list
+
+| File                                                         | Change                                                |
+| ------------------------------------------------------------ | ----------------------------------------------------- |
+| `packages/ui/src/utils/autoShrink.ts`                        | NEW (~130 LOC) — pure helpers + inlined `wrapToLines` |
+| `packages/ui/src/utils/__tests__/autoShrink.test.ts`         | NEW unit tests                                        |
+| `packages/ui/src/components/Canvas/useFieldCreationPopup.ts` | +shrink dispatch inside existing `setTimeout(0)`      |
+| `packages/ui/src/components/RightPanel/TextFieldProps.tsx`   | +onBlur shrink                                        |
+| `packages/ui/src/components/RightPanel/ImageFieldProps.tsx`  | +shrink after `handleStaticUpload`                    |
+
+`templateStore.ts`, `fitFontSize.ts`, no longer touched.
+
+## 9. Implementation order
+
+1. Extract `textMeasure.ts`; rewire `fitFontSize.ts`.
+2. Write `autoShrink.ts` + unit tests.
+3. Wire into `useFieldCreationPopup.ts`.
+4. Wire into `TextFieldProps.tsx` (onBlur) and `ImageFieldProps.tsx`.
+5. Add to `setFieldMode` in templateStore (with the helper split per §5).
+6. Type-check, lint, tests, build.
+7. Manual smoke in `pnpm dev`.
+8. Master QA on implementation.


### PR DESCRIPTION
## Summary

Closes #42. When a static text or image field commits, automatically shrink
the rect **width** so there's no wasted whitespace beyond the content. The
user-drawn **height** is always preserved — it's an intentional layout
choice.

- **Text:** `width = ceil(measureText) + 16pt internal pad`. The pad is 8pt
  per side: 6pt matches the renderer's own innerPad (`pushTextLabel.ts:61`)
  and 2pt is a safety margin so glyphs never clip into truncate-mode.
- **Image:** `width = naturalW × currentH / naturalH` — image fills the
  user's chosen height at natural aspect.
- Width never grows past what the user drew. If content overflows the rect,
  the existing overflow-mode (truncate / dynamic font) handles it.
- Triggers: draw-to-create popup confirm, right-panel text input `onBlur`,
  right-panel image replacement. Does **not** fire on resize.
- Measurement context uses `fontWeight` + `fontStyle` so bold/italic text
  doesn't mismeasure.

## Side-effect — Hard Rule #11 split

`TextFieldProps.tsx` was 479 LOC (already over the 300-LOC cap on `main`).
Per Hard Rule #11 ("split as you touch"), this PR splits it into
`InfoTip.tsx`, `AlignButtonGroup.tsx`, and `TextTypographySection.tsx`. The
main file is now 269 LOC. `InfoTip` is re-exported for backward compat with
`LoopFieldProps`.

## Deferred to a follow-up

- The `setFieldMode` (dynamic → static) trigger from the issue. In practice
  the new static value is `emptyStaticValue` (empty string / empty filename)
  almost every time, which the helpers skip. The right-panel `onBlur` covers
  the user-visible case. Documented in `plans/42-auto-shrink-static-fields.md` §8b.1.
- E2E specs the issue suggests — this PR ships unit + manual browser smoke.
  Will file a follow-up if you want the Playwright coverage.

## Test plan

- [x] `pnpm --filter template-goblin-ui type-check` clean
- [x] `pnpm --filter template-goblin-ui test` — 457/457 pass (12 new for autoShrink)
- [x] `pnpm lint` clean
- [x] `pnpm build` clean
- [x] Manual smoke in dev: drew a wide rect, typed "Jaimin" → rect shrinks to fit "Jaimin" at the user's height, no truncation.