### PR TITLE
chore(ui): replace react-color SketchPicker with react-colorful (#121)

### DIFF
--- a/.changeset/react-colorful-picker.md
+++ b/.changeset/react-colorful-picker.md
@@ -1,0 +1,25 @@
+---
+'template-goblin-ui': minor
+---
+
+chore(ui): replace react-color SketchPicker with react-colorful (#121)
+
+`react-color`'s `SketchPicker` used the legacy `defaultProps` API on a
+function component, emitting a React-18 deprecation warning every time
+the picker opened. It also warm-loaded a heavy palette on first mount
+which froze the renderer for ~3-5 seconds.
+
+Swapped for `react-colorful` (5 KB, zero deps, actively maintained,
+modern API). Same affordance the user is used to per #121's
+"no visual redesign" caveat: Saturation/Value square + Hue slider +
+hex text input + the 10-swatch preset grid the SketchPicker carried
+(rendered ourselves since react-colorful ships only the picker
+primitive).
+
+Verified live in Chrome at localhost:4242: picker opens in **23 ms**
+(issue target was <100 ms), zero `defaultProps` warnings across the
+full flow, zero other console warnings. Preset swatches, hex input
+typing, the parent hex field, and the onboarding preview disc
+(GH #115) all stay in sync regardless of which surface the user
+edits from. Escape closes the popover without bubbling to the
+surrounding modal; outside click closes it.

--- a/packages/ui/e2e/color-picker.spec.ts
+++ b/packages/ui/e2e/color-picker.spec.ts
@@ -1,0 +1,113 @@
+/**
+ * #121 — the colour picker popover is now backed by `react-colorful`
+ * instead of `react-color`'s `SketchPicker`. This spec pins the bits the
+ * issue's acceptance criteria called out:
+ *
+ *   - Console clean of the `defaultProps` warning.
+ *   - Picker opens in < 100 ms on first mount (cold-cache).
+ *   - Hue/Saturation interaction, hex text input, and preset swatches
+ *     all propagate the selected colour back to the parent.
+ *
+ * Driven through the onboarding colour swatch — same `ColorPickerPopover`
+ * component every other surface (band background, divider, page number,
+ * text colour) uses, so the contract holds everywhere.
+ */
+import type { ConsoleMessage, Page } from '@playwright/test'
+import { test, expect } from '@playwright/test'
+
+test.describe.configure({ mode: 'serial' })
+
+async function clearStorage(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    localStorage.removeItem('template-goblin-template')
+    localStorage.removeItem('template-goblin-ui')
+    try {
+      indexedDB.deleteDatabase('template-goblin')
+    } catch {
+      /* ignore */
+    }
+  })
+}
+
+async function gotoColorStep(page: Page): Promise<void> {
+  await page.locator('[data-testid="onboarding-solid-color"]').click()
+  await expect(page.getByRole('heading', { name: /pick a background color/i })).toBeVisible({
+    timeout: 5000,
+  })
+}
+
+test.describe('#121 — ColorPickerPopover backed by react-colorful', () => {
+  test.beforeEach(async ({ page }) => {
+    await clearStorage(page)
+    await page.goto('/')
+    await gotoColorStep(page)
+  })
+
+  test('no `defaultProps` warning logged when the picker opens', async ({ page }) => {
+    const warnings: string[] = []
+    const onMsg = (m: ConsoleMessage): void => {
+      const t = m.text()
+      if (m.type() === 'warning' || m.type() === 'error') warnings.push(t)
+    }
+    page.on('console', onMsg)
+
+    await page.locator('[data-testid="color-picker-swatch"]').click()
+    await expect(page.locator('[data-testid="color-picker-popover"]')).toBeVisible()
+    // Give React's microtask queue a beat to flush any deferred warnings.
+    await page.waitForTimeout(300)
+
+    page.off('console', onMsg)
+    const defaultPropsWarnings = warnings.filter((w) =>
+      /defaultProps will be removed from function components/i.test(w),
+    )
+    expect(defaultPropsWarnings).toEqual([])
+  })
+
+  test('picker mounts in under 500ms (loose ceiling — issue asked for <100ms)', async ({
+    page,
+  }) => {
+    // The hard <100ms target from the issue body is below Playwright's
+    // measurement noise floor on most CI runners, but the regression we're
+    // guarding (SketchPicker's 3-5 SECOND palette warm-up) is so large
+    // that a 500ms ceiling catches it without flaking.
+    const t0 = Date.now()
+    await page.locator('[data-testid="color-picker-swatch"]').click()
+    await expect(page.locator('[data-testid="color-picker-popover"]')).toBeVisible()
+    const elapsed = Date.now() - t0
+    expect(elapsed).toBeLessThan(500)
+  })
+
+  test('clicking a preset swatch propagates the colour to the parent', async ({ page }) => {
+    await page.locator('[data-testid="color-picker-swatch"]').click()
+    await page.locator('[data-testid="color-picker-preset-#ef4444"]').click()
+
+    // The hex input inside the popover should now show the preset.
+    await expect(page.locator('[data-testid="color-picker-hex"]')).toHaveValue('#ef4444')
+    // The onboarding hex input (the parent's `value`) should also reflect.
+    await expect(page.locator('[data-testid="onboarding-color-hex"]')).toHaveValue('#ef4444')
+  })
+
+  test('typing into the picker hex input updates the parent live', async ({ page }) => {
+    await page.locator('[data-testid="color-picker-swatch"]').click()
+    const pickerHex = page.locator('[data-testid="color-picker-hex"]')
+    await pickerHex.fill('#abcdef')
+    await expect(page.locator('[data-testid="onboarding-color-hex"]')).toHaveValue('#abcdef')
+  })
+
+  test('Escape closes the picker without bubbling out', async ({ page }) => {
+    await page.locator('[data-testid="color-picker-swatch"]').click()
+    await expect(page.locator('[data-testid="color-picker-popover"]')).toBeVisible()
+    await page.keyboard.press('Escape')
+    await expect(page.locator('[data-testid="color-picker-popover"]')).toHaveCount(0)
+    // Onboarding stays on the colour step — Escape didn't bubble.
+    await expect(page.getByRole('heading', { name: /pick a background color/i })).toBeVisible()
+  })
+
+  test('outside click closes the picker', async ({ page }) => {
+    await page.locator('[data-testid="color-picker-swatch"]').click()
+    await expect(page.locator('[data-testid="color-picker-popover"]')).toBeVisible()
+    // Click on the heading (well outside the popover).
+    await page.getByRole('heading', { name: /pick a background color/i }).click()
+    await expect(page.locator('[data-testid="color-picker-popover"]')).toHaveCount(0)
+  })
+})

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -20,7 +20,7 @@
     "fabric": "^6.9.1",
     "jszip": "^3.10.1",
     "react": "^18.3.1",
-    "react-color": "^2.19.3",
+    "react-colorful": "^5.7.0",
     "react-dom": "^18.3.1",
     "tailwindcss": "^4.2.2",
     "zustand": "^5.0.3"
@@ -30,7 +30,6 @@
     "@template-goblin/types": "workspace:*",
     "@types/pdfkit": "^0.13.5",
     "@types/react": "^18.3.14",
-    "@types/react-color": "^3.0.13",
     "@types/react-dom": "^18.3.3",
     "@vitejs/plugin-react": "^4.3.4",
     "fake-indexeddb": "^6.2.5",
@@ -48,5 +47,5 @@
   "comment:react-konva": "React bindings for Konva — BEING REMOVED in favour of Fabric.js (kept during migration only)",
   "comment:zustand": "Lightweight state management — canvas state, undo/redo, UI state",
   "comment:fake-indexeddb": "Test-only: polyfills IndexedDB in jsdom/Node so the templateStore's IDB-backed persist adapter (GH #11) is exercised by Vitest. Loaded via vite.config `test.setupFiles`.",
-  "comment:react-color": "In-page Sketch colour picker replacing the native `<input type=\"color\">`. The native OS picker froze the whole page on some browser/GPU combos until it was dismissed — react-color renders inline in a popover so the page stays interactive."
+  "comment:react-colorful": "5 KB, zero-dep, maintained colour picker (Hue slider + Saturation/Value square). Replaces react-color's SketchPicker which used the legacy `defaultProps` API (React-18 warning on every mount) and warm-loaded a heavy palette on first open (~3-5s freeze on first mount, GH #121). The picker still renders inline in a popover so the page stays interactive — native OS pickers froze the whole tab on some browser/GPU combos."
 }

--- a/packages/ui/src/components/ColorPickerPopover.tsx
+++ b/packages/ui/src/components/ColorPickerPopover.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
-import { SketchPicker, type ColorResult } from 'react-color'
+import { HexColorPicker } from 'react-colorful'
 
 interface ColorPickerPopoverProps {
   value: string
@@ -11,11 +11,17 @@ interface ColorPickerPopoverProps {
 }
 
 /**
- * Compact hex-colour swatch that opens a SketchPicker (react-color) in a
- * popover when clicked. Replaces the native `<input type="color">` which
- * caused the whole page to freeze on some browsers / GPU configurations
- * when the OS-level picker was open. The popover closes on outside click
- * and on Escape.
+ * Compact hex-colour swatch that opens a colour picker popover when
+ * clicked. Built on `react-colorful` (#121) — replaces the previous
+ * `react-color` SketchPicker which used the legacy `defaultProps` API
+ * (React-18 deprecation warning on every mount) and warm-loaded a heavy
+ * palette on first open (3-5s freeze). The popover closes on outside
+ * click and on Escape.
+ *
+ * Affordance preserved per #121 acceptance criteria: the existing
+ * Saturation/Value square + Hue slider + hex input + preset-swatch grid
+ * the user is used to. `react-colorful` is fully controlled and ships
+ * without the noisy preset rail, so we render the swatch grid ourselves.
  */
 export function ColorPickerPopover({
   value,
@@ -36,7 +42,7 @@ export function ColorPickerPopover({
     if (!open || !wrapperRef.current) return
     const r = wrapperRef.current.getBoundingClientRect()
     const POPOVER_W = 220
-    const POPOVER_H = 280
+    const POPOVER_H = 320
     const left = Math.min(window.innerWidth - POPOVER_W - 8, Math.max(8, r.right - POPOVER_W))
     const top = Math.min(window.innerHeight - POPOVER_H - 8, r.bottom + 4)
     setPosition({ top, left })
@@ -62,12 +68,22 @@ export function ColorPickerPopover({
     }
   }, [open])
 
-  const handleChange = useCallback(
-    (result: ColorResult) => {
-      onChange(result.hex)
+  // `react-colorful` only accepts a 7-character `#RRGGBB`. Hex typed
+  // mid-keystroke (`#ff`) would throw; we accept partial input in the
+  // text field but only push it down to the picker + parent on a valid
+  // match. This mirrors the same regex gate used by the onboarding hex
+  // input (#115).
+  const handleHexInput = useCallback(
+    (raw: string) => {
+      // Always echo what the user typed back into the parent so the
+      // value stays editable. Downstream consumers (#115 onboarding,
+      // properties panel) all gate their commit on `/^#RRGGBB$/`.
+      onChange(raw)
     },
     [onChange],
   )
+
+  const safePickerColor = /^#[0-9a-fA-F]{6}$/.test(value) ? value : '#000000'
 
   return (
     <span ref={wrapperRef} style={{ display: 'inline-block', position: 'relative' }}>
@@ -77,6 +93,7 @@ export function ColorPickerPopover({
         aria-label={ariaLabel ?? 'Select color'}
         aria-expanded={open}
         title={value}
+        data-testid="color-picker-swatch"
         style={{
           width: swatchWidth,
           height: swatchHeight,
@@ -97,32 +114,96 @@ export function ColorPickerPopover({
           // Without this, pressing Escape inside the picker closes both
           // the popover AND the surrounding band-settings modal.
           data-color-popover="true"
+          data-testid="color-picker-popover"
           style={{
             position: 'fixed',
             top: position.top,
             left: position.left,
             zIndex: 2000,
+            background: 'var(--bg-secondary)',
+            border: '1px solid var(--border)',
+            borderRadius: 6,
+            padding: 10,
+            width: 220,
+            boxShadow: '0 4px 14px rgba(0, 0, 0, 0.25)',
           }}
         >
-          <SketchPicker
-            color={value}
-            onChange={handleChange}
-            disableAlpha
-            presetColors={[
-              '#000000',
-              '#ffffff',
-              '#ef4444',
-              '#f59e0b',
-              '#22c55e',
-              '#3b82f6',
-              '#8b5cf6',
-              '#ec4899',
-              '#64748b',
-              '#0a0a0a',
-            ]}
+          <HexColorPicker
+            color={safePickerColor}
+            onChange={onChange}
+            style={{ width: '100%', height: 160 }}
           />
+          <input
+            type="text"
+            value={value}
+            onChange={(e) => handleHexInput(e.target.value)}
+            spellCheck={false}
+            maxLength={7}
+            data-testid="color-picker-hex"
+            style={{
+              marginTop: 8,
+              width: '100%',
+              fontFamily: 'var(--font-mono, monospace)',
+              fontSize: 12,
+              padding: '4px 6px',
+              background: 'var(--bg-primary)',
+              color: 'var(--text-primary)',
+              border: '1px solid var(--border)',
+              borderRadius: 3,
+              boxSizing: 'border-box',
+            }}
+          />
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: 'repeat(5, 1fr)',
+              gap: 6,
+              marginTop: 8,
+            }}
+          >
+            {PRESETS.map((hex) => (
+              <button
+                key={hex}
+                type="button"
+                onClick={() => onChange(hex)}
+                aria-label={`Preset color ${hex}`}
+                title={hex}
+                data-testid={`color-picker-preset-${hex}`}
+                style={{
+                  width: '100%',
+                  height: 22,
+                  padding: 0,
+                  border:
+                    hex.toLowerCase() === value.toLowerCase()
+                      ? '2px solid var(--accent)'
+                      : '1px solid var(--border)',
+                  borderRadius: 3,
+                  cursor: 'pointer',
+                  background: hex,
+                }}
+              />
+            ))}
+          </div>
         </div>
       )}
     </span>
   )
 }
+
+/**
+ * The 10 swatches the previous SketchPicker carried, kept as-is per #121's
+ * "no visual redesign" caveat. Lives at module scope so the array
+ * identity is stable across re-renders.
+ */
+const PRESETS = [
+  '#000000',
+  '#ffffff',
+  '#ef4444',
+  '#f59e0b',
+  '#22c55e',
+  '#3b82f6',
+  '#8b5cf6',
+  '#ec4899',
+  '#64748b',
+  '#0a0a0a',
+] as const

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,9 +111,9 @@ importers:
       react:
         specifier: ^18.3.1
         version: 18.3.1
-      react-color:
-        specifier: ^2.19.3
-        version: 2.19.3(react@18.3.1)
+      react-colorful:
+        specifier: ^5.7.0
+        version: 5.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
@@ -136,9 +136,6 @@ importers:
       '@types/react':
         specifier: ^18.3.14
         version: 18.3.28
-      '@types/react-color':
-        specifier: ^3.0.13
-        version: 3.0.13(@types/react@18.3.28)
       '@types/react-dom':
         specifier: ^18.3.3
         version: 18.3.7(@types/react@18.3.28)
@@ -844,11 +841,6 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
-  '@icons/material@0.2.4':
-    resolution: {integrity: sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==}
-    peerDependencies:
-      react: '*'
-
   '@inquirer/external-editor@1.0.3':
     resolution: {integrity: sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==}
     engines: {node: '>=18'}
@@ -1384,11 +1376,6 @@ packages:
   '@types/prop-types@15.7.15':
     resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
 
-  '@types/react-color@3.0.13':
-    resolution: {integrity: sha512-2c/9FZ4ixC5T3JzN0LP5Cke2Mf0MKOP2Eh0NPDPWmuVH3NjPyhEjqNMQpN1Phr5m74egAy+p2lYNAFrX1z9Yrg==}
-    peerDependencies:
-      '@types/react': '*'
-
   '@types/react-dom@18.3.7':
     resolution: {integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==}
     peerDependencies:
@@ -1396,11 +1383,6 @@ packages:
 
   '@types/react@18.3.28':
     resolution: {integrity: sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==}
-
-  '@types/reactcss@1.2.13':
-    resolution: {integrity: sha512-gi3S+aUi6kpkF5vdhUsnkwbiSEIU/BEJyD7kBy2SudWBUuKmJk8AQKE0OVcQQeEy40Azh0lV6uynxlikYIJuwg==}
-    peerDependencies:
-      '@types/react': '*'
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
@@ -3023,9 +3005,6 @@ packages:
     resolution: {integrity: sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  lodash-es@4.18.1:
-    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
-
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
 
@@ -3056,9 +3035,6 @@ packages:
   lodash.upperfirst@4.3.1:
     resolution: {integrity: sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==}
 
-  lodash@4.18.1:
-    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
-
   log-update@6.1.0:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
     engines: {node: '>=18'}
@@ -3086,9 +3062,6 @@ packages:
 
   makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
-
-  material-colors@1.2.6:
-    resolution: {integrity: sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg==}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -3476,9 +3449,6 @@ packages:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
 
-  prop-types@15.8.1:
-    resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
-
   psl@1.15.0:
     resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
 
@@ -3518,18 +3488,16 @@ packages:
   randomfill@1.0.4:
     resolution: {integrity: sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==}
 
-  react-color@2.19.3:
-    resolution: {integrity: sha512-LEeGE/ZzNLIsFWa1TMe8y5VYqr7bibneWmvJwm1pCn/eNmrabWDh659JSPn9BuaMpEfU83WTOJfnCcjDZwNQTA==}
+  react-colorful@5.7.0:
+    resolution: {integrity: sha512-fuesYIemttah97XmsIHmz4OORDHiSFzyc9HMAIrCHJou2jaRQmL8cFJ76K4zQhhj8jzwOBlOi4BaGTjjOZCfTg==}
     peerDependencies:
-      react: '*'
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
 
   react-dom@18.3.1:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
     peerDependencies:
       react: ^18.3.1
-
-  react-is@16.13.1:
-    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
@@ -3541,11 +3509,6 @@ packages:
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
-
-  reactcss@1.2.3:
-    resolution: {integrity: sha512-KiwVUcFu1RErkI97ywr8nvx8dNOpT03rbnma0SSalTYjkrPYaEajR4a/MRt6DZ46K6arDRbWMNHF+xH7G7n/8A==}
-    peerDependencies:
-      react: '*'
 
   read-yaml-file@1.1.0:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
@@ -3870,9 +3833,6 @@ packages:
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
-
-  tinycolor2@1.6.0:
-    resolution: {integrity: sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==}
 
   tinyexec@1.1.1:
     resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
@@ -4935,10 +4895,6 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@icons/material@0.2.4(react@18.3.1)':
-    dependencies:
-      react: 18.3.1
-
   '@inquirer/external-editor@1.0.3(@types/node@25.6.0)':
     dependencies:
       chardet: 2.1.1
@@ -5499,11 +5455,6 @@ snapshots:
 
   '@types/prop-types@15.7.15': {}
 
-  '@types/react-color@3.0.13(@types/react@18.3.28)':
-    dependencies:
-      '@types/react': 18.3.28
-      '@types/reactcss': 1.2.13(@types/react@18.3.28)
-
   '@types/react-dom@18.3.7(@types/react@18.3.28)':
     dependencies:
       '@types/react': 18.3.28
@@ -5512,10 +5463,6 @@ snapshots:
     dependencies:
       '@types/prop-types': 15.7.15
       csstype: 3.2.3
-
-  '@types/reactcss@1.2.13(@types/react@18.3.28)':
-    dependencies:
-      '@types/react': 18.3.28
 
   '@types/stack-utils@2.0.3': {}
 
@@ -7574,8 +7521,6 @@ snapshots:
     dependencies:
       p-locate: 6.0.0
 
-  lodash-es@4.18.1: {}
-
   lodash.camelcase@4.3.0: {}
 
   lodash.isplainobject@4.0.6: {}
@@ -7595,8 +7540,6 @@ snapshots:
   lodash.uniq@4.5.0: {}
 
   lodash.upperfirst@4.3.1: {}
-
-  lodash@4.18.1: {}
 
   log-update@6.1.0:
     dependencies:
@@ -7632,8 +7575,6 @@ snapshots:
   makeerror@1.0.12:
     dependencies:
       tmpl: 1.0.5
-
-  material-colors@1.2.6: {}
 
   math-intrinsics@1.1.0: {}
 
@@ -7785,7 +7726,8 @@ snapshots:
   nwsapi@2.2.23:
     optional: true
 
-  object-assign@4.1.1: {}
+  object-assign@4.1.1:
+    optional: true
 
   object-inspect@1.13.4: {}
 
@@ -8003,12 +7945,6 @@ snapshots:
       kleur: 3.0.3
       sisteransi: 1.0.5
 
-  prop-types@15.8.1:
-    dependencies:
-      loose-envify: 1.4.0
-      object-assign: 4.1.1
-      react-is: 16.13.1
-
   psl@1.15.0:
     dependencies:
       punycode: 2.3.1
@@ -8051,24 +7987,16 @@ snapshots:
       randombytes: 2.1.0
       safe-buffer: 5.1.2
 
-  react-color@2.19.3(react@18.3.1):
+  react-colorful@5.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@icons/material': 0.2.4(react@18.3.1)
-      lodash: 4.18.1
-      lodash-es: 4.18.1
-      material-colors: 1.2.6
-      prop-types: 15.8.1
       react: 18.3.1
-      reactcss: 1.2.3(react@18.3.1)
-      tinycolor2: 1.6.0
+      react-dom: 18.3.1(react@18.3.1)
 
   react-dom@18.3.1(react@18.3.1):
     dependencies:
       loose-envify: 1.4.0
       react: 18.3.1
       scheduler: 0.23.2
-
-  react-is@16.13.1: {}
 
   react-is@18.3.1: {}
 
@@ -8077,11 +8005,6 @@ snapshots:
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
-
-  reactcss@1.2.3(react@18.3.1):
-    dependencies:
-      lodash: 4.18.1
-      react: 18.3.1
 
   read-yaml-file@1.1.0:
     dependencies:
@@ -8443,8 +8366,6 @@ snapshots:
   tiny-inflate@1.0.3: {}
 
   tinybench@2.9.0: {}
-
-  tinycolor2@1.6.0: {}
 
   tinyexec@1.1.1: {}
 


### PR DESCRIPTION
## Summary

\`react-color\`'s \`SketchPicker\` used the legacy \`defaultProps\` API on a function component (React-18 deprecation warning on every mount) and warm-loaded a heavy palette on first open (~3-5s freeze). Swapped for \`react-colorful\` — 5 KB, zero deps, actively maintained, modern API. Same affordance per #121's "no visual redesign" caveat: Saturation/Value square + Hue slider + hex input + the 10-swatch preset grid the SketchPicker carried (rendered ourselves since react-colorful ships only the picker primitive).

## Test plan

- [x] 6 new Playwright tests in \`e2e/color-picker.spec.ts\` covering no-defaultProps, fast open, preset propagation, hex typing, Escape close-without-bubble, outside click.
- [x] Regression sweep across 27 colour + onboarding + band + page-dim e2e tests — 26 pass / 1 unrelated skip.
- [x] 433 core + 507 UI unit tests pass.
- [x] Type-check, lint, and production build all clean.
- [x] Live test in Chrome at \`localhost:4242\`: picker opens in **23 ms** (issue target was <100 ms), **zero** \`defaultProps\` warnings across the full flow, **zero** other console warnings. Red preset → all four colour surfaces (picker swatch button, picker hex input, parent hex input, onboarding preview disc) read \`#ef4444\`. Typing \`#abcdef\` in the picker → parent + preview disc both update to \`#abcdef\`. Blue preset → all switch to \`#3b82f6\`. Escape closes the popover (count 1 → 0) without bubbling out of the onboarding card.

## Acceptance criteria from #121

- [x] Console clean of \`defaultProps\` warnings
- [x] Picker opens in <100 ms on first mount (measured 23 ms live)
- [x] All existing colour fields continue to work (text colour, band background, divider colour, page-number colour — same wrapper API)
- [x] Removed \`react-color\` from \`package.json\`

Closes #121.