### PR TITLE
fix(store): heal poisoned page dimensions on rehydrate (#113)

### DIFF
--- a/.changeset/heal-poisoned-page-dims.md
+++ b/.changeset/heal-poisoned-page-dims.md
@@ -1,0 +1,18 @@
+---
+'template-goblin-ui': patch
+---
+
+fix(store): heal poisoned page dimensions on rehydrate (#113)
+
+Closes the final gap from #113. The write-time `clampPageDimension` in
+`setPageSize` / `updatePage` and the manifest validator at PDF generation
+already prevent NEW bad state, but anyone whose IndexedDB still carries
+`meta.width: -100` (or `null` from a pre-fix `NaN` round-tripping through
+JSON) would still rehydrate the bad value verbatim and crash the canvas
+on next load.
+
+`clampPersistedPageDimensions` now runs in the persist `getItem` adapter
+right after `JSON.parse`, walking `meta.width` / `meta.height` and every
+explicitly-set `pages[].width` / `pages[].height` through the same
+≥ 1pt floor used on the write path. Anything non-numeric, non-finite,
+or below 1 heals to 1.

--- a/packages/ui/src/store/__tests__/pageDimClamp.test.ts
+++ b/packages/ui/src/store/__tests__/pageDimClamp.test.ts
@@ -34,6 +34,121 @@ beforeEach(() => {
   useTemplateStore.getState().reset()
 })
 
+describe('rehydration — heals poisoned page dimensions (GH #113)', () => {
+  /**
+   * Pre-existing IDB blobs written before the `setPageSize` clamp landed
+   * can carry `width: -100`. Without a hydration-time guard those rehydrate
+   * verbatim and crash the canvas. The healer floors every dimension at 1pt.
+   */
+  it('heals a negative meta.width on read', async () => {
+    const poisoned = {
+      state: {
+        meta: { width: -100, height: 842, name: 'Poison', unit: 'pt' },
+        fields: [],
+        pages: [],
+        groups: [],
+        fonts: [],
+        staticImages: [],
+        backgroundDataUrl: null,
+        pageBackgroundDataUrls: [],
+        fontBuffers: [],
+        placeholderBuffers: [],
+        staticImageBuffers: [],
+        staticImageDataUrls: [],
+      },
+      version: 2,
+    }
+    storage.set('template-goblin-template', JSON.stringify(poisoned))
+    await useTemplateStore.persist.rehydrate()
+    expect(useTemplateStore.getState().meta.width).toBe(1)
+    expect(useTemplateStore.getState().meta.height).toBe(842)
+  })
+
+  it('heals a null meta.height on read (NaN becomes null after JSON round-trip)', async () => {
+    // A pre-fix `Number.NaN` written to IDB serialises to `null` in JSON,
+    // so the realistic poisoned shape is `height: null` — not NaN.
+    const poisoned = {
+      state: {
+        meta: { width: 595, height: null, name: 'Poison', unit: 'pt' },
+        fields: [],
+        pages: [],
+        groups: [],
+        fonts: [],
+        staticImages: [],
+        backgroundDataUrl: null,
+        pageBackgroundDataUrls: [],
+        fontBuffers: [],
+        placeholderBuffers: [],
+        staticImageBuffers: [],
+        staticImageDataUrls: [],
+      },
+      version: 2,
+    }
+    storage.set('template-goblin-template', JSON.stringify(poisoned))
+    await useTemplateStore.persist.rehydrate()
+    expect(useTemplateStore.getState().meta.height).toBe(1)
+  })
+
+  it('heals a negative per-page width on read', async () => {
+    const poisoned = {
+      state: {
+        meta: { width: 595, height: 842, name: 'P', unit: 'pt' },
+        fields: [],
+        pages: [
+          {
+            id: 'p0',
+            index: 0,
+            backgroundType: 'color',
+            backgroundColor: '#fff',
+            backgroundFilename: null,
+            width: -50,
+            height: 100,
+          },
+        ],
+        groups: [],
+        fonts: [],
+        staticImages: [],
+        backgroundDataUrl: null,
+        pageBackgroundDataUrls: [],
+        fontBuffers: [],
+        placeholderBuffers: [],
+        staticImageBuffers: [],
+        staticImageDataUrls: [],
+      },
+      version: 2,
+    }
+    storage.set('template-goblin-template', JSON.stringify(poisoned))
+    await useTemplateStore.persist.rehydrate()
+    const page = useTemplateStore.getState().pages[0]
+    expect(page?.width).toBe(1)
+    expect(page?.height).toBe(100)
+  })
+
+  it('passes valid dimensions through untouched on rehydrate', async () => {
+    const healthy = {
+      state: {
+        meta: { width: 595, height: 842, name: 'P', unit: 'pt' },
+        fields: [],
+        pages: [],
+        groups: [],
+        fonts: [],
+        staticImages: [],
+        backgroundDataUrl: null,
+        pageBackgroundDataUrls: [],
+        fontBuffers: [],
+        placeholderBuffers: [],
+        staticImageBuffers: [],
+        staticImageDataUrls: [],
+      },
+      version: 2,
+    }
+    storage.set('template-goblin-template', JSON.stringify(healthy))
+    await useTemplateStore.persist.rehydrate()
+    expect(useTemplateStore.getState().meta.width).toBe(595)
+    expect(useTemplateStore.getState().meta.height).toBe(842)
+  })
+})
+
 describe('setPageSize — page dimension clamp', () => {
   it('keeps a valid positive dimension untouched', () => {
     useTemplateStore.getState().setPageSize('A4', 595, 842)

--- a/packages/ui/src/store/templateStore.ts
+++ b/packages/ui/src/store/templateStore.ts
@@ -228,6 +228,40 @@ function clampPageDimension(value: number): number {
 }
 
 /**
+ * Heal a persisted state blob in-place: clamp every page dimension at
+ * read time so a pre-existing poisoned IDB entry (written before the
+ * `setPageSize` / `updatePage` clamp landed) can't crash the canvas on
+ * rehydrate. Closes the third gap from GH #113 — the first two were the
+ * write-time clamp and the manifest validator, both already in. This is
+ * the recovery path for users whose IDB still carries `width: -100` from
+ * earlier testing.
+ *
+ * Mutates the passed object. Returns nothing — callers spread `s` after.
+ */
+function clampPersistedPageDimensions(s: {
+  meta?: { width?: unknown; height?: unknown }
+  pages?: Array<{ width?: unknown; height?: unknown }>
+}): void {
+  const heal = (v: unknown): number =>
+    typeof v === 'number' && Number.isFinite(v) && v >= 1 ? v : 1
+  if (s.meta) {
+    // meta.width/height are required `number` per the type, so anything
+    // non-numeric here (null after JSON round-trip, missing) is also
+    // corruption — coerce to 1 just like a negative would.
+    s.meta.width = heal(s.meta.width)
+    s.meta.height = heal(s.meta.height)
+  }
+  if (Array.isArray(s.pages)) {
+    for (const p of s.pages) {
+      // per-page width/height are optional (template-meta fallback applies
+      // when undefined), so only touch them when they're explicitly set.
+      if (p.width !== undefined) p.width = heal(p.width)
+      if (p.height !== undefined) p.height = heal(p.height)
+    }
+  }
+}
+
+/**
  * Default `PageBand` config emitted the first time the user enables a
  * band from the toolbar menu (#61). Divider on by default — the user
  * specifically asked for this in the right-panel rebuild iteration. Height
@@ -1337,6 +1371,13 @@ export const useTemplateStore = create<TemplateState>()(
           try {
             const parsed = JSON.parse(raw) as { state: PersistedState; version?: number }
             const s = parsed.state
+            // GH #113 — heal poisoned page dimensions at rehydrate time.
+            // The `setPageSize` / `updatePage` clamp blocks new bad writes,
+            // but anyone whose IDB carries a pre-fix `width: -100` would
+            // still crash the canvas on next load without this guard.
+            clampPersistedPageDimensions(
+              s as unknown as Parameters<typeof clampPersistedPageDimensions>[0],
+            )
             // Version read — pre-Phase-1 writers used implicit `1`, so
             // default missing/unknown versions to 1 so `migrate` runs.
             const version = typeof parsed.version === 'number' ? parsed.version : 1


### PR DESCRIPTION
## Summary

Closes the final gap from #113. The write-time `clampPageDimension` and the manifest validator (both shipped in #122 via 6e96121) already prevent new bad state, but anyone whose IndexedDB still carries `meta.width: -100` from before that fix would still rehydrate the bad value verbatim and crash Fabric on next load.

- New `clampPersistedPageDimensions` walks `meta.width` / `meta.height` and every explicitly-set `pages[].width` / `pages[].height`. Anything non-numeric, non-finite, or below 1 heals to 1pt.
- Called from the persist `getItem` adapter right after `JSON.parse`, before image-buffer reconstruction — so the spread that builds the rehydrated state picks up healed values automatically.
- Four new unit tests cover negative `meta.width`, null `meta.height` (the realistic post-JSON shape `NaN` serialises to), negative per-page `width`, and a healthy-state pass-through.

#113's three layers — prevention (write-time clamp), defence (validator at PDF gen), and now recovery (hydration-time heal) — are all in.

## Test plan

- [x] Core unit tests: 433 pass (Jest)
- [x] UI unit tests: 497 pass (Vitest), +4 in `pageDimClamp.test.ts`
- [x] Type-check + lint clean
- [x] Real-browser test: planted `{ meta: { width: -100 }, pages: [{ width: -50, height: 100 }] }` directly into IDB → reloaded → store rehydrated with `meta.width = 1`, `pages[0].width = 1`, untouched values (height 842, page height 100) preserved, canvas booted cleanly with 23 Fabric objects and full editor chrome visible.

Closes #113.