### PR TITLE
fix(ui): shorten 'Next: page size' button so it fits the onboarding card (#114)

### DIFF
--- a/.changeset/next-button-truncation.md
+++ b/.changeset/next-button-truncation.md
@@ -1,0 +1,26 @@
+---
+'template-goblin-ui': patch
+---
+
+fix(ui): shorten 'Next: page size' button so it fits the onboarding card (#114)
+
+The default `max-w-md` onboarding card was narrow enough that the
+primary action clipped to "Next: page si..." on first paint. Per
+#114's preferred fix, shorten the label to "Next →" in both the
+onboarding picker and the symmetric `AddPageDialog` button. The arrow
+keeps the call-to-action obvious; the next step's "Choose page size"
+heading carries the context.
+
+Verified live in Chrome at localhost:4242: button reads "Next →",
+scrollWidth === clientWidth (60px), no clipping. The 4 new Playwright
+tests in `e2e/onboarding-next-button.spec.ts` pin the label, measure
+scrollWidth ≤ clientWidth at both default and 360px viewports, and
+confirm the click still advances to the page-size step.
+
+Related-branch fixes folded in:
+
+- 7 existing specs hard-coded the old label in `hasText:` matchers.
+  Updated to `/Next →/`.
+- `change-background.spec.ts` still drove a native `<input type="color">`
+  that the #121 picker swap removed — switched to the new
+  `color-picker-swatch` + `color-picker-hex` testids.

--- a/packages/ui/e2e/add-page-dialog.spec.ts
+++ b/packages/ui/e2e/add-page-dialog.spec.ts
@@ -161,7 +161,7 @@ test.describe('Add Page dialog (#47)', () => {
 
     await page.locator('button', { hasText: /Solid color/ }).click()
     // Color step.
-    await page.locator('button', { hasText: /Next: page size/ }).click()
+    await page.locator('button', { hasText: /Next →/ }).click()
     // Size step is visible.
     await expect(page.locator('text=Page size:')).toBeVisible()
     // "Same as previous (... × ... pt)" radio is the default for "previous".
@@ -176,7 +176,7 @@ test.describe('Add Page dialog (#47)', () => {
     await expect(fabricCanvas(page)).toBeVisible()
     await openAddPage(page)
     await page.locator('button', { hasText: /Solid color/ }).click()
-    await page.locator('button', { hasText: /Next: page size/ }).click()
+    await page.locator('button', { hasText: /Next →/ }).click()
     await expect(page.locator('text=Page size:')).toBeVisible()
 
     const dialog = page.locator('.tg-dialog')
@@ -193,7 +193,7 @@ test.describe('Add Page dialog (#47)', () => {
     await expect(fabricCanvas(page)).toBeVisible()
     await openAddPage(page)
     await page.locator('button', { hasText: /Solid color/ }).click()
-    await page.locator('button', { hasText: /Next: page size/ }).click()
+    await page.locator('button', { hasText: /Next →/ }).click()
     await expect(page.locator('text=Page size:')).toBeVisible()
 
     const dialog = page.locator('.tg-dialog')
@@ -280,7 +280,7 @@ test.describe('Add Page dialog (#47)', () => {
     await expect(fabricCanvas(page)).toBeVisible()
     await openAddPage(page)
     await page.locator('button', { hasText: /Solid color/ }).click()
-    await page.locator('button', { hasText: /Next: page size/ }).click()
+    await page.locator('button', { hasText: /Next →/ }).click()
     await expect(page.locator('text=Page size:')).toBeVisible()
 
     // The custom block is rendered (reserved slot) but `tabIndex={-1}`

--- a/packages/ui/e2e/change-background.spec.ts
+++ b/packages/ui/e2e/change-background.spec.ts
@@ -172,7 +172,7 @@ test.describe('Change Background dialog (#58)', () => {
 
     // Solid color routes through the size step where the radio renders.
     await page.locator('button', { hasText: /Solid color/ }).click()
-    await page.locator('button', { hasText: /Next: page size/ }).click()
+    await page.locator('button', { hasText: /Next →/ }).click()
     await expect(page.locator('text=Page size:')).toBeVisible()
 
     const dialog = page.locator('.tg-dialog')
@@ -228,17 +228,13 @@ test.describe('Change Background dialog (#58)', () => {
 
     await page.locator('button', { hasText: /Solid color/ }).click()
 
-    // Set a non-default colour. React owns the value via a controlled
-    // input, so we call its native setter and dispatch the `input` event
-    // — Playwright's `fill()` doesn't apply to `<input type="color">`,
-    // and a plain `el.value = X` is overwritten by React's next render.
-    await page.locator('input[type="color"]').evaluate((el: HTMLInputElement) => {
-      const proto = Object.getPrototypeOf(el)
-      const setter = Object.getOwnPropertyDescriptor(proto, 'value')?.set
-      setter?.call(el, '#ff8800')
-      el.dispatchEvent(new Event('input', { bubbles: true }))
-    })
-    await page.locator('button', { hasText: /Next: page size/ }).click()
+    // Set a non-default colour. The native `<input type="color">` was
+    // replaced by the react-colorful popover (GH #121) — open the swatch
+    // and fill the popover's hex text input, which is a plain `<input>`
+    // that Playwright's `fill()` handles natively.
+    await page.locator('[data-testid="color-picker-swatch"]').click()
+    await page.locator('[data-testid="color-picker-hex"]').fill('#ff8800')
+    await page.locator('button', { hasText: /Next →/ }).click()
     await page.getByRole('button', { name: 'Apply', exact: true }).click()
 
     await expect

--- a/packages/ui/e2e/header-footer-regressions.spec.ts
+++ b/packages/ui/e2e/header-footer-regressions.spec.ts
@@ -46,7 +46,7 @@ async function clearStorage(page: Page): Promise<void> {
 
 async function completeOnboarding(page: Page): Promise<void> {
   await page.locator('button', { hasText: /^Solid color$/ }).click()
-  await page.locator('button', { hasText: /^Next: page size$/ }).click()
+  await page.locator('button', { hasText: /^Next →$/ }).click()
   await expect(page.getByRole('heading', { name: /choose page size/i })).toBeVisible({
     timeout: 5000,
   })

--- a/packages/ui/e2e/header-footer.spec.ts
+++ b/packages/ui/e2e/header-footer.spec.ts
@@ -48,7 +48,7 @@ async function clearStorage(page: Page): Promise<void> {
 async function completeOnboarding(page: Page): Promise<void> {
   await page.locator('button', { hasText: /^Solid color$/ }).click()
   // The color picker reveals a hex textbox. Accept the default white.
-  await page.locator('button', { hasText: /^Next: page size$/ }).click()
+  await page.locator('button', { hasText: /^Next →$/ }).click()
   // Page size dialog auto-selects A4 by default → click Apply / Continue.
   await expect(page.getByRole('heading', { name: /choose page size/i })).toBeVisible({
     timeout: 5000,

--- a/packages/ui/e2e/onboarding-next-button.spec.ts
+++ b/packages/ui/e2e/onboarding-next-button.spec.ts
@@ -1,0 +1,64 @@
+/**
+ * #114 — the onboarding colour step's primary action used to read
+ * "Next: page size" which clipped to "Next: page si..." inside the
+ * default `max-w-md` card. Shortened to "Next →"; this spec pins both
+ * the new label AND that the rendered button has no clipped text on
+ * the default viewport (scrollWidth must equal clientWidth — no
+ * overflow being hidden by any ancestor).
+ *
+ * Same fix applied to the symmetric `AddPageDialog` button.
+ */
+import type { Page } from '@playwright/test'
+import { test, expect } from '@playwright/test'
+
+test.describe.configure({ mode: 'serial' })
+
+async function clearStorage(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    localStorage.removeItem('template-goblin-template')
+    localStorage.removeItem('template-goblin-ui')
+    try {
+      indexedDB.deleteDatabase('template-goblin')
+    } catch {
+      /* ignore */
+    }
+  })
+}
+
+/** True when an element's content fits within its box (no clipped text). */
+async function isFullyRendered(page: Page, testid: string): Promise<boolean> {
+  return await page.locator(`[data-testid="${testid}"]`).evaluate((el) => {
+    return el.scrollWidth <= el.clientWidth && el.scrollHeight <= el.clientHeight
+  })
+}
+
+test.describe('#114 — onboarding Next button label fits the card', () => {
+  test.beforeEach(async ({ page }) => {
+    await clearStorage(page)
+    await page.goto('/')
+    await page.locator('[data-testid="onboarding-solid-color"]').click()
+    await expect(page.getByRole('heading', { name: /pick a background color/i })).toBeVisible({
+      timeout: 5000,
+    })
+  })
+
+  test('button reads "Next →" (shortened from the truncating "Next: page size")', async ({
+    page,
+  }) => {
+    await expect(page.locator('[data-testid="onboarding-color-next"]')).toHaveText(/^Next →$/)
+  })
+
+  test('button content fits its box — no clipping at the default card width', async ({ page }) => {
+    expect(await isFullyRendered(page, 'onboarding-color-next')).toBe(true)
+  })
+
+  test('button still works — clicking advances to the page-size step', async ({ page }) => {
+    await page.locator('[data-testid="onboarding-color-next"]').click()
+    await expect(page.getByRole('heading', { name: /choose page size/i })).toBeVisible()
+  })
+
+  test('button also fits on a narrower viewport (mobile-ish, 360px wide)', async ({ page }) => {
+    await page.setViewportSize({ width: 360, height: 800 })
+    expect(await isFullyRendered(page, 'onboarding-color-next')).toBe(true)
+  })
+})

--- a/packages/ui/src/components/Canvas/AddPageDialog.tsx
+++ b/packages/ui/src/components/Canvas/AddPageDialog.tsx
@@ -246,7 +246,8 @@ export function AddPageDialog({
                 className="tg-btn tg-btn--primary"
                 onClick={() => gotoSize({ kind: 'color', color })}
               >
-                Next: page size
+                {/* GH #114 — same shortening as OnboardingPicker. */}
+                Next →
               </button>
             </div>
           </div>

--- a/packages/ui/src/components/Canvas/OnboardingPicker.tsx
+++ b/packages/ui/src/components/Canvas/OnboardingPicker.tsx
@@ -170,7 +170,13 @@ export function OnboardingPicker({
                 onClick={() => setMode('size')}
                 data-testid="onboarding-color-next"
               >
-                Next: page size
+                {/*
+                 * GH #114 — "Next: page size" overflowed the card on the
+                 * default `max-w-md` width, clipping to "Next: page si...".
+                 * The arrow keeps the call-to-action obvious; the next
+                 * step's "Choose page size" heading carries the context.
+                 */}
+                Next →
               </button>
             </div>
           </>


### PR DESCRIPTION
## Summary

The default \`max-w-md\` onboarding card was narrow enough that the primary action clipped to \"Next: page si...\" on first paint. Shortened to \"Next →\" per #114's preferred fix; the arrow keeps the call-to-action obvious and the next step's \"Choose page size\" heading carries the context. Same shortening applied to the symmetric \`AddPageDialog\` button.

## Test plan

- [x] New \`e2e/onboarding-next-button.spec.ts\` (4 tests): label reads \"Next →\", scrollWidth ≤ clientWidth at default viewport, click advances to page-size step, content still fits on a 360px mobile viewport.
- [x] Regression sweep across 9 specs (48 tests) touching the colour, onboarding, band, page-dim, change-bg, and add-page paths — 46 pass / 1 unrelated skip / 1 stale spec from #121 also fixed (\`change-background.spec.ts\` still drove a native \`<input type=\"color\">\` that the picker swap removed).
- [x] 7 existing specs hard-coded the old label in \`hasText:\` matchers — updated to \`/Next →/\`.
- [x] 433 core unit + 507 UI unit + type-check + lint + production build all clean.
- [x] Live Chrome test at \`localhost:4242\`: button renders as \"Next →\", scrollWidth === clientWidth (60px), no clipping, click advances to \"Choose page size\" step.

Closes #114.