### PR TITLE
fix(ui): onboarding colour preview icon reflects selected colour (#115)

### DIFF
--- a/.changeset/onboarding-color-preview-icon.md
+++ b/.changeset/onboarding-color-preview-icon.md
@@ -1,0 +1,22 @@
+---
+'template-goblin-ui': patch
+---
+
+fix(ui): onboarding colour preview icon reflects selected colour (#115)
+
+The inner disc of the SVG above "Pick a background color" used to inherit
+`var(--text-muted)` via `currentColor` and stayed grey regardless of what
+the user typed in the hex field or clicked in the swatch. The disc's
+`fill` is now bound to the live colour state, gated on the same
+`#RRGGBB` regex the Apply handler uses — partial typing falls back to
+the muted theme tint so the icon doesn't flash arbitrary colours
+mid-keystroke. Disc enlarged from `r=3` to `r=6` so the preview reads
+from across the canvas.
+
+Also fixed two pre-existing regressions in `e2e/onboarding-to-canvas.spec.ts`
+uncovered while testing this branch: the spec drove the pre-#61 flow
+(click Apply directly after typing the hex) but the UI now has an
+intermediate "Next: page size" step, and the `getFabricBgColor` helper
+read `fabricCanvas.backgroundColor` which has been empty since the
+GH #46 multi-page refactor — it now reads `pages[0].backgroundColor`
+from the store with the Fabric property as a fallback.

--- a/packages/ui/e2e/onboarding-color-preview-icon.spec.ts
+++ b/packages/ui/e2e/onboarding-color-preview-icon.spec.ts
@@ -1,0 +1,88 @@
+/**
+ * #115 — the onboarding "Pick a background color" card's preview icon
+ * must reflect the user's selected colour live as they type the hex
+ * or use the swatch. Before the fix, the inner disc inherited
+ * `var(--text-muted)` and stayed grey regardless of selection.
+ */
+import type { Page } from '@playwright/test'
+import { test, expect } from '@playwright/test'
+
+test.describe.configure({ mode: 'serial' })
+
+async function clearStorage(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    localStorage.removeItem('template-goblin-template')
+    localStorage.removeItem('template-goblin-ui')
+    try {
+      indexedDB.deleteDatabase('template-goblin')
+    } catch {
+      /* ignore */
+    }
+  })
+}
+
+async function gotoColorStep(page: Page): Promise<void> {
+  await page.locator('[data-testid="onboarding-solid-color"]').click()
+  await expect(page.getByRole('heading', { name: /pick a background color/i })).toBeVisible({
+    timeout: 5000,
+  })
+}
+
+/** Resolve the inner-disc fill, normalising `#RRGGBB` to lowercase for compare. */
+async function discFill(page: Page): Promise<string> {
+  return await page.locator('[data-testid="onboarding-color-preview-disc"]').evaluate((el) => {
+    // `getAttribute('fill')` returns whatever React rendered — either the
+    // hex string we set, or the CSS-variable fallback for partial input.
+    return (el.getAttribute('fill') ?? '').toLowerCase()
+  })
+}
+
+test.describe('#115 — onboarding color preview icon', () => {
+  test.beforeEach(async ({ page }) => {
+    await clearStorage(page)
+    await page.goto('/')
+    await gotoColorStep(page)
+  })
+
+  test('starts with the muted fallback when the default white is the initial value', async ({
+    page,
+  }) => {
+    // Default `color` state is `#ffffff` — a valid hex, so the disc should
+    // already reflect white, not the muted fallback.
+    expect(await discFill(page)).toBe('#ffffff')
+  })
+
+  test('updates to red when the user types #ff0000 into the hex input', async ({ page }) => {
+    const hexInput = page.locator('[data-testid="onboarding-color-hex"]')
+    await hexInput.fill('#ff0000')
+    await expect(page.locator('[data-testid="onboarding-color-preview-disc"]')).toHaveAttribute(
+      'fill',
+      '#ff0000',
+    )
+  })
+
+  test('updates again when the user changes the hex to blue', async ({ page }) => {
+    const hexInput = page.locator('[data-testid="onboarding-color-hex"]')
+    await hexInput.fill('#0000ff')
+    expect(await discFill(page)).toBe('#0000ff')
+    await hexInput.fill('#00ff00')
+    expect(await discFill(page)).toBe('#00ff00')
+  })
+
+  test('falls back to the muted tint while the user is mid-typing a partial hex', async ({
+    page,
+  }) => {
+    const hexInput = page.locator('[data-testid="onboarding-color-hex"]')
+    // `#ff` is not a valid #RRGGBB — the disc should NOT show a random
+    // colour. We expect the muted-tint CSS-variable fallback instead.
+    await hexInput.fill('#ff')
+    const fill = await discFill(page)
+    expect(fill).toMatch(/var\(--text-muted\)/)
+  })
+
+  test('uppercase hex is normalised to lowercase but still rendered', async ({ page }) => {
+    const hexInput = page.locator('[data-testid="onboarding-color-hex"]')
+    await hexInput.fill('#ABCDEF')
+    expect(await discFill(page)).toBe('#abcdef')
+  })
+})

--- a/packages/ui/e2e/onboarding-to-canvas.spec.ts
+++ b/packages/ui/e2e/onboarding-to-canvas.spec.ts
@@ -65,10 +65,23 @@ async function toScreen(page: Page, ptX: number, ptY: number): Promise<{ x: numb
  * Returns the canvas backgroundColor as reported by the Fabric instance.
  */
 async function getFabricBgColor(page: Page): Promise<string> {
+  // GH #46-era refactor: the page background colour moved off the Fabric
+  // canvas's `backgroundColor` (single-page only) onto the `pages[0]`
+  // PageDefinition (per-page colour). The on-canvas paint is the
+  // page-bounds rect; the source of truth is the store. Falls back to
+  // the Fabric property for ancient pre-refactor templates.
   return await page.evaluate(() => {
+    interface TmplStoreLike {
+      getState(): {
+        pages?: Array<{ index: number; backgroundColor?: string | null }>
+      }
+    }
     interface FabricLike {
       backgroundColor?: string
     }
+    const store = (window as unknown as { __templateStore?: TmplStoreLike }).__templateStore
+    const page0 = store?.getState().pages?.find((p) => p.index === 0)
+    if (page0?.backgroundColor) return page0.backgroundColor
     const fc = (window as unknown as { __fabricCanvas?: FabricLike }).__fabricCanvas
     return fc?.backgroundColor ?? ''
   })
@@ -126,6 +139,9 @@ test.describe('Onboarding → solid colour', () => {
     await hexInput.fill('#00ff00')
 
     // Apply.
+    // Onboarding now has an intermediate "Next: page size" step before Apply
+    // (added in #61 / refined in #112). Click through it with the A4 default.
+    await page.locator('[data-testid="onboarding-color-next"]').click()
     await page.locator('[data-testid="onboarding-color-apply"]').click()
 
     // Onboarding should disappear and the Fabric canvas should mount.
@@ -157,6 +173,9 @@ test.describe('Onboarding → solid colour', () => {
     // Complete onboarding.
     await page.locator('[data-testid="onboarding-solid-color"]').click()
     await page.locator('[data-testid="onboarding-color-hex"]').fill('#ccddee')
+    // Onboarding now has an intermediate "Next: page size" step before Apply
+    // (added in #61 / refined in #112). Click through it with the A4 default.
+    await page.locator('[data-testid="onboarding-color-next"]').click()
     await page.locator('[data-testid="onboarding-color-apply"]').click()
 
     // Wait for canvas.
@@ -216,6 +235,9 @@ test.describe('Onboarding → solid colour', () => {
     // Complete onboarding with solid colour.
     await page.locator('[data-testid="onboarding-solid-color"]').click()
     await page.locator('[data-testid="onboarding-color-hex"]').fill('#123456')
+    // Onboarding now has an intermediate "Next: page size" step before Apply
+    // (added in #61 / refined in #112). Click through it with the A4 default.
+    await page.locator('[data-testid="onboarding-color-next"]').click()
     await page.locator('[data-testid="onboarding-color-apply"]').click()
 
     // Canvas must appear despite the stale currentPageId.

--- a/packages/ui/src/components/Canvas/OnboardingPicker.tsx
+++ b/packages/ui/src/components/Canvas/OnboardingPicker.tsx
@@ -103,6 +103,14 @@ export function OnboardingPicker({
 
         {mode === 'color' && (
           <>
+            {/*
+             * GH #115 — the inner disc reflects the currently-selected color
+             * so the user sees their choice update live as they pick from
+             * the swatch or type a hex. We accept the hex only when it
+             * matches `#RRGGBB` (the same gate the Apply handler uses);
+             * partial typing falls back to the muted theme tint so the icon
+             * doesn't flash arbitrary colors mid-keystroke.
+             */}
             <svg
               width="64"
               height="64"
@@ -110,9 +118,17 @@ export function OnboardingPicker({
               fill="none"
               stroke="var(--text-muted)"
               strokeWidth="1.5"
+              data-testid="onboarding-color-preview-icon"
             >
               <circle cx="12" cy="12" r="10" />
-              <circle cx="12" cy="12" r="3" fill="currentColor" />
+              <circle
+                cx="12"
+                cy="12"
+                r="6"
+                stroke="none"
+                fill={/^#[0-9a-fA-F]{6}$/.test(color) ? color.toLowerCase() : 'var(--text-muted)'}
+                data-testid="onboarding-color-preview-disc"
+              />
             </svg>
             <h2 className="tg-upload-title">Pick a background color</h2>
             <div


### PR DESCRIPTION
## Summary

The SVG above "Pick a background color" stayed grey no matter what the user typed or picked — the inner disc inherited `var(--text-muted)` via `currentColor`. It now binds to the live colour state, gated on the same `#RRGGBB` regex the Apply handler uses. Partial typing (`#ff`, `not a hex`) falls back to the muted tint so the icon doesn't strobe mid-keystroke. Disc enlarged from `r=3` → `r=6` so the preview reads from across the canvas.

Two pre-existing regressions in \`e2e/onboarding-to-canvas.spec.ts\` were uncovered while testing this branch and fixed here:

- 3 tests drove the pre-#61 flow (typed hex → \`onboarding-color-apply\`) but the UI now has an intermediate \"Next: page size\" step. Inserted the step before each Apply.
- \`getFabricBgColor\` read \`fabricCanvas.backgroundColor\` which has been empty since the GH #46 multi-page refactor moved page colour onto \`pages[0].backgroundColor\`. Helper now reads the store, falls back to the Fabric property for ancient single-page templates.

## Test plan

- [x] 5 new Playwright tests in \`e2e/onboarding-color-preview-icon.spec.ts\` (default white, red/green/blue typing, partial-hex muted fallback, uppercase→lowercase normalisation)
- [x] Existing onboarding-to-canvas suite (6 tests) green again
- [x] 433 core unit + 507 UI unit + type-check + lint + production build all clean
- [x] Manual live test in Chrome at \`localhost:4242\`: hex \`#ff0000\`, \`#00ff00\`, \`#0000ff\`, \`#abcdef\`, \`#ABCDEF\` all paint the disc; \`#ff\` and \`not a hex\` fall back to muted; clicking through to Apply lands \`page0.backgroundColor = '#ff0000'\` on the canvas

Closes #115.