### PR TITLE
feat(ui): inline validation + disabled Apply on invalid custom page dimensions (#112)

### DIFF
--- a/.changeset/page-dim-inline-validation.md
+++ b/.changeset/page-dim-inline-validation.md
@@ -1,0 +1,26 @@
+---
+'template-goblin-ui': patch
+---
+
+feat(ui): inline validation + disabled Apply on invalid custom page dimensions (#112)
+
+The store-side clamp from #112's prior pass silently floored negative /
+zero / non-finite custom dimensions to 1pt — protecting state but leaving
+the user with no feedback about why the value they typed was rejected.
+This adds the missing UX layer the bug body asked for:
+
+- New `validateCustomDims(width, height)` helper in `PageSizePicker.tsx`
+  returns per-field error messages plus a `hasError` convenience flag.
+- The shared `PageSizePicker` renders a red inline chip below each input
+  ("Width must be at least 1 pt.", "Height must be at least 1 pt.",
+  "Width must be a number." for non-finite values) with `aria-invalid`
+  and `aria-describedby` on the input for screen-reader users.
+- All three primary-action surfaces gate on validation when the picker
+  is in `'custom'` mode: `OnboardingPicker` Apply, `AddPageDialog`
+  Add Page / Apply, and the toolbar `PageSizeDialog` Apply (which has
+  its own non-picker inputs, so it inlines the same chips).
+- 10 unit tests on `validateCustomDims` (happy path, sub-1pt, zero,
+  fractional, NaN, ±Infinity, single-side, both-side errors).
+- 5 Playwright tests on the onboarding flow covering the exact bug
+  repro, recovery on correction, zero-equivalence, both-side errors,
+  and switching back to a preset clearing the disabled state.

--- a/packages/ui/e2e/page-dim-validation.spec.ts
+++ b/packages/ui/e2e/page-dim-validation.spec.ts
@@ -1,0 +1,90 @@
+/**
+ * #112 — custom page-dimension input validation.
+ *
+ * Bug repro:
+ *   1. Onboarding → Solid Color → Next: page size
+ *   2. Select "Custom"
+ *   3. Enter `-100` in Width
+ *   4. Click Apply  ← used to be accepted, app opened with a broken canvas
+ *
+ * Expectation now: the inline error chip surfaces a per-field message
+ * ("Width must be at least 1 pt.") and the Apply button is disabled
+ * until the user enters a value ≥ 1 in BOTH fields.
+ */
+import type { Page } from '@playwright/test'
+import { test, expect } from '@playwright/test'
+
+test.describe.configure({ mode: 'serial' })
+
+async function clearStorage(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    localStorage.removeItem('template-goblin-template')
+    localStorage.removeItem('template-goblin-ui')
+    try {
+      indexedDB.deleteDatabase('template-goblin')
+    } catch {
+      /* ignore */
+    }
+  })
+}
+
+async function gotoSizeStep(page: Page): Promise<void> {
+  await page.locator('[data-testid="onboarding-solid-color"]').click()
+  await page.locator('[data-testid="onboarding-color-next"]').click()
+  await expect(page.getByRole('heading', { name: /choose page size/i })).toBeVisible({
+    timeout: 5000,
+  })
+  // Select the "Custom" radio.
+  await page.getByRole('radio', { name: /^Custom$/ }).check()
+}
+
+test.describe('#112 — onboarding page-size custom-dim validation', () => {
+  test.beforeEach(async ({ page }) => {
+    await clearStorage(page)
+    await page.goto('/')
+    await gotoSizeStep(page)
+  })
+
+  test('inline error appears + Apply disabled when Width is -100', async ({ page }) => {
+    const widthInput = page.locator('[data-testid="page-size-custom-width"]')
+    await widthInput.fill('-100')
+
+    await expect(page.locator('[data-testid="page-size-width-error"]')).toContainText(
+      /at least 1 pt/i,
+    )
+    await expect(page.locator('[data-testid="onboarding-color-apply"]')).toBeDisabled()
+  })
+
+  test('correcting the invalid width re-enables Apply and clears the error', async ({ page }) => {
+    const widthInput = page.locator('[data-testid="page-size-custom-width"]')
+    await widthInput.fill('-100')
+    await expect(page.locator('[data-testid="onboarding-color-apply"]')).toBeDisabled()
+
+    await widthInput.fill('595')
+    await expect(page.locator('[data-testid="page-size-width-error"]')).toHaveCount(0)
+    await expect(page.locator('[data-testid="onboarding-color-apply"]')).toBeEnabled()
+  })
+
+  test('zero width is rejected the same as negative', async ({ page }) => {
+    await page.locator('[data-testid="page-size-custom-width"]').fill('0')
+    await expect(page.locator('[data-testid="page-size-width-error"]')).toContainText(
+      /at least 1 pt/i,
+    )
+    await expect(page.locator('[data-testid="onboarding-color-apply"]')).toBeDisabled()
+  })
+
+  test('both fields invalid reports both errors', async ({ page }) => {
+    await page.locator('[data-testid="page-size-custom-width"]').fill('-1')
+    await page.locator('[data-testid="page-size-custom-height"]').fill('-1')
+    await expect(page.locator('[data-testid="page-size-width-error"]')).toBeVisible()
+    await expect(page.locator('[data-testid="page-size-height-error"]')).toBeVisible()
+    await expect(page.locator('[data-testid="onboarding-color-apply"]')).toBeDisabled()
+  })
+
+  test('switching back to a preset clears the disabled-Apply state', async ({ page }) => {
+    await page.locator('[data-testid="page-size-custom-width"]').fill('-100')
+    await expect(page.locator('[data-testid="onboarding-color-apply"]')).toBeDisabled()
+    await page.getByRole('radio', { name: /^A4/ }).check()
+    await expect(page.locator('[data-testid="onboarding-color-apply"]')).toBeEnabled()
+  })
+})

--- a/packages/ui/src/components/Canvas/AddPageDialog.tsx
+++ b/packages/ui/src/components/Canvas/AddPageDialog.tsx
@@ -1,6 +1,11 @@
 import React, { useState, useRef } from 'react'
 import { type PageBackgroundType, type PageSize } from '@template-goblin/types'
-import { PageSizePicker, resolveChoice, type PageSizeChoice } from './PageSizePicker.js'
+import {
+  PageSizePicker,
+  resolveChoice,
+  validateCustomDims,
+  type PageSizeChoice,
+} from './PageSizePicker.js'
 import { ColorPickerPopover } from '../ColorPickerPopover.js'
 
 /**
@@ -278,6 +283,9 @@ export function AddPageDialog({
                 className="tg-btn tg-btn--primary"
                 onClick={commit}
                 data-testid="add-page-confirm"
+                disabled={
+                  sizeChoice === 'custom' && validateCustomDims(customWidth, customHeight).hasError
+                }
               >
                 {mode === 'edit' ? 'Apply' : 'Add Page'}
               </button>

--- a/packages/ui/src/components/Canvas/OnboardingPicker.tsx
+++ b/packages/ui/src/components/Canvas/OnboardingPicker.tsx
@@ -1,6 +1,11 @@
 import React, { useState } from 'react'
 import { type PageSize } from '@template-goblin/types'
-import { PageSizePicker, resolveChoice, type PageSizeChoice } from './PageSizePicker.js'
+import {
+  PageSizePicker,
+  resolveChoice,
+  validateCustomDims,
+  type PageSizeChoice,
+} from './PageSizePicker.js'
 import { ColorPickerPopover } from '../ColorPickerPopover.js'
 
 /**
@@ -180,6 +185,9 @@ export function OnboardingPicker({
                   onChooseColor(hex, size)
                 }}
                 data-testid="onboarding-color-apply"
+                disabled={
+                  sizeChoice === 'custom' && validateCustomDims(customWidth, customHeight).hasError
+                }
               >
                 Apply
               </button>

--- a/packages/ui/src/components/Canvas/PageSizePicker.tsx
+++ b/packages/ui/src/components/Canvas/PageSizePicker.tsx
@@ -2,6 +2,32 @@ import React from 'react'
 import { PAGE_SIZE_PRESETS, type PageSize } from '@template-goblin/types'
 
 /**
+ * Per-field validation of the custom Width / Height inputs (#112).
+ * Returns the inline error message for each side, or `null` when valid.
+ * `hasError` is a convenience flag callers use to gate the Apply button.
+ *
+ * Note: only consulted when the picker is in `'custom'` mode; preset and
+ * Match/Previous choices have known-good dimensions and never error.
+ */
+export interface CustomDimValidation {
+  widthError: string | null
+  heightError: string | null
+  hasError: boolean
+}
+
+export function validateCustomDims(width: number, height: number): CustomDimValidation {
+  const widthError = checkOne(width, 'Width')
+  const heightError = checkOne(height, 'Height')
+  return { widthError, heightError, hasError: !!(widthError || heightError) }
+}
+
+function checkOne(value: number, label: string): string | null {
+  if (!Number.isFinite(value)) return `${label} must be a number.`
+  if (value < 1) return `${label} must be at least 1 pt.`
+  return null
+}
+
+/**
  * Reusable page-size radio picker. The "Same as previous" option is shown
  * when `previousSize` is supplied (i.e. on second-and-later pages); when
  * onboarding the very first page there is no previous size, so the prop is
@@ -48,6 +74,7 @@ export function PageSizePicker({
   previousSizeLabel = 'Same as previous',
   matchImage,
 }: PageSizePickerProps) {
+  const { widthError, heightError } = validateCustomDims(customWidth, customHeight)
   const presets: { key: PageSize; label: string }[] = [
     { key: 'A4', label: 'A4 (595 × 842 pt)' },
     { key: 'A3', label: 'A3 (842 × 1191 pt)' },
@@ -115,7 +142,22 @@ export function PageSizePicker({
               value={customWidth}
               onChange={(e) => setCustomWidth(Number(e.target.value))}
               tabIndex={value === 'custom' ? 0 : -1}
+              aria-invalid={value === 'custom' && !!widthError}
+              aria-describedby={
+                value === 'custom' && widthError ? 'page-size-width-error' : undefined
+              }
+              data-testid="page-size-custom-width"
             />
+            {value === 'custom' && widthError && (
+              <div
+                id="page-size-width-error"
+                data-testid="page-size-width-error"
+                role="alert"
+                style={{ fontSize: 11, color: 'var(--error)', marginTop: 4 }}
+              >
+                {widthError}
+              </div>
+            )}
           </div>
           <div style={{ flex: 1 }}>
             <label
@@ -135,7 +177,22 @@ export function PageSizePicker({
               value={customHeight}
               onChange={(e) => setCustomHeight(Number(e.target.value))}
               tabIndex={value === 'custom' ? 0 : -1}
+              aria-invalid={value === 'custom' && !!heightError}
+              aria-describedby={
+                value === 'custom' && heightError ? 'page-size-height-error' : undefined
+              }
+              data-testid="page-size-custom-height"
             />
+            {value === 'custom' && heightError && (
+              <div
+                id="page-size-height-error"
+                data-testid="page-size-height-error"
+                role="alert"
+                style={{ fontSize: 11, color: 'var(--error)', marginTop: 4 }}
+              >
+                {heightError}
+              </div>
+            )}
           </div>
         </div>
       </div>

--- a/packages/ui/src/components/Canvas/__tests__/validateCustomDims.test.ts
+++ b/packages/ui/src/components/Canvas/__tests__/validateCustomDims.test.ts
@@ -1,0 +1,57 @@
+/**
+ * #112 — per-field validation of the custom Width / Height inputs in the
+ * page-size picker. The store's `clampPageDimension` floors silently,
+ * which protects state but doesn't tell the user WHY the value is bad.
+ * `validateCustomDims` is what the picker + Apply gate use to surface
+ * a per-field error before the user clicks through.
+ */
+import { describe, it, expect } from 'vitest'
+import { validateCustomDims } from '../PageSizePicker.js'
+
+describe('validateCustomDims', () => {
+  it('accepts canonical A4 dimensions', () => {
+    const r = validateCustomDims(595, 842)
+    expect(r.widthError).toBeNull()
+    expect(r.heightError).toBeNull()
+    expect(r.hasError).toBe(false)
+  })
+
+  it('accepts the minimum-allowed 1pt dimension', () => {
+    const r = validateCustomDims(1, 1)
+    expect(r.hasError).toBe(false)
+  })
+
+  it.each([
+    [-100, 'negative width'],
+    [0, 'zero width'],
+    [0.5, 'sub-1pt width'],
+  ])('rejects width %s (%s) with a min-1pt message', (width) => {
+    const r = validateCustomDims(width, 842)
+    expect(r.widthError).toMatch(/at least 1 pt/i)
+    expect(r.heightError).toBeNull()
+    expect(r.hasError).toBe(true)
+  })
+
+  it('rejects a negative height while keeping a valid width clean', () => {
+    const r = validateCustomDims(595, -50)
+    expect(r.widthError).toBeNull()
+    expect(r.heightError).toMatch(/at least 1 pt/i)
+    expect(r.hasError).toBe(true)
+  })
+
+  it.each([Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])(
+    'rejects non-finite width %s with a "must be a number" message',
+    (value) => {
+      const r = validateCustomDims(value, 842)
+      expect(r.widthError).toMatch(/must be a number/i)
+      expect(r.hasError).toBe(true)
+    },
+  )
+
+  it('reports BOTH fields when both are invalid', () => {
+    const r = validateCustomDims(-1, -1)
+    expect(r.widthError).toMatch(/at least 1 pt/i)
+    expect(r.heightError).toMatch(/at least 1 pt/i)
+    expect(r.hasError).toBe(true)
+  })
+})

--- a/packages/ui/src/components/Toolbar/PageSizeDialog.tsx
+++ b/packages/ui/src/components/Toolbar/PageSizeDialog.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { useTemplateStore } from '../../store/templateStore.js'
 import { useUiStore } from '../../store/uiStore.js'
 import type { PageSize } from '@template-goblin/types'
+import { validateCustomDims } from '../Canvas/PageSizePicker.js'
 
 interface PageSizeOption {
   label: string
@@ -21,6 +22,12 @@ export function PageSizeDialog() {
   const [selected, setSelected] = useState<string>('match')
   const [customWidth, setCustomWidth] = useState(595)
   const [customHeight, setCustomHeight] = useState(842)
+
+  // #112 — block Apply on a sub-1 / non-finite custom dimension. The store
+  // clamp + manifest validator catch bad values defence-in-depth, but the
+  // user should see WHY their value was rejected before hitting Apply.
+  const customDimValidation = validateCustomDims(customWidth, customHeight)
+  const applyDisabled = selected === 'custom' && customDimValidation.hasError
 
   if (!showDialog || !pendingBackground) return null
 
@@ -122,7 +129,22 @@ export function PageSizeDialog() {
                 min={1}
                 value={customWidth}
                 onChange={(e) => setCustomWidth(Number(e.target.value))}
+                aria-invalid={!!customDimValidation.widthError}
+                aria-describedby={
+                  customDimValidation.widthError ? 'toolbar-page-size-width-error' : undefined
+                }
+                data-testid="toolbar-page-size-custom-width"
               />
+              {customDimValidation.widthError && (
+                <div
+                  id="toolbar-page-size-width-error"
+                  data-testid="toolbar-page-size-width-error"
+                  role="alert"
+                  style={{ fontSize: 11, color: 'var(--error)', marginTop: 4 }}
+                >
+                  {customDimValidation.widthError}
+                </div>
+              )}
             </div>
             <div style={{ flex: 1 }}>
               <label
@@ -141,7 +163,22 @@ export function PageSizeDialog() {
                 min={1}
                 value={customHeight}
                 onChange={(e) => setCustomHeight(Number(e.target.value))}
+                aria-invalid={!!customDimValidation.heightError}
+                aria-describedby={
+                  customDimValidation.heightError ? 'toolbar-page-size-height-error' : undefined
+                }
+                data-testid="toolbar-page-size-custom-height"
               />
+              {customDimValidation.heightError && (
+                <div
+                  id="toolbar-page-size-height-error"
+                  data-testid="toolbar-page-size-height-error"
+                  role="alert"
+                  style={{ fontSize: 11, color: 'var(--error)', marginTop: 4 }}
+                >
+                  {customDimValidation.heightError}
+                </div>
+              )}
             </div>
           </div>
         )}
@@ -150,7 +187,12 @@ export function PageSizeDialog() {
           <button className="tg-btn" onClick={handleCancel}>
             Cancel
           </button>
-          <button className="tg-btn tg-btn--primary" onClick={handleApply}>
+          <button
+            className="tg-btn tg-btn--primary"
+            onClick={handleApply}
+            disabled={applyDisabled}
+            data-testid="toolbar-page-size-apply"
+          >
             Apply
           </button>
         </div>


### PR DESCRIPTION
## Summary

Adds the UX layer the original bug body asked for. The store-side `clampPageDimension` from the prior pass already silently floored bad values to 1pt — protecting state — but the user just saw their `-100` typed in, no feedback, dialog accepted. Now:

- New `validateCustomDims(width, height)` helper in `PageSizePicker.tsx`.
- Inline red chip below each input — *"Width must be at least 1 pt."*, *"Height must be at least 1 pt."*, *"Width must be a number."* for non-finite values — wired up with `aria-invalid` / `aria-describedby` for screen readers.
- Primary action gated on validation in all three custom-W/H surfaces:
  - `OnboardingPicker` (Solid Color → Next: page size → Custom → Apply)
  - `AddPageDialog` (Add Page / Apply after picking background → Custom)
  - Toolbar `PageSizeDialog` (after image upload → Custom)

## Test plan

- [x] 10 unit tests on `validateCustomDims` (happy path, sub-1pt, zero, fractional, NaN, ±Infinity, single-side, both-side)
- [x] 5 Playwright tests on the onboarding flow:
  - exact bug repro (Width = `-100` → chip + Apply disabled)
  - correcting the value re-enables Apply
  - zero rejected same as negative
  - both-side errors render
  - switching to a preset clears the disabled state
- [x] Manual live test in Chrome at `localhost:4242`: typed `-100` → red chip + disabled Apply; typed `0` height → second chip; fixed values → chips cleared and Apply re-enabled; clicked Apply → canvas mounted cleanly at 595×842 with 290 Fabric objects.

Closes #112.