### PR TITLE
feat(ui): Word-style menu + ribbon top bar redesign (#128)

### DIFF
--- a/.changeset/navbar-menu-ribbon-redesign.md
+++ b/.changeset/navbar-menu-ribbon-redesign.md
@@ -1,0 +1,65 @@
+---
+'template-goblin-ui': minor
+---
+
+feat(ui): Word-style menu + ribbon top bar redesign (#128)
+
+The single-row 657-line `Toolbar.tsx` crammed every action together with
+no grouping. Replaced with a two-row Word-style shell.
+
+**Row 1 — Menu tab strip:**
+File · Edit · Insert · Format · View · Help &nbsp;|&nbsp;
+pinned tools (Text · Image · Table) &nbsp;|&nbsp;
+Preview · Save · Lock
+
+**Row 2 — Ribbon:** swaps to match the active tab. Each tab's controls
+get a dedicated, always-visible row so common actions are one click
+away (Word ribbon model), and pinned Insert tools stay reachable from
+any tab.
+
+**Tab contents:**
+
+- **File** — New · Open · Change Background
+- **Edit** — Undo · Redo
+- **Insert** — Header · Footer · Page Number (each opens a settings
+  popup containing the show/hide toggle + all options)
+- **Format** — Properties panel toggle · Font Manager
+- **View** — Toggle left/right panels · Snap · Zoom −/%/+ · Theme
+- **Help** — GitHub · Shortcuts
+
+**Page Number placement** can land in either Header or Footer
+regardless of whether the chosen band is currently enabled — the
+store's `ensureBandForPageNumber` helper auto-creates+enables the
+target band on placement pick. No "enable a header first" friction.
+
+**Pinned Insert tools** (Text / Image / Table) keep the same one-click
+draw-to-create UX from before and stay visible across every tab. Lock
+toggles template-wide; the pinned tools disable when locked.
+
+**File structure** under `Toolbar/`:
+
+- `Toolbar.tsx` — empty-state OR two-row shell (~120 LOC)
+- `MenuTabBar.tsx`, `RibbonBar.tsx`
+- `icons.tsx` — shared inline SVGs (Hard Rule #7)
+- `primitives/MenuButton.tsx`, `RibbonButton.tsx`, `RibbonGroup.tsx`
+- `ribbons/FileRibbon.tsx`, `EditRibbon.tsx`, `InsertRibbon.tsx`,
+  `FormatRibbon.tsx`, `ViewRibbon.tsx`, `HelpRibbon.tsx`
+
+Themed with CSS variables (`--bg-secondary`, `--bg-tertiary`,
+`--text-primary`, `--accent`, …); every button is a `.tg-ribbon-btn`
+or `.tg-menu-tab` so Tailwind v4 preflight's base-layer
+`button { background-color: transparent }` doesn't strip the active
+highlight. Verified live in Chrome — menubar/ribbon/text/tab colours
+all flip correctly between light and dark themes.
+
+UI store gains a single new field: `activeMenuTab: 'file' | 'edit' |
+'insert' | 'format' | 'view' | 'help'` (default `'insert'`).
+
+Comprehensive Playwright coverage in `e2e/navbar-redesign.spec.ts`
+(32 tests) hitting every visible button — happy path + edge cases:
+locked template, multi-tab swap, theme persistence, popup auto-create
+on placement pick, etc. Existing band/color/onboarding/page-dim/
+change-bg specs (5 specs touched) updated to the new selectors; full
+sweep: 87/88 pass / 1 unrelated skip.
+
+Closes #128.

--- a/packages/ui/e2e/change-background.spec.ts
+++ b/packages/ui/e2e/change-background.spec.ts
@@ -157,6 +157,9 @@ async function readPageBackgroundDataUrl(page: Page, pageId: string): Promise<st
 }
 
 async function openChangeBgDialog(page: Page): Promise<void> {
+  // #128 — Change Background lives under the File tab in the new menu
+  // bar. Click File first to surface the ribbon button.
+  await page.locator('[data-testid="menu-tab-file"]').click()
   await page.locator('[data-testid="toolbar-change-background"]').click()
   await expect(page.locator('.tg-dialog-title', { hasText: 'Change Background' })).toBeVisible()
 }
@@ -185,10 +188,14 @@ test.describe('Change Background dialog (#58)', () => {
     await seed(page, { multiPage: false })
     await page.goto('/')
     await expect(fabricCanvas(page)).toBeVisible()
+    // #128 — Change Background lives under File now; surface the ribbon first.
+    await page.locator('[data-testid="menu-tab-file"]').click()
     const btn = page.locator('[data-testid="toolbar-change-background"]')
     await expect(btn).toContainText(/Change Background/i)
     // The old "BG" label should not appear in the toolbar text.
-    const toolbarText = (await page.locator('.tg-toolbar').textContent()) ?? ''
+    // #128 — the toolbar wrapper now uses role="region" instead of the
+    // legacy `.tg-toolbar` class.
+    const toolbarText = (await page.getByRole('region', { name: /toolbar/i }).textContent()) ?? ''
     expect(toolbarText).not.toMatch(/^BG$|\bBG\b(?!\.)/)
   })
 

--- a/packages/ui/e2e/header-footer.spec.ts
+++ b/packages/ui/e2e/header-footer.spec.ts
@@ -122,36 +122,33 @@ test.describe('#61 — Page Layout dialog + band visuals', () => {
     await waitForCanvas(page)
   })
 
-  /** Open the anchored Page Layout menu from the toolbar. */
-  async function openMenu(page: Page): Promise<void> {
-    await page.locator('[data-testid="toolbar-page-layout"]').click()
-    await expect(page.locator('[data-testid="page-layout-menu"]')).toBeVisible({
+  /** Switch to the Insert tab so the Header / Footer / Page Number toggles
+   *  surface in the ribbon. The navbar redesign (#128) replaced the old
+   *  anchored Page Layout menu with three direct toggles + per-band ⚙. */
+  async function openInsertTab(page: Page): Promise<void> {
+    await page.locator('[data-testid="menu-tab-insert"]').click()
+    await expect(page.locator('[data-testid="ribbon-insert-header"]')).toBeVisible({
       timeout: 3000,
     })
   }
 
-  /** Click a top-level item (Header / Footer / Page Number) to open its flyout. */
-  async function openFlyout(page: Page, item: 'header' | 'footer' | 'page-number'): Promise<void> {
-    await page.locator(`[data-testid="page-layout-menu-${item}"]`).click()
-  }
-
-  test('toolbar opens an anchored menu with Header / Footer / Page Number items', async ({
+  test('Insert ribbon surfaces Header / Footer / Page Number as direct toggles', async ({
     page,
   }) => {
-    await openMenu(page)
-    await expect(page.locator('[data-testid="page-layout-menu-header"]')).toBeVisible()
-    await expect(page.locator('[data-testid="page-layout-menu-footer"]')).toBeVisible()
-    await expect(page.locator('[data-testid="page-layout-menu-page-number"]')).toBeVisible()
-    // Sidebar stays in the field-selection placeholder — band controls
-    // are no longer there.
-    await expect(page.locator('text=Select a field to edit its properties')).toBeVisible()
+    await openInsertTab(page)
+    await expect(page.locator('[data-testid="ribbon-insert-header"]')).toBeVisible()
+    await expect(page.locator('[data-testid="ribbon-insert-footer"]')).toBeVisible()
+    await expect(page.locator('[data-testid="ribbon-insert-pagenumber"]')).toBeVisible()
+    // Each toggle has its own ⚙ settings affordance.
+    await expect(page.locator('[data-testid="ribbon-insert-header-settings"]')).toBeVisible()
+    await expect(page.locator('[data-testid="ribbon-insert-footer-settings"]')).toBeVisible()
+    await expect(page.locator('[data-testid="ribbon-insert-pagenumber-settings"]')).toBeVisible()
   })
 
-  test('Header flyout: "Show header" toggle paints a band on the canvas', async ({ page }) => {
+  test('Header toggle paints a band on the canvas in one click', async ({ page }) => {
     expect((await bandObjects(page)).filter((o) => o.isBand)).toHaveLength(0)
-    await openMenu(page)
-    await openFlyout(page, 'header')
-    await page.locator('[data-testid="page-layout-flyout-header-toggle"]').click()
+    await openInsertTab(page)
+    await page.locator('[data-testid="ribbon-insert-header"]').click()
     await expect
       .poll(async () => (await bandObjects(page)).filter((o) => o.isBand).length, {
         timeout: 3000,
@@ -159,34 +156,18 @@ test.describe('#61 — Page Layout dialog + band visuals', () => {
       .toBeGreaterThan(0)
   })
 
-  test('Header settings opens the full configuration modal', async ({ page }) => {
-    await openMenu(page)
-    await openFlyout(page, 'header')
-    await page.locator('[data-testid="page-layout-flyout-header-toggle"]').click()
-    // Header on → Settings… button enables → click → modal opens.
-    await page.locator('[data-testid="page-layout-flyout-header-settings"]').click()
+  test('Header ⚙ opens the full configuration modal', async ({ page }) => {
+    await openInsertTab(page)
+    await page.locator('[data-testid="ribbon-insert-header-settings"]').click()
     await expect(page.locator('[data-testid="band-settings-modal"]')).toBeVisible()
-    // The modal exposes the Apply-to-first-page toggle the user can now
-    // adjust without rummaging through a sidebar.
     await expect(page.locator('text=Apply to first page')).toBeVisible()
   })
 
-  test('Page Number flyout: showing the page number paints a Textbox', async ({ page }) => {
-    // First enable a footer so the page number has a band to live in.
-    await openMenu(page)
-    await openFlyout(page, 'footer')
-    await page.locator('[data-testid="page-layout-flyout-footer-toggle"]').click()
-    await openFlyout(page, 'page-number')
-    await page.locator('[data-testid="page-layout-flyout-pageNumber-toggle"]').click()
-    // Default config has `showOnFirstPage: false`; flip via the store so
-    // the single-page test template renders the number on page 0.
-    await page.evaluate(() => {
-      interface StoreLike {
-        getState(): { setPageNumberConfig: (p: { showOnFirstPage: boolean }) => void }
-      }
-      const store = (window as unknown as { __templateStore?: StoreLike }).__templateStore
-      store?.getState().setPageNumberConfig({ showOnFirstPage: true })
-    })
+  test('Page Number toggle paints a Textbox once enabled', async ({ page }) => {
+    await openInsertTab(page)
+    // Enabling page number with default placement=footer auto-enables
+    // the footer band (#61 follow-up).
+    await page.locator('[data-testid="ribbon-insert-pagenumber"]').click()
     await expect
       .poll(async () => (await bandObjects(page)).filter((o) => o.isBand && o.isTextbox).length, {
         timeout: 3000,
@@ -197,15 +178,14 @@ test.describe('#61 — Page Layout dialog + band visuals', () => {
   test('applyToFirstPage = false (set via Settings modal) removes the band on page 0', async ({
     page,
   }) => {
-    await openMenu(page)
-    await openFlyout(page, 'header')
-    await page.locator('[data-testid="page-layout-flyout-header-toggle"]').click()
+    await openInsertTab(page)
+    await page.locator('[data-testid="ribbon-insert-header"]').click()
     await expect
       .poll(async () => (await bandObjects(page)).filter((o) => o.isBand).length, {
         timeout: 3000,
       })
       .toBeGreaterThan(0)
-    await page.locator('[data-testid="page-layout-flyout-header-settings"]').click()
+    await page.locator('[data-testid="ribbon-insert-header-settings"]').click()
     await expect(page.locator('[data-testid="band-settings-modal"]')).toBeVisible()
     // Uncheck "Apply to first page" inside the modal.
     await page

--- a/packages/ui/e2e/header-footer.spec.ts
+++ b/packages/ui/e2e/header-footer.spec.ts
@@ -122,9 +122,10 @@ test.describe('#61 — Page Layout dialog + band visuals', () => {
     await waitForCanvas(page)
   })
 
-  /** Switch to the Insert tab so the Header / Footer / Page Number toggles
-   *  surface in the ribbon. The navbar redesign (#128) replaced the old
-   *  anchored Page Layout menu with three direct toggles + per-band ⚙. */
+  /** Switch to the Insert tab so the Header / Footer / Page Number
+   *  buttons surface. Each ribbon button opens its settings popup;
+   *  the show/hide toggle and every other option live inside the popup
+   *  (#128 final UX). */
   async function openInsertTab(page: Page): Promise<void> {
     await page.locator('[data-testid="menu-tab-insert"]').click()
     await expect(page.locator('[data-testid="ribbon-insert-header"]')).toBeVisible({
@@ -132,23 +133,22 @@ test.describe('#61 — Page Layout dialog + band visuals', () => {
     })
   }
 
-  test('Insert ribbon surfaces Header / Footer / Page Number as direct toggles', async ({
-    page,
-  }) => {
+  test('Insert ribbon surfaces Header / Footer / Page Number buttons', async ({ page }) => {
     await openInsertTab(page)
     await expect(page.locator('[data-testid="ribbon-insert-header"]')).toBeVisible()
     await expect(page.locator('[data-testid="ribbon-insert-footer"]')).toBeVisible()
     await expect(page.locator('[data-testid="ribbon-insert-pagenumber"]')).toBeVisible()
-    // Each toggle has its own ⚙ settings affordance.
-    await expect(page.locator('[data-testid="ribbon-insert-header-settings"]')).toBeVisible()
-    await expect(page.locator('[data-testid="ribbon-insert-footer-settings"]')).toBeVisible()
-    await expect(page.locator('[data-testid="ribbon-insert-pagenumber-settings"]')).toBeVisible()
   })
 
-  test('Header toggle paints a band on the canvas in one click', async ({ page }) => {
+  test('Header button → popup → Show header paints the band on the canvas', async ({ page }) => {
     expect((await bandObjects(page)).filter((o) => o.isBand)).toHaveLength(0)
     await openInsertTab(page)
     await page.locator('[data-testid="ribbon-insert-header"]').click()
+    await expect(page.locator('[data-testid="band-settings-modal"]')).toBeVisible()
+    await page
+      .locator('.tg-toggle-row', { hasText: 'Show header' })
+      .locator('input[type="checkbox"]')
+      .check()
     await expect
       .poll(async () => (await bandObjects(page)).filter((o) => o.isBand).length, {
         timeout: 3000,
@@ -156,18 +156,23 @@ test.describe('#61 — Page Layout dialog + band visuals', () => {
       .toBeGreaterThan(0)
   })
 
-  test('Header ⚙ opens the full configuration modal', async ({ page }) => {
+  test('Header popup exposes the Apply to first page toggle', async ({ page }) => {
     await openInsertTab(page)
-    await page.locator('[data-testid="ribbon-insert-header-settings"]').click()
-    await expect(page.locator('[data-testid="band-settings-modal"]')).toBeVisible()
+    await page.locator('[data-testid="ribbon-insert-header"]').click()
+    await page
+      .locator('.tg-toggle-row', { hasText: 'Show header' })
+      .locator('input[type="checkbox"]')
+      .check()
     await expect(page.locator('text=Apply to first page')).toBeVisible()
   })
 
-  test('Page Number toggle paints a Textbox once enabled', async ({ page }) => {
+  test('Page Number popup → Show page number paints a Textbox', async ({ page }) => {
     await openInsertTab(page)
-    // Enabling page number with default placement=footer auto-enables
-    // the footer band (#61 follow-up).
     await page.locator('[data-testid="ribbon-insert-pagenumber"]').click()
+    await page
+      .locator('.tg-toggle-row', { hasText: 'Show page number' })
+      .locator('input[type="checkbox"]')
+      .check()
     await expect
       .poll(async () => (await bandObjects(page)).filter((o) => o.isBand && o.isTextbox).length, {
         timeout: 3000,
@@ -175,19 +180,21 @@ test.describe('#61 — Page Layout dialog + band visuals', () => {
       .toBeGreaterThan(0)
   })
 
-  test('applyToFirstPage = false (set via Settings modal) removes the band on page 0', async ({
+  test('applyToFirstPage = false (set via the popup) removes the band on page 0', async ({
     page,
   }) => {
     await openInsertTab(page)
     await page.locator('[data-testid="ribbon-insert-header"]').click()
+    await page
+      .locator('.tg-toggle-row', { hasText: 'Show header' })
+      .locator('input[type="checkbox"]')
+      .check()
     await expect
       .poll(async () => (await bandObjects(page)).filter((o) => o.isBand).length, {
         timeout: 3000,
       })
       .toBeGreaterThan(0)
-    await page.locator('[data-testid="ribbon-insert-header-settings"]').click()
-    await expect(page.locator('[data-testid="band-settings-modal"]')).toBeVisible()
-    // Uncheck "Apply to first page" inside the modal.
+    // The popup is already open from the previous step; uncheck applyToFirstPage.
     await page
       .locator('.tg-toggle-row', { hasText: 'Apply to first page' })
       .locator('input[type="checkbox"]')

--- a/packages/ui/e2e/navbar-redesign.spec.ts
+++ b/packages/ui/e2e/navbar-redesign.spec.ts
@@ -1,0 +1,390 @@
+/**
+ * #128 — comprehensive coverage of the new menu + ribbon top bar.
+ *
+ * Every visible button gets a happy-path test + the edge cases that
+ * touch it (locked template, no background, multi-tab swap, theme
+ * persistence, etc.). Drives store reads via `__uiStore` /
+ * `__templateStore` because those are exposed in DEV builds and let
+ * the assertions check effect, not just affordance.
+ */
+import type { Page } from '@playwright/test'
+import { test, expect } from '@playwright/test'
+
+test.describe.configure({ mode: 'serial' })
+
+async function clearStorage(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    localStorage.removeItem('template-goblin-template')
+    localStorage.removeItem('template-goblin-ui')
+    try {
+      indexedDB.deleteDatabase('template-goblin')
+    } catch {
+      /* ignore */
+    }
+  })
+}
+
+async function completeOnboarding(page: Page): Promise<void> {
+  await page.locator('[data-testid="onboarding-solid-color"]').click()
+  await page.locator('[data-testid="onboarding-color-next"]').click()
+  await expect(page.getByRole('heading', { name: /choose page size/i })).toBeVisible({
+    timeout: 5000,
+  })
+  await page.locator('[data-testid="onboarding-color-apply"]').click()
+  await expect(page.locator('[data-testid="canvas-stage-wrapper"] canvas').first()).toBeVisible({
+    timeout: 5000,
+  })
+}
+
+async function gotoEditor(page: Page): Promise<void> {
+  await clearStorage(page)
+  await page.goto('/')
+  await completeOnboarding(page)
+}
+
+interface UiSnapshot {
+  activeMenuTab: string
+  activeTool: string
+  showGrid: boolean
+  zoom: number
+  theme: string
+  showLeftPanel: boolean
+  showRightPanel: boolean
+  showPreview: boolean
+  locked: boolean
+  headerEnabled: boolean
+  footerEnabled: boolean
+  pageNumberEnabled: boolean
+}
+
+async function ui(page: Page): Promise<UiSnapshot> {
+  return await page.evaluate(() => {
+    interface UStore {
+      getState(): {
+        activeMenuTab: string
+        activeTool: string
+        showGrid: boolean
+        zoom: number
+        theme: string
+        showLeftPanel: boolean
+        showRightPanel: boolean
+        showPreview: boolean
+      }
+    }
+    interface TStore {
+      getState(): {
+        meta: { locked: boolean }
+        header?: { enabled: boolean }
+        footer?: { enabled: boolean }
+        pageNumber?: { enabled: boolean }
+      }
+    }
+    const u = (window as unknown as { __uiStore?: UStore }).__uiStore?.getState()
+    const t = (window as unknown as { __templateStore?: TStore }).__templateStore?.getState()
+    return {
+      activeMenuTab: u?.activeMenuTab ?? '',
+      activeTool: u?.activeTool ?? '',
+      showGrid: !!u?.showGrid,
+      zoom: u?.zoom ?? 1,
+      theme: u?.theme ?? '',
+      showLeftPanel: !!u?.showLeftPanel,
+      showRightPanel: !!u?.showRightPanel,
+      showPreview: !!u?.showPreview,
+      locked: !!t?.meta.locked,
+      headerEnabled: !!t?.header?.enabled,
+      footerEnabled: !!t?.footer?.enabled,
+      pageNumberEnabled: !!t?.pageNumber?.enabled,
+    }
+  })
+}
+
+test.describe('#128 — Menu tab strip', () => {
+  test.beforeEach(({ page }) => gotoEditor(page))
+
+  test('all 6 tabs render and click-swap the ribbon', async ({ page }) => {
+    const tabs = ['file', 'edit', 'insert', 'format', 'view', 'help'] as const
+    for (const t of tabs) {
+      await expect(page.locator(`[data-testid="menu-tab-${t}"]`)).toBeVisible()
+    }
+    // Default opening tab is `insert`.
+    expect((await ui(page)).activeMenuTab).toBe('insert')
+    // Click each tab, verify the corresponding ribbon mounts.
+    for (const t of tabs) {
+      await page.locator(`[data-testid="menu-tab-${t}"]`).click()
+      await expect(page.locator(`[data-testid="ribbon-${t}"]`)).toBeVisible()
+      expect((await ui(page)).activeMenuTab).toBe(t)
+    }
+  })
+})
+
+test.describe('#128 — Pinned tools (Text / Image / Table)', () => {
+  test.beforeEach(({ page }) => gotoEditor(page))
+
+  for (const { tool, kind } of [
+    { tool: 'toolbar-tool-text', kind: 'addText' },
+    { tool: 'toolbar-tool-image', kind: 'addImage' },
+    { tool: 'toolbar-tool-table', kind: 'addLoop' },
+  ] as const) {
+    test(`${tool} toggles activeTool=${kind} and back to select`, async ({ page }) => {
+      expect((await ui(page)).activeTool).toBe('select')
+      await page.locator(`[data-testid="${tool}"]`).click()
+      expect((await ui(page)).activeTool).toBe(kind)
+      // Click again returns to select.
+      await page.locator(`[data-testid="${tool}"]`).click()
+      expect((await ui(page)).activeTool).toBe('select')
+    })
+
+    test(`${tool} is visible regardless of active menu tab`, async ({ page }) => {
+      for (const t of ['file', 'edit', 'format', 'view', 'help'] as const) {
+        await page.locator(`[data-testid="menu-tab-${t}"]`).click()
+        await expect(page.locator(`[data-testid="${tool}"]`)).toBeVisible()
+      }
+    })
+  }
+
+  test('locked template disables every pinned tool', async ({ page }) => {
+    await page.evaluate(() => {
+      interface T {
+        getState(): { setLocked: (v: boolean) => void }
+      }
+      ;(window as unknown as { __templateStore?: T }).__templateStore?.getState().setLocked(true)
+    })
+    for (const tool of ['toolbar-tool-text', 'toolbar-tool-image', 'toolbar-tool-table']) {
+      await expect(page.locator(`[data-testid="${tool}"]`)).toBeDisabled()
+    }
+  })
+})
+
+test.describe('#128 — Far-right CTAs (Preview / Save / Lock)', () => {
+  test.beforeEach(({ page }) => gotoEditor(page))
+
+  test('Preview button opens the preview dialog', async ({ page }) => {
+    expect((await ui(page)).showPreview).toBe(false)
+    await page.locator('[data-testid="toolbar-preview"]').click()
+    expect((await ui(page)).showPreview).toBe(true)
+    await expect(page.locator('[data-testid="preview-dialog"]')).toBeVisible()
+  })
+
+  test('Save button flashes "Saved!" then reverts', async ({ page }) => {
+    const btn = page.locator('[data-testid="toolbar-save"]')
+    await expect(btn).toContainText(/^Save$/)
+    await btn.click()
+    await expect(btn).toContainText(/Saved!/)
+    // Reverts within ~1.5s.
+    await expect(btn).toContainText(/^Save$/, { timeout: 2500 })
+  })
+
+  test('Lock toggle flips templateStore.meta.locked + label', async ({ page }) => {
+    const btn = page.locator('[data-testid="toolbar-lock"]')
+    await expect(btn).toContainText(/Lock/)
+    await btn.click()
+    expect((await ui(page)).locked).toBe(true)
+    await expect(btn).toContainText(/Unlock/)
+    await btn.click()
+    expect((await ui(page)).locked).toBe(false)
+  })
+})
+
+test.describe('#128 — File ribbon', () => {
+  test.beforeEach(async ({ page }) => {
+    await gotoEditor(page)
+    await page.locator('[data-testid="menu-tab-file"]').click()
+  })
+
+  test('New button confirms then resets the template', async ({ page }) => {
+    page.once('dialog', (d) => d.accept())
+    await page.locator('[data-testid="toolbar-new"]').click()
+    // Onboarding picker reappears (canvas was reset → no background).
+    await expect(page.locator('[data-testid="onboarding-solid-color"]')).toBeVisible({
+      timeout: 3000,
+    })
+  })
+
+  test('New button does NOT reset when the confirm is dismissed', async ({ page }) => {
+    page.once('dialog', (d) => d.dismiss())
+    await page.locator('[data-testid="toolbar-new"]').click()
+    // Canvas stays mounted (no onboarding).
+    await expect(page.locator('[data-testid="canvas-stage-wrapper"] canvas').first()).toBeVisible()
+  })
+
+  test('Open button surfaces and opens a hidden file input', async ({ page }) => {
+    await expect(page.locator('[data-testid="toolbar-open"]')).toBeVisible()
+    // Click — file input is hidden but Playwright surfaces it via the
+    // upcoming file chooser event handler.
+    const chooserPromise = page.waitForEvent('filechooser')
+    await page.locator('[data-testid="toolbar-open"]').click()
+    const chooser = await chooserPromise
+    expect(chooser).toBeTruthy()
+  })
+
+  test('Change Background button opens the dialog', async ({ page }) => {
+    await page.locator('[data-testid="toolbar-change-background"]').click()
+    // The Change Background dialog reuses `AddPageDialog` in edit mode.
+    // Its title is "Change Background".
+    await expect(page.locator('.tg-dialog-title', { hasText: 'Change Background' })).toBeVisible({
+      timeout: 3000,
+    })
+  })
+})
+
+test.describe('#128 — Edit ribbon', () => {
+  test.beforeEach(async ({ page }) => {
+    await gotoEditor(page)
+    await page.locator('[data-testid="menu-tab-edit"]').click()
+  })
+
+  test('Undo / Redo render and are disabled when there is no history', async ({ page }) => {
+    await expect(page.locator('[data-testid="ribbon-undo"]')).toBeDisabled()
+    await expect(page.locator('[data-testid="ribbon-redo"]')).toBeDisabled()
+  })
+})
+
+test.describe('#128 — Insert ribbon', () => {
+  test.beforeEach(async ({ page }) => {
+    await gotoEditor(page)
+    await page.locator('[data-testid="menu-tab-insert"]').click()
+  })
+
+  test('Header toggle paints a band on first click', async ({ page }) => {
+    expect((await ui(page)).headerEnabled).toBe(false)
+    await page.locator('[data-testid="ribbon-insert-header"]').click()
+    expect((await ui(page)).headerEnabled).toBe(true)
+  })
+
+  test('Footer toggle paints a band on first click', async ({ page }) => {
+    expect((await ui(page)).footerEnabled).toBe(false)
+    await page.locator('[data-testid="ribbon-insert-footer"]').click()
+    expect((await ui(page)).footerEnabled).toBe(true)
+  })
+
+  test('Page Number toggle auto-enables its default placement band (footer)', async ({ page }) => {
+    expect((await ui(page)).pageNumberEnabled).toBe(false)
+    expect((await ui(page)).footerEnabled).toBe(false)
+    await page.locator('[data-testid="ribbon-insert-pagenumber"]').click()
+    const after = await ui(page)
+    expect(after.pageNumberEnabled).toBe(true)
+    expect(after.footerEnabled).toBe(true)
+  })
+
+  test('Settings ⚙ auto-enables the band AND opens the modal in one click', async ({ page }) => {
+    expect((await ui(page)).headerEnabled).toBe(false)
+    await page.locator('[data-testid="ribbon-insert-header-settings"]').click()
+    expect((await ui(page)).headerEnabled).toBe(true)
+    await expect(page.locator('[data-testid="band-settings-modal"]')).toBeVisible()
+  })
+})
+
+test.describe('#128 — View ribbon', () => {
+  test.beforeEach(async ({ page }) => {
+    await gotoEditor(page)
+    await page.locator('[data-testid="menu-tab-view"]').click()
+  })
+
+  test('Snap toggle flips uiStore.showGrid', async ({ page }) => {
+    const before = (await ui(page)).showGrid
+    await page.locator('[data-testid="ribbon-snap"]').click()
+    expect((await ui(page)).showGrid).toBe(!before)
+  })
+
+  test('Zoom in / reset / out cycle the zoom level', async ({ page }) => {
+    expect((await ui(page)).zoom).toBe(1)
+    await page.locator('[data-testid="ribbon-zoom-in"]').click()
+    expect((await ui(page)).zoom).toBeGreaterThan(1)
+    await page.locator('[data-testid="ribbon-zoom-reset"]').click()
+    expect((await ui(page)).zoom).toBe(1)
+    await page.locator('[data-testid="ribbon-zoom-out"]').click()
+    expect((await ui(page)).zoom).toBeLessThan(1)
+  })
+
+  test('Theme toggle flips data-theme on .tg-app', async ({ page }) => {
+    const before = await page.locator('.tg-app').getAttribute('data-theme')
+    await page.locator('[data-testid="ribbon-theme"]').click()
+    const after = await page.locator('.tg-app').getAttribute('data-theme')
+    expect(after).not.toBe(before)
+  })
+
+  test('Left panel toggle flips uiStore.showLeftPanel', async ({ page }) => {
+    const before = (await ui(page)).showLeftPanel
+    await page.locator('[data-testid="toolbar-toggle-left-panel"]').click()
+    expect((await ui(page)).showLeftPanel).toBe(!before)
+  })
+
+  test('Right panel toggle flips uiStore.showRightPanel', async ({ page }) => {
+    const before = (await ui(page)).showRightPanel
+    await page.locator('[data-testid="toolbar-toggle-right-panel"]').click()
+    expect((await ui(page)).showRightPanel).toBe(!before)
+  })
+})
+
+test.describe('#128 — Format ribbon', () => {
+  test.beforeEach(async ({ page }) => {
+    await gotoEditor(page)
+    await page.locator('[data-testid="menu-tab-format"]').click()
+  })
+
+  test('Properties panel toggle mirrors showLeftPanel state', async ({ page }) => {
+    const before = (await ui(page)).showLeftPanel
+    await page.locator('[data-testid="ribbon-toggle-properties"]').click()
+    expect((await ui(page)).showLeftPanel).toBe(!before)
+  })
+
+  test('Fonts… button opens the font manager dialog', async ({ page }) => {
+    await page.locator('[data-testid="ribbon-fonts"]').click()
+    await expect(page.locator('.tg-dialog-title', { hasText: 'Font Manager' })).toBeVisible({
+      timeout: 3000,
+    })
+  })
+})
+
+test.describe('#128 — Help ribbon', () => {
+  test.beforeEach(async ({ page }) => {
+    await gotoEditor(page)
+    await page.locator('[data-testid="menu-tab-help"]').click()
+  })
+
+  test('GitHub button opens a new tab', async ({ page, context }) => {
+    const popupPromise = context.waitForEvent('page')
+    await page.locator('[data-testid="ribbon-help-github"]').click()
+    const popup = await popupPromise
+    expect(popup.url()).toContain('github.com')
+    await popup.close()
+  })
+
+  test('Shortcuts button opens a native alert', async ({ page }) => {
+    let alertText = ''
+    page.once('dialog', async (d) => {
+      alertText = d.message()
+      await d.accept()
+    })
+    await page.locator('[data-testid="ribbon-help-shortcuts"]').click()
+    expect(alertText).toMatch(/Ctrl\+Z/)
+  })
+})
+
+test.describe('#128 — Theme styling across both palettes', () => {
+  test.beforeEach(({ page }) => gotoEditor(page))
+
+  test('menu bar background reflects --bg-secondary in both themes', async ({ page }) => {
+    // Light theme baseline (default — actual depends on system pref, so
+    // read the live token instead of hard-coding rgb).
+    const tokenBefore = await page.evaluate(() =>
+      getComputedStyle(document.querySelector('.tg-app') as HTMLElement).getPropertyValue(
+        '--bg-secondary',
+      ),
+    )
+    const menuBg = await page
+      .locator('[role="menubar"]')
+      .evaluate((el) => getComputedStyle(el).backgroundColor)
+    expect(menuBg).toBeTruthy()
+    // Flip theme via View ribbon → re-read.
+    await page.locator('[data-testid="menu-tab-view"]').click()
+    await page.locator('[data-testid="ribbon-theme"]').click()
+    const tokenAfter = await page.evaluate(() =>
+      getComputedStyle(document.querySelector('.tg-app') as HTMLElement).getPropertyValue(
+        '--bg-secondary',
+      ),
+    )
+    // Token resolves to a different value across themes.
+    expect(tokenAfter).not.toBe(tokenBefore)
+  })
+})

--- a/packages/ui/e2e/navbar-redesign.spec.ts
+++ b/packages/ui/e2e/navbar-redesign.spec.ts
@@ -245,32 +245,95 @@ test.describe('#128 — Insert ribbon', () => {
     await page.locator('[data-testid="menu-tab-insert"]').click()
   })
 
-  test('Header toggle paints a band on first click', async ({ page }) => {
-    expect((await ui(page)).headerEnabled).toBe(false)
+  test('Header button opens the band settings popup', async ({ page }) => {
     await page.locator('[data-testid="ribbon-insert-header"]').click()
+    await expect(page.locator('[data-testid="band-settings-modal"]')).toBeVisible()
+    // Show toggle lives inside the popup.
+    await expect(page.locator('text=Show header')).toBeVisible()
+  })
+
+  test('Footer button opens the band settings popup', async ({ page }) => {
+    await page.locator('[data-testid="ribbon-insert-footer"]').click()
+    await expect(page.locator('[data-testid="band-settings-modal"]')).toBeVisible()
+    await expect(page.locator('text=Show footer')).toBeVisible()
+  })
+
+  test('Page Number button opens the page-number settings popup', async ({ page }) => {
+    await page.locator('[data-testid="ribbon-insert-pagenumber"]').click()
+    await expect(page.locator('[data-testid="band-settings-modal"]')).toBeVisible()
+  })
+
+  test('Page Number → pick Header placement auto-creates the header band', async ({ page }) => {
+    // Pre-condition: both bands disabled.
+    expect((await ui(page)).headerEnabled).toBe(false)
+    expect((await ui(page)).footerEnabled).toBe(false)
+    // Open Page Number popup.
+    await page.locator('[data-testid="ribbon-insert-pagenumber"]').click()
+    await expect(page.locator('[data-testid="band-settings-modal"]')).toBeVisible()
+    // Enable page number (defaults to footer placement → footer auto-created).
+    await page
+      .locator('.tg-toggle-row', { hasText: 'Show page number' })
+      .locator('input[type="checkbox"]')
+      .check()
+    expect((await ui(page)).pageNumberEnabled).toBe(true)
+    expect((await ui(page)).footerEnabled).toBe(true)
+    // The Placement buttons MUST be enabled — switch to Header → header auto-creates.
+    const headerPlacementBtn = page.locator('.tg-btn', { hasText: /^Header$/ })
+    await expect(headerPlacementBtn).not.toBeDisabled()
+    await headerPlacementBtn.click()
     expect((await ui(page)).headerEnabled).toBe(true)
   })
 
-  test('Footer toggle paints a band on first click', async ({ page }) => {
+  test('Page Number → pick Footer placement auto-creates the footer band when header was first', async ({
+    page,
+  }) => {
+    // Force header-only path: open page-number popup, enable, then
+    // switch to header first, then back to footer (footer was never on).
+    await page.evaluate(() => {
+      interface T {
+        getState(): { setFooter: (v: undefined) => void }
+      }
+      ;(window as unknown as { __templateStore?: T }).__templateStore
+        ?.getState()
+        .setFooter(undefined)
+    })
+    await page.locator('[data-testid="ribbon-insert-pagenumber"]').click()
+    await page
+      .locator('.tg-toggle-row', { hasText: 'Show page number' })
+      .locator('input[type="checkbox"]')
+      .check()
+    // Manually pick Header first to make footer the "missing" band.
+    await page.locator('.tg-btn', { hasText: /^Header$/ }).click()
+    await page.evaluate(() => {
+      interface T {
+        getState(): { setFooter: (v: undefined) => void }
+      }
+      ;(window as unknown as { __templateStore?: T }).__templateStore
+        ?.getState()
+        .setFooter(undefined)
+    })
     expect((await ui(page)).footerEnabled).toBe(false)
-    await page.locator('[data-testid="ribbon-insert-footer"]').click()
+    // Now click Footer placement — footer band auto-creates.
+    const footerPlacementBtn = page.locator('.tg-btn', { hasText: /^Footer$/ })
+    await expect(footerPlacementBtn).not.toBeDisabled()
+    await footerPlacementBtn.click()
     expect((await ui(page)).footerEnabled).toBe(true)
   })
 
-  test('Page Number toggle auto-enables its default placement band (footer)', async ({ page }) => {
-    expect((await ui(page)).pageNumberEnabled).toBe(false)
-    expect((await ui(page)).footerEnabled).toBe(false)
-    await page.locator('[data-testid="ribbon-insert-pagenumber"]').click()
-    const after = await ui(page)
-    expect(after.pageNumberEnabled).toBe(true)
-    expect(after.footerEnabled).toBe(true)
-  })
-
-  test('Settings ⚙ auto-enables the band AND opens the modal in one click', async ({ page }) => {
-    expect((await ui(page)).headerEnabled).toBe(false)
-    await page.locator('[data-testid="ribbon-insert-header-settings"]').click()
-    expect((await ui(page)).headerEnabled).toBe(true)
-    await expect(page.locator('[data-testid="band-settings-modal"]')).toBeVisible()
+  test('Enabled band shows an active highlight on the ribbon button', async ({ page }) => {
+    // Programmatic enable so we don't depend on the popup's checkbox path.
+    await page.evaluate(() => {
+      interface T {
+        getState(): { setHeaderEnabled: (v: boolean) => void }
+      }
+      ;(window as unknown as { __templateStore?: T }).__templateStore
+        ?.getState()
+        .setHeaderEnabled(true)
+    })
+    await expect(page.locator('[data-testid="ribbon-insert-header"]')).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    )
   })
 })
 
@@ -328,7 +391,7 @@ test.describe('#128 — Format ribbon', () => {
     expect((await ui(page)).showLeftPanel).toBe(!before)
   })
 
-  test('Fonts… button opens the font manager dialog', async ({ page }) => {
+  test('Font Manager button opens the font manager dialog', async ({ page }) => {
     await page.locator('[data-testid="ribbon-fonts"]').click()
     await expect(page.locator('.tg-dialog-title', { hasText: 'Font Manager' })).toBeVisible({
       timeout: 3000,

--- a/packages/ui/src/App.css
+++ b/packages/ui/src/App.css
@@ -126,6 +126,68 @@ html, body, #root {
 .tg-btn--primary { background: var(--accent); color: #fff; border: none; }
 .tg-btn--primary:hover { background: var(--accent-hover); }
 
+/* === Ribbon buttons (#128 navbar redesign) =================================
+ * Tailwind v4 preflight applies `background-color: transparent` to every
+ * `<button>` via the base layer — inline style won't override it without
+ * `!important`. Stylesheet classes WILL because they outrank the base
+ * layer on selector match. Hence the dedicated `.tg-ribbon-btn` family.
+ */
+.tg-ribbon-btn {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+  min-width: 48px;
+  padding: 4px 8px;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-primary);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.12s ease, border-color 0.12s ease;
+}
+.tg-ribbon-btn--compact { flex-direction: row; gap: 4px; min-width: 28px; }
+.tg-ribbon-btn:hover { background: var(--bg-tertiary); }
+.tg-ribbon-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+.tg-ribbon-btn:disabled:hover { background: transparent; }
+.tg-ribbon-btn--active {
+  background: var(--bg-tertiary);
+}
+.tg-ribbon-btn--active:hover { background: var(--bg-tertiary); }
+.tg-ribbon-btn--primary {
+  background: var(--accent);
+  color: #fff;
+  border: none;
+}
+.tg-ribbon-btn--primary:hover { background: var(--accent-hover); }
+.tg-ribbon-btn--success {
+  background: #16a34a;
+  color: #fff;
+  border: none;
+}
+.tg-ribbon-btn--success:hover { background: #0a7a32; }
+
+/* Row-1 menu-tab buttons — text-only triggers along the top strip. */
+.tg-menu-tab {
+  background: transparent;
+  color: var(--text-primary);
+  border: none;
+  padding: 6px 12px;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  border-radius: 4px;
+  outline: none;
+  transition: background 0.12s ease;
+}
+.tg-menu-tab:hover,
+.tg-menu-tab:focus-visible { background: var(--bg-tertiary); }
+.tg-menu-tab--active { background: var(--bg-tertiary); }
+
 /* ===== Panels ===== */
 .tg-left-panel {
   /* `overflow: hidden` on the OUTER panel prevents the browser scrollbar

--- a/packages/ui/src/components/RightPanel/PageNumberSection.tsx
+++ b/packages/ui/src/components/RightPanel/PageNumberSection.tsx
@@ -14,13 +14,20 @@ import { AlignButtonGroup } from './AlignButtonGroup.js'
 
 interface Props {
   config: PageNumberConfig | undefined
+  /**
+   * Kept on the props for backwards compat with existing call sites, but
+   * the section no longer disables Placement when a band is missing —
+   * the store's `setPageNumber` / `setPageNumberConfig` auto-create the
+   * targeted band, so the user can freely pick Header or Footer without
+   * having to enable the band first.
+   */
   hasHeader: boolean
   hasFooter: boolean
   onSet: (config: PageNumberConfig | undefined) => void
   onPatch: (patch: Partial<PageNumberConfig>) => void
 }
 
-export function PageNumberSection({ config, hasHeader, hasFooter, onSet, onPatch }: Props) {
+export function PageNumberSection({ config, onSet, onPatch }: Props) {
   const enabled = !!config?.enabled
 
   return (
@@ -35,10 +42,11 @@ export function PageNumberSection({ config, hasHeader, hasFooter, onSet, onPatch
           checked={enabled}
           onChange={(e) => {
             if (e.target.checked) {
+              // The store auto-creates the placement band, so we can
+              // honour whatever default the user previously chose (or the
+              // built-in default of 'footer').
               const next = config ?? defaultPageNumberConfig()
-              // Steer placement to whichever band actually exists.
-              const placement = hasFooter ? 'footer' : hasHeader ? 'header' : 'footer'
-              onSet({ ...next, enabled: true, placement })
+              onSet({ ...next, enabled: true })
             } else {
               onPatch({ enabled: false })
             }
@@ -48,26 +56,19 @@ export function PageNumberSection({ config, hasHeader, hasFooter, onSet, onPatch
 
       {enabled && config && (
         <>
-          {!hasHeader && !hasFooter && (
-            <div
-              style={{
-                fontSize: 11,
-                color: 'var(--text-warn, #b04a00)',
-                margin: '4px 0',
-                lineHeight: 1.4,
-              }}
-            >
-              Enable a header or footer first — page number lives inside a band.
-            </div>
-          )}
-
           <div className="tg-form-row">
             <label>Placement</label>
             <div style={{ display: 'flex', gap: 4, flex: 1 }}>
+              {/*
+                Placement buttons are NEVER disabled — picking Header or
+                Footer auto-creates+enables the corresponding band via the
+                store's `ensureBandForPageNumber` helper. Lets the user
+                land page numbers in either band without manually
+                enabling it first.
+              */}
               <button
                 className={`tg-btn ${config.placement === 'header' ? 'tg-btn--active' : ''}`}
                 style={{ flex: 1, fontSize: 11 }}
-                disabled={!hasHeader}
                 onClick={() => onPatch({ placement: 'header' })}
               >
                 Header
@@ -75,7 +76,6 @@ export function PageNumberSection({ config, hasHeader, hasFooter, onSet, onPatch
               <button
                 className={`tg-btn ${config.placement === 'footer' ? 'tg-btn--active' : ''}`}
                 style={{ flex: 1, fontSize: 11 }}
-                disabled={!hasFooter}
                 onClick={() => onPatch({ placement: 'footer' })}
               >
                 Footer

--- a/packages/ui/src/components/Toolbar/MenuTabBar.tsx
+++ b/packages/ui/src/components/Toolbar/MenuTabBar.tsx
@@ -1,0 +1,198 @@
+import { useState } from 'react'
+import { useTemplateStore } from '../../store/templateStore.js'
+import { useUiStore } from '../../store/uiStore.js'
+import { saveTemplate } from '../../utils/saveOpen.js'
+import { FIELD_COLORS } from '../../theme/fieldColors.js'
+import { MenuButton, MenuSeparator } from './primitives/MenuButton.js'
+import { RibbonButton } from './primitives/RibbonButton.js'
+import {
+  TextIcon,
+  ImageIcon,
+  TableIcon,
+  PreviewIcon,
+  SaveIcon,
+  LockedIcon,
+  UnlockedIcon,
+} from './icons.js'
+
+/**
+ * Row-1 of the new top bar (#128). Three logical zones, separated by
+ * subtle dividers:
+ *
+ *   [ File · Edit · Insert · Format · View · Help ]   ← tab strip
+ *           …                                          ← spacer
+ *   [ Text · Image · Table ]                           ← pinned tools
+ *           …                                          ← spacer
+ *   [ Preview · Save · Lock ]                          ← primary CTAs
+ *
+ * The tab strip drives `uiStore.activeMenuTab`; the ribbon below picks
+ * the matching `*Ribbon.tsx`. Pinned tools mirror what Word puts on
+ * Home — always one click away no matter which tab is active. The CTAs
+ * stay at the far right where every user expects Save to live.
+ */
+type MenuTab = 'file' | 'edit' | 'insert' | 'format' | 'view' | 'help'
+
+const TABS: Array<{ id: MenuTab; label: string }> = [
+  { id: 'file', label: 'File' },
+  { id: 'edit', label: 'Edit' },
+  { id: 'insert', label: 'Insert' },
+  { id: 'format', label: 'Format' },
+  { id: 'view', label: 'View' },
+  { id: 'help', label: 'Help' },
+]
+
+export function MenuTabBar() {
+  const activeTab = useUiStore((s) => s.activeMenuTab)
+  const setActiveMenuTab = useUiStore((s) => s.setActiveMenuTab)
+
+  const meta = useTemplateStore((s) => s.meta)
+  const locked = meta.locked
+  const setLocked = useTemplateStore((s) => s.setLocked)
+  const activeTool = useUiStore((s) => s.activeTool)
+  const setActiveTool = useUiStore((s) => s.setActiveTool)
+  const selectedFieldIds = useUiStore((s) => s.selectedFieldIds)
+  const fields = useTemplateStore((s) => s.fields)
+  const hasBackground = useTemplateStore(
+    (s) =>
+      s.backgroundDataUrl !== null ||
+      s.pages.some(
+        (p) => p.index === 0 && (p.backgroundType === 'color' || p.backgroundType === 'image'),
+      ),
+  )
+  const showPreview = useUiStore((s) => s.showPreview)
+  const setShowPreview = useUiStore((s) => s.setShowPreview)
+
+  const selectedFieldTypes = new Set(
+    fields.filter((f) => selectedFieldIds.includes(f.id)).map((f) => f.type),
+  )
+
+  const [savedFlash, setSavedFlash] = useState(false)
+  async function handleSave() {
+    try {
+      await saveTemplate()
+      setSavedFlash(true)
+      window.setTimeout(() => setSavedFlash(false), 1400)
+    } catch (err) {
+      alert(err instanceof Error ? err.message : 'Save failed')
+    }
+  }
+
+  // Type-coloured pinned tool button. Reuses the field-colour theme so
+  // the visual match between toolbar button and on-canvas field stays
+  // consistent. Active when the tool is selected OR a matching field is
+  // currently in the selection — the existing UX cue from the old bar.
+  function PinnedTool({
+    tool,
+    label,
+    icon,
+    colour,
+  }: {
+    tool: 'addText' | 'addImage' | 'addLoop'
+    label: string
+    icon: React.ReactNode
+    colour: { stroke: string; toolbarBg: string; toolbarFg: string }
+  }) {
+    const fieldType = tool === 'addText' ? 'text' : tool === 'addImage' ? 'image' : 'table'
+    const isActive = activeTool === tool || selectedFieldTypes.has(fieldType)
+    return (
+      <RibbonButton
+        label={label}
+        icon={icon}
+        onClick={() => setActiveTool(activeTool === tool ? 'select' : tool)}
+        disabled={locked || !hasBackground}
+        compact
+        title={`Insert ${label.toLowerCase()}`}
+        testid={`toolbar-tool-${fieldType}`}
+        style={
+          isActive
+            ? { background: colour.stroke, color: '#fff', borderColor: colour.stroke }
+            : {
+                background: colour.toolbarBg,
+                color: colour.toolbarFg,
+                borderColor: colour.stroke,
+                borderStyle: 'solid',
+                borderWidth: 1,
+              }
+        }
+      />
+    )
+  }
+
+  return (
+    <div
+      role="menubar"
+      aria-label="Main menu"
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 2,
+        padding: '6px 10px',
+        background: 'var(--bg-secondary)',
+        borderBottom: '1px solid var(--border-light)',
+      }}
+    >
+      {/* Tab strip */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+        {TABS.map((t) => (
+          <MenuButton
+            key={t.id}
+            label={t.label}
+            active={activeTab === t.id}
+            onClick={() => setActiveMenuTab(t.id)}
+            testid={`menu-tab-${t.id}`}
+          />
+        ))}
+      </div>
+
+      <MenuSeparator />
+
+      {/* Pinned insert tools — always one click away */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+        <PinnedTool tool="addText" label="Text" icon={<TextIcon />} colour={FIELD_COLORS.text} />
+        <PinnedTool
+          tool="addImage"
+          label="Image"
+          icon={<ImageIcon />}
+          colour={FIELD_COLORS.image}
+        />
+        <PinnedTool tool="addLoop" label="Table" icon={<TableIcon />} colour={FIELD_COLORS.table} />
+      </div>
+
+      <div style={{ flex: 1 }} />
+
+      {/* Primary CTAs — far right */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+        <RibbonButton
+          icon={<PreviewIcon />}
+          label="Preview"
+          onClick={() => setShowPreview(!showPreview)}
+          disabled={!hasBackground}
+          compact
+          title="Preview template"
+          variant={showPreview ? 'toggle' : 'default'}
+          active={showPreview}
+          testid="toolbar-preview"
+        />
+        <RibbonButton
+          icon={<SaveIcon />}
+          label={savedFlash ? 'Saved!' : 'Save'}
+          onClick={handleSave}
+          compact
+          title="Save template (Ctrl+S)"
+          variant="success"
+          testid="toolbar-save"
+        />
+        <RibbonButton
+          icon={locked ? <LockedIcon /> : <UnlockedIcon />}
+          label={locked ? 'Unlock' : 'Lock'}
+          onClick={() => setLocked(!locked)}
+          compact
+          title={locked ? 'Unlock template' : 'Lock template'}
+          variant={locked ? 'toggle' : 'default'}
+          active={locked}
+          testid="toolbar-lock"
+        />
+      </div>
+    </div>
+  )
+}

--- a/packages/ui/src/components/Toolbar/RibbonBar.tsx
+++ b/packages/ui/src/components/Toolbar/RibbonBar.tsx
@@ -1,0 +1,45 @@
+import { useUiStore } from '../../store/uiStore.js'
+import { FileRibbon } from './ribbons/FileRibbon.js'
+import { EditRibbon } from './ribbons/EditRibbon.js'
+import { InsertRibbon } from './ribbons/InsertRibbon.js'
+import { FormatRibbon } from './ribbons/FormatRibbon.js'
+import { ViewRibbon } from './ribbons/ViewRibbon.js'
+import { HelpRibbon } from './ribbons/HelpRibbon.js'
+
+/**
+ * Row-2 of the new top bar (#128) — swaps the displayed ribbon to match
+ * `uiStore.activeMenuTab`. Each ribbon owns its own state subscriptions
+ * so this switcher is just a thin dispatcher.
+ *
+ * Themed via CSS variables; the surrounding bar uses `--bg-surface` so
+ * it sits flush with the menu row above while staying distinct from the
+ * canvas below.
+ */
+export function RibbonBar() {
+  const activeTab = useUiStore((s) => s.activeMenuTab)
+
+  return (
+    <div
+      role="tabpanel"
+      aria-label={`${activeTab} ribbon`}
+      data-testid={`ribbon-${activeTab}`}
+      style={{
+        display: 'flex',
+        alignItems: 'stretch',
+        minHeight: 56,
+        background: 'var(--bg-surface)',
+        borderBottom: '1px solid var(--border)',
+        padding: '4px 8px',
+        gap: 4,
+        overflowX: 'auto',
+      }}
+    >
+      {activeTab === 'file' && <FileRibbon />}
+      {activeTab === 'edit' && <EditRibbon />}
+      {activeTab === 'insert' && <InsertRibbon />}
+      {activeTab === 'format' && <FormatRibbon />}
+      {activeTab === 'view' && <ViewRibbon />}
+      {activeTab === 'help' && <HelpRibbon />}
+    </div>
+  )
+}

--- a/packages/ui/src/components/Toolbar/Toolbar.tsx
+++ b/packages/ui/src/components/Toolbar/Toolbar.tsx
@@ -1,18 +1,27 @@
-import { useRef, useState } from 'react'
+import { useRef } from 'react'
 import { useTemplateStore } from '../../store/templateStore.js'
 import { useUiStore } from '../../store/uiStore.js'
-import { saveTemplate, openTemplate } from '../../utils/saveOpen.js'
-import { FIELD_COLORS } from '../../theme/fieldColors.js'
+import { openTemplate } from '../../utils/saveOpen.js'
+import { MenuTabBar } from './MenuTabBar.js'
+import { RibbonBar } from './RibbonBar.js'
+import { RibbonButton } from './primitives/RibbonButton.js'
+import { MoonIcon, SunIcon, OpenIcon, BackgroundIcon } from './icons.js'
 
+/**
+ * Top-of-app toolbar (#128 redesign).
+ *
+ * Two shells:
+ *   1. Empty-state — the user has no background yet. Show the same
+ *      tight call-to-action card the onboarding flow renders, so we
+ *      don't ship a half-empty Word ribbon over a blank canvas.
+ *   2. Editor shell — `MenuTabBar` (row 1: tabs + pinned tools + CTAs)
+ *      + `RibbonBar` (row 2: active tab's controls). Each row is its
+ *      own component; this file stays under 100 lines.
+ */
 export function Toolbar() {
   const fileInputRef = useRef<HTMLInputElement>(null)
   const bgInputRef = useRef<HTMLInputElement>(null)
 
-  const meta = useTemplateStore((s) => s.meta)
-  const locked = meta.locked
-  // Page 0 has a "background" when either the legacy image data URL is set
-  // OR when the user chose a solid color during onboarding (stored as a
-  // `color` PageDefinition at index 0).
   const hasBackground = useTemplateStore(
     (s) =>
       s.backgroundDataUrl !== null ||
@@ -20,69 +29,31 @@ export function Toolbar() {
         (p) => p.index === 0 && (p.backgroundType === 'color' || p.backgroundType === 'image'),
       ),
   )
-  const canUndo = useTemplateStore((s) => s.canUndo())
-  const canRedo = useTemplateStore((s) => s.canRedo())
-  const undo = useTemplateStore((s) => s.undo)
-  const redo = useTemplateStore((s) => s.redo)
-  const setLocked = useTemplateStore((s) => s.setLocked)
-
   const theme = useUiStore((s) => s.theme)
   const toggleTheme = useUiStore((s) => s.toggleTheme)
-  const activeTool = useUiStore((s) => s.activeTool)
-  const setActiveTool = useUiStore((s) => s.setActiveTool)
-  const selectedFieldIds = useUiStore((s) => s.selectedFieldIds)
-  const fields = useTemplateStore((s) => s.fields)
-  const showLeftPanel = useUiStore((s) => s.showLeftPanel)
-  const setShowLeftPanel = useUiStore((s) => s.setShowLeftPanel)
-  const showRightPanelUi = useUiStore((s) => s.showRightPanel)
-  const pageLayoutMenuOpen = useUiStore((s) => s.pageLayoutMenu.kind !== 'closed')
-  const setShowRightPanelUi = useUiStore((s) => s.setShowRightPanel)
-  // Set of field types present in the current selection — each matching
-  // toolbar button gets a ring so the user can see at a glance what types
-  // they have selected on the canvas.
-  const selectedFieldTypes = new Set(
-    fields.filter((f) => selectedFieldIds.includes(f.id)).map((f) => f.type),
-  )
-  const showGrid = useUiStore((s) => s.showGrid)
-  const setShowGrid = useUiStore((s) => s.setShowGrid)
-  const showPreview = useUiStore((s) => s.showPreview)
-  const setShowPreview = useUiStore((s) => s.setShowPreview)
-  const setShowFontManager = useUiStore((s) => s.setShowFontManager)
-  const zoom = useUiStore((s) => s.zoom)
-  const zoomIn = useUiStore((s) => s.zoomIn)
-  const zoomOut = useUiStore((s) => s.zoomOut)
-  const resetZoom = useUiStore((s) => s.resetZoom)
 
   function handleBgUpload(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0]
     if (!file) return
-
-    // Validate file size (20 MB max)
     if (file.size > 20 * 1024 * 1024) {
       alert('Image too large. Maximum size is 20 MB.')
       e.target.value = ''
       return
     }
-
-    // Validate file type
     if (!file.type.startsWith('image/')) {
       alert('Please select an image file.')
       e.target.value = ''
       return
     }
-
     const reader = new FileReader()
     reader.onload = () => {
       const dataUrl = reader.result as string
-
       const img = new Image()
       img.onload = () => {
-        // Validate dimensions
         if (img.naturalWidth > 10000 || img.naturalHeight > 10000) {
           alert('Image dimensions too large. Maximum is 10000x10000 pixels.')
           return
         }
-
         const bufReader = new FileReader()
         bufReader.onload = () => {
           useUiStore.getState().setPendingBackground({
@@ -101,24 +72,6 @@ export function Toolbar() {
     e.target.value = ''
   }
 
-  // Bug 5 (#61 follow-up) — Save was silent: the `.tgbl` downloaded but
-  // the user got no confirmation. Flip the button to a "Saved!" label
-  // for ~1.4s after a successful save so the click feels acknowledged.
-  const [savedFlash, setSavedFlash] = useState(false)
-  async function handleSave() {
-    try {
-      await saveTemplate()
-      setSavedFlash(true)
-      window.setTimeout(() => setSavedFlash(false), 1400)
-    } catch (err) {
-      alert(err instanceof Error ? err.message : 'Save failed')
-    }
-  }
-
-  function handleOpen() {
-    fileInputRef.current?.click()
-  }
-
   async function handleOpenFile(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0]
     if (!file) return
@@ -130,79 +83,45 @@ export function Toolbar() {
     e.target.value = ''
   }
 
-  // When no background, show minimal toolbar
+  // ── Empty state: render a minimal top strip with Upload + Open + theme.
+  //    The onboarding picker fills the canvas — this just frames the page.
   if (!hasBackground) {
     return (
-      <div className="tg-toolbar">
-        <div className="tg-toolbar-group">
-          <button className="tg-btn tg-btn--primary" onClick={() => bgInputRef.current?.click()}>
-            <svg
-              width="14"
-              height="14"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-            >
-              <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
-              <circle cx="8.5" cy="8.5" r="1.5" />
-              <polyline points="21 15 16 10 5 21" />
-            </svg>
-            Upload Background
-          </button>
-          <input ref={bgInputRef} type="file" accept="image/*" hidden onChange={handleBgUpload} />
-        </div>
-        <div className="tg-toolbar-separator" />
-        <div className="tg-toolbar-group">
-          <button className="tg-btn" onClick={handleOpen}>
-            <svg
-              width="14"
-              height="14"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-            >
-              <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />
-            </svg>
-            Open .tgbl
-          </button>
-          <input ref={fileInputRef} type="file" accept=".tgbl" hidden onChange={handleOpenFile} />
-        </div>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
+          padding: '8px 12px',
+          background: 'var(--bg-secondary)',
+          borderBottom: '1px solid var(--border-light)',
+        }}
+      >
+        <RibbonButton
+          icon={<BackgroundIcon />}
+          label="Upload Background"
+          onClick={() => bgInputRef.current?.click()}
+          variant="primary"
+          compact
+          testid="toolbar-upload-background"
+        />
+        <input ref={bgInputRef} type="file" accept="image/*" hidden onChange={handleBgUpload} />
+        <RibbonButton
+          icon={<OpenIcon />}
+          label="Open .tgbl"
+          onClick={() => fileInputRef.current?.click()}
+          compact
+          testid="toolbar-open"
+        />
+        <input ref={fileInputRef} type="file" accept=".tgbl" hidden onChange={handleOpenFile} />
         <div style={{ flex: 1 }} />
-        <button className="tg-btn" onClick={toggleTheme} title="Toggle theme">
-          {theme === 'light' ? (
-            <svg
-              width="14"
-              height="14"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-            >
-              <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
-            </svg>
-          ) : (
-            <svg
-              width="14"
-              height="14"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-            >
-              <circle cx="12" cy="12" r="5" />
-              <line x1="12" y1="1" x2="12" y2="3" />
-              <line x1="12" y1="21" x2="12" y2="23" />
-              <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
-              <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
-              <line x1="1" y1="12" x2="3" y2="12" />
-              <line x1="21" y1="12" x2="23" y2="12" />
-              <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
-              <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
-            </svg>
-          )}
-        </button>
+        <RibbonButton
+          icon={theme === 'light' ? <MoonIcon /> : <SunIcon />}
+          onClick={toggleTheme}
+          compact
+          title="Toggle theme"
+          ariaLabel="Toggle theme"
+        />
         <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--text-secondary)' }}>
           TemplateGoblin
         </span>
@@ -210,448 +129,11 @@ export function Toolbar() {
     )
   }
 
+  // ── Editor shell: menu tab strip + active-tab ribbon.
   return (
-    <div className="tg-toolbar">
-      {/* Left-sidebar hamburger — toggles the styling / properties panel. */}
-      <div className="tg-toolbar-group">
-        <button
-          className={`tg-btn ${showLeftPanel ? 'tg-btn--active' : ''}`}
-          onClick={() => setShowLeftPanel(!showLeftPanel)}
-          title={showLeftPanel ? 'Hide properties panel' : 'Show properties panel'}
-          data-testid="toolbar-toggle-left-panel"
-          aria-pressed={showLeftPanel}
-          aria-label="Toggle properties panel"
-        >
-          <svg
-            width="16"
-            height="16"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-          >
-            <line x1="3" y1="6" x2="21" y2="6" />
-            <line x1="3" y1="12" x2="21" y2="12" />
-            <line x1="3" y1="18" x2="21" y2="18" />
-          </svg>
-        </button>
-      </div>
-
-      <div className="tg-toolbar-separator" />
-
-      {/* Open / Upload — leftmost of the action groups */}
-      <div className="tg-toolbar-group">
-        <button className="tg-btn" onClick={handleOpen}>
-          <svg
-            width="14"
-            height="14"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-          >
-            <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />
-          </svg>
-          Open
-        </button>
-        <input ref={fileInputRef} type="file" accept=".tgbl" hidden onChange={handleOpenFile} />
-        {/* Improvement 1 (#61 follow-up) — Users previously had no way to
-            start over without manually clearing IndexedDB. Confirm before
-            wiping so an accidental click doesn't destroy in-progress work. */}
-        <button
-          className="tg-btn"
-          onClick={() => {
-            const ok = window.confirm(
-              'Start a new template? Your current unsaved work will be lost.',
-            )
-            if (!ok) return
-            useTemplateStore.getState().reset()
-            useUiStore.getState().clearSelection()
-          }}
-          title="Start a new blank template"
-          data-testid="toolbar-new"
-        >
-          <svg
-            width="14"
-            height="14"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            aria-hidden="true"
-          >
-            <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
-            <polyline points="14 2 14 8 20 8" />
-            <line x1="12" y1="18" x2="12" y2="12" />
-            <line x1="9" y1="15" x2="15" y2="15" />
-          </svg>
-          New
-        </button>
-        <button
-          className="tg-btn"
-          onClick={() => useUiStore.getState().setShowChangeBgDialog(true)}
-          title="Change the current page's background"
-          data-testid="toolbar-change-background"
-        >
-          <svg
-            width="14"
-            height="14"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-          >
-            <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
-            <circle cx="8.5" cy="8.5" r="1.5" />
-            <polyline points="21 15 16 10 5 21" />
-          </svg>
-          Change Background
-        </button>
-        <input ref={bgInputRef} type="file" accept="image/*" hidden onChange={handleBgUpload} />
-      </div>
-
-      <div className="tg-toolbar-separator" />
-
-      {/* Field tools */}
-      <div className="tg-toolbar-group">
-        <button
-          className={`tg-btn ${activeTool === 'addText' || selectedFieldTypes.has('text') ? 'tg-btn--active' : ''}`}
-          onClick={() => setActiveTool(activeTool === 'addText' ? 'select' : 'addText')}
-          disabled={locked || !hasBackground}
-          style={
-            activeTool === 'addText' || selectedFieldTypes.has('text')
-              ? {
-                  background: FIELD_COLORS.text.stroke,
-                  color: '#fff',
-                  borderColor: FIELD_COLORS.text.stroke,
-                }
-              : {
-                  background: FIELD_COLORS.text.toolbarBg,
-                  color: FIELD_COLORS.text.toolbarFg,
-                  borderColor: FIELD_COLORS.text.stroke,
-                }
-          }
-        >
-          <svg
-            width="14"
-            height="14"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-          >
-            <polyline points="4 7 4 4 20 4 20 7" />
-            <line x1="9" y1="20" x2="15" y2="20" />
-            <line x1="12" y1="4" x2="12" y2="20" />
-          </svg>
-          Text
-        </button>
-        <button
-          className={`tg-btn ${activeTool === 'addImage' || selectedFieldTypes.has('image') ? 'tg-btn--active' : ''}`}
-          onClick={() => setActiveTool(activeTool === 'addImage' ? 'select' : 'addImage')}
-          disabled={locked || !hasBackground}
-          style={
-            activeTool === 'addImage' || selectedFieldTypes.has('image')
-              ? {
-                  background: FIELD_COLORS.image.stroke,
-                  color: '#fff',
-                  borderColor: FIELD_COLORS.image.stroke,
-                }
-              : {
-                  background: FIELD_COLORS.image.toolbarBg,
-                  color: FIELD_COLORS.image.toolbarFg,
-                  borderColor: FIELD_COLORS.image.stroke,
-                }
-          }
-        >
-          <svg
-            width="14"
-            height="14"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-          >
-            <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
-            <circle cx="8.5" cy="8.5" r="1.5" />
-            <polyline points="21 15 16 10 5 21" />
-          </svg>
-          Image
-        </button>
-        <button
-          className={`tg-btn ${activeTool === 'addLoop' || selectedFieldTypes.has('table') ? 'tg-btn--active' : ''}`}
-          onClick={() => setActiveTool(activeTool === 'addLoop' ? 'select' : 'addLoop')}
-          disabled={locked || !hasBackground}
-          style={
-            activeTool === 'addLoop' || selectedFieldTypes.has('table')
-              ? {
-                  background: FIELD_COLORS.table.stroke,
-                  color: '#fff',
-                  borderColor: FIELD_COLORS.table.stroke,
-                }
-              : {
-                  background: FIELD_COLORS.table.toolbarBg,
-                  color: FIELD_COLORS.table.toolbarFg,
-                  borderColor: FIELD_COLORS.table.stroke,
-                }
-          }
-        >
-          <svg
-            width="14"
-            height="14"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-          >
-            <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
-            <line x1="3" y1="9" x2="21" y2="9" />
-            <line x1="3" y1="15" x2="21" y2="15" />
-            <line x1="9" y1="3" x2="9" y2="21" />
-            <line x1="15" y1="3" x2="15" y2="21" />
-          </svg>
-          Table
-        </button>
-        {/* #61 — Insert-style entry-point for the page-wide header / footer
-            and page-number settings. Mirrors Google Docs / Word's
-            Insert → Header & Footer pattern. The button anchors a
-            dropdown menu (`PageLayoutMenu`) rather than launching a
-            centered modal — keeps the editor focus where the user is
-            working and matches every production document tool. */}
-        <button
-          className={`tg-btn ${pageLayoutMenuOpen ? 'tg-btn--active' : ''}`}
-          onClick={() =>
-            useUiStore
-              .getState()
-              .setPageLayoutMenu(pageLayoutMenuOpen ? { kind: 'closed' } : { kind: 'main' })
-          }
-          disabled={locked || !hasBackground}
-          title="Page layout (header, footer, page number)"
-          data-testid="toolbar-page-layout"
-          data-page-layout-anchor="true"
-        >
-          <svg
-            width="14"
-            height="14"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            aria-hidden="true"
-          >
-            <rect x="3" y="3" width="18" height="18" rx="1" />
-            <line x1="3" y1="8" x2="21" y2="8" />
-            <line x1="3" y1="16" x2="21" y2="16" />
-          </svg>
-          Page Layout
-        </button>
-      </div>
-
-      <div className="tg-toolbar-separator" />
-
-      {/* Undo/Redo */}
-      <div className="tg-toolbar-group">
-        <button className="tg-btn" onClick={undo} disabled={!canUndo} title="Undo (Ctrl+Z)">
-          <svg
-            width="14"
-            height="14"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-          >
-            <polyline points="1 4 1 10 7 10" />
-            <path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10" />
-          </svg>
-        </button>
-        <button className="tg-btn" onClick={redo} disabled={!canRedo} title="Redo (Ctrl+Shift+Z)">
-          <svg
-            width="14"
-            height="14"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-          >
-            <polyline points="23 4 23 10 17 10" />
-            <path d="M20.49 15a9 9 0 1 1-2.13-9.36L23 10" />
-          </svg>
-        </button>
-      </div>
-
-      <div className="tg-toolbar-separator" />
-
-      {/* View controls */}
-      <div className="tg-toolbar-group">
-        <button
-          className={`tg-btn ${showGrid ? 'tg-btn--active' : ''}`}
-          onClick={() => setShowGrid(!showGrid)}
-        >
-          Snap
-        </button>
-        <button className="tg-btn" onClick={zoomOut} title="Zoom out">
-          -
-        </button>
-        <button
-          className="tg-btn"
-          onClick={resetZoom}
-          style={{ minWidth: 48, justifyContent: 'center' }}
-        >
-          {Math.round(zoom * 100)}%
-        </button>
-        <button className="tg-btn" onClick={zoomIn} title="Zoom in">
-          +
-        </button>
-      </div>
-
-      {/* Spacer pushes remaining buttons to far right */}
-      <div style={{ flex: 1 }} />
-
-      {/* Fonts & Theme */}
-      <div className="tg-toolbar-group">
-        <button className="tg-btn" onClick={() => setShowFontManager(true)}>
-          Fonts
-        </button>
-        <button className="tg-btn" onClick={toggleTheme} title="Toggle theme">
-          {theme === 'light' ? (
-            <svg
-              width="14"
-              height="14"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-            >
-              <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
-            </svg>
-          ) : (
-            <svg
-              width="14"
-              height="14"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-            >
-              <circle cx="12" cy="12" r="5" />
-              <line x1="12" y1="1" x2="12" y2="3" />
-              <line x1="12" y1="21" x2="12" y2="23" />
-              <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
-              <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
-              <line x1="1" y1="12" x2="3" y2="12" />
-              <line x1="21" y1="12" x2="23" y2="12" />
-              <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
-              <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
-            </svg>
-          )}
-        </button>
-      </div>
-
-      <div className="tg-toolbar-separator" />
-
-      {/* Preview — end group */}
-      <button
-        className="tg-btn"
-        onClick={() => setShowPreview(!showPreview)}
-        disabled={!hasBackground}
-        title="Preview template"
-        data-testid="toolbar-preview"
-      >
-        <svg
-          width="14"
-          height="14"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-        >
-          <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
-          <circle cx="12" cy="12" r="3" />
-        </svg>
-        Preview
-      </button>
-
-      {/* Lock */}
-      <button
-        className={`tg-btn ${locked ? 'tg-btn--active' : ''}`}
-        onClick={() => setLocked(!locked)}
-        title={locked ? 'Unlock template' : 'Lock template'}
-      >
-        <svg
-          width="14"
-          height="14"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-        >
-          {locked ? (
-            <>
-              <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
-              <path d="M7 11V7a5 5 0 0 1 10 0v4" />
-            </>
-          ) : (
-            <>
-              <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
-              <path d="M7 11V7a5 5 0 0 1 9.9-1" />
-            </>
-          )}
-        </svg>
-        {locked ? 'Unlock' : 'Lock'}
-      </button>
-
-      {/* Right-sidebar hamburger — toggles the structure / JSON panel. */}
-      <button
-        className={`tg-btn ${showRightPanelUi ? 'tg-btn--active' : ''}`}
-        onClick={() => setShowRightPanelUi(!showRightPanelUi)}
-        title={showRightPanelUi ? 'Hide structure panel' : 'Show structure panel'}
-        data-testid="toolbar-toggle-right-panel"
-        aria-pressed={showRightPanelUi}
-        aria-label="Toggle structure panel"
-      >
-        <svg
-          width="16"
-          height="16"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-        >
-          <line x1="3" y1="6" x2="21" y2="6" />
-          <line x1="3" y1="12" x2="21" y2="12" />
-          <line x1="3" y1="18" x2="21" y2="18" />
-        </svg>
-      </button>
-
-      <div className="tg-toolbar-separator" />
-
-      {/* Save — last, green. Flips to "Saved!" briefly after a successful
-          download so the click has visible feedback (#61 follow-up Bug 5). */}
-      <button
-        className="tg-btn"
-        style={{
-          background: savedFlash ? '#0a7a32' : '#16a34a',
-          color: '#fff',
-          borderRadius: 6,
-        }}
-        onClick={handleSave}
-        title="Save template (Ctrl+S)"
-        data-testid="toolbar-save"
-      >
-        <svg
-          width="14"
-          height="14"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-        >
-          <path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z" />
-          <polyline points="17 21 17 13 7 13 7 21" />
-          <polyline points="7 3 7 8 15 8" />
-        </svg>
-        {savedFlash ? 'Saved!' : 'Save'}
-      </button>
+    <div role="region" aria-label="Application toolbar">
+      <MenuTabBar />
+      <RibbonBar />
     </div>
   )
 }

--- a/packages/ui/src/components/Toolbar/icons.tsx
+++ b/packages/ui/src/components/Toolbar/icons.tsx
@@ -1,0 +1,173 @@
+import type { ReactNode } from 'react'
+
+/**
+ * Shared SVG icon set for the new menu bar + ribbon (#128). All icons
+ * inherit colour via `stroke="currentColor"` so they automatically adapt
+ * to light + dark themes through `--text-primary`. Hard Rule #7 — no
+ * icon library; these are inline SVGs.
+ */
+
+interface IconBoxProps {
+  size?: number
+  children: ReactNode
+  title?: string
+}
+
+function IconBox({ size = 16, children, title }: IconBoxProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden={!title}
+      role={title ? 'img' : undefined}
+    >
+      {title && <title>{title}</title>}
+      {children}
+    </svg>
+  )
+}
+
+export const OpenIcon = ({ size }: { size?: number }) => (
+  <IconBox size={size}>
+    <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />
+  </IconBox>
+)
+
+export const NewIcon = ({ size }: { size?: number }) => (
+  <IconBox size={size}>
+    <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+    <polyline points="14 2 14 8 20 8" />
+    <line x1="12" y1="18" x2="12" y2="12" />
+    <line x1="9" y1="15" x2="15" y2="15" />
+  </IconBox>
+)
+
+export const SaveIcon = ({ size }: { size?: number }) => (
+  <IconBox size={size}>
+    <path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z" />
+    <polyline points="17 21 17 13 7 13 7 21" />
+    <polyline points="7 3 7 8 15 8" />
+  </IconBox>
+)
+
+export const BackgroundIcon = ({ size }: { size?: number }) => (
+  <IconBox size={size}>
+    <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
+    <circle cx="8.5" cy="8.5" r="1.5" />
+    <polyline points="21 15 16 10 5 21" />
+  </IconBox>
+)
+
+export const TextIcon = ({ size }: { size?: number }) => (
+  <IconBox size={size}>
+    <polyline points="4 7 4 4 20 4 20 7" />
+    <line x1="9" y1="20" x2="15" y2="20" />
+    <line x1="12" y1="4" x2="12" y2="20" />
+  </IconBox>
+)
+
+export const ImageIcon = BackgroundIcon
+
+export const TableIcon = ({ size }: { size?: number }) => (
+  <IconBox size={size}>
+    <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
+    <line x1="3" y1="9" x2="21" y2="9" />
+    <line x1="3" y1="15" x2="21" y2="15" />
+    <line x1="9" y1="3" x2="9" y2="21" />
+    <line x1="15" y1="3" x2="15" y2="21" />
+  </IconBox>
+)
+
+export const PageLayoutIcon = ({ size }: { size?: number }) => (
+  <IconBox size={size}>
+    <rect x="3" y="3" width="18" height="18" rx="1" />
+    <line x1="3" y1="8" x2="21" y2="8" />
+    <line x1="3" y1="16" x2="21" y2="16" />
+  </IconBox>
+)
+
+export const UndoIcon = ({ size }: { size?: number }) => (
+  <IconBox size={size}>
+    <polyline points="1 4 1 10 7 10" />
+    <path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10" />
+  </IconBox>
+)
+
+export const RedoIcon = ({ size }: { size?: number }) => (
+  <IconBox size={size}>
+    <polyline points="23 4 23 10 17 10" />
+    <path d="M20.49 15a9 9 0 1 1-2.13-9.36L23 10" />
+  </IconBox>
+)
+
+export const PreviewIcon = ({ size }: { size?: number }) => (
+  <IconBox size={size}>
+    <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+    <circle cx="12" cy="12" r="3" />
+  </IconBox>
+)
+
+export const LockedIcon = ({ size }: { size?: number }) => (
+  <IconBox size={size}>
+    <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+    <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+  </IconBox>
+)
+
+export const UnlockedIcon = ({ size }: { size?: number }) => (
+  <IconBox size={size}>
+    <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+    <path d="M7 11V7a5 5 0 0 1 9.9-1" />
+  </IconBox>
+)
+
+export const SunIcon = ({ size }: { size?: number }) => (
+  <IconBox size={size}>
+    <circle cx="12" cy="12" r="5" />
+    <line x1="12" y1="1" x2="12" y2="3" />
+    <line x1="12" y1="21" x2="12" y2="23" />
+    <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+    <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+    <line x1="1" y1="12" x2="3" y2="12" />
+    <line x1="21" y1="12" x2="23" y2="12" />
+    <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+    <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+  </IconBox>
+)
+
+export const MoonIcon = ({ size }: { size?: number }) => (
+  <IconBox size={size}>
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+  </IconBox>
+)
+
+export const PanelLeftIcon = ({ size }: { size?: number }) => (
+  <IconBox size={size}>
+    <line x1="3" y1="6" x2="21" y2="6" />
+    <line x1="3" y1="12" x2="21" y2="12" />
+    <line x1="3" y1="18" x2="21" y2="18" />
+  </IconBox>
+)
+
+export const ZoomInIcon = ({ size }: { size?: number }) => (
+  <IconBox size={size}>
+    <circle cx="11" cy="11" r="8" />
+    <line x1="21" y1="21" x2="16.65" y2="16.65" />
+    <line x1="11" y1="8" x2="11" y2="14" />
+    <line x1="8" y1="11" x2="14" y2="11" />
+  </IconBox>
+)
+
+export const ZoomOutIcon = ({ size }: { size?: number }) => (
+  <IconBox size={size}>
+    <circle cx="11" cy="11" r="8" />
+    <line x1="21" y1="21" x2="16.65" y2="16.65" />
+    <line x1="8" y1="11" x2="14" y2="11" />
+  </IconBox>
+)

--- a/packages/ui/src/components/Toolbar/primitives/MenuButton.tsx
+++ b/packages/ui/src/components/Toolbar/primitives/MenuButton.tsx
@@ -1,0 +1,90 @@
+import { forwardRef, type ReactNode } from 'react'
+
+/**
+ * A row-1 menu trigger (#128) — File / Edit / Insert / Format / View /
+ * Help. Looks like a text-only button until hovered or active. Active
+ * state mirrors the user's currently-selected tab so the ribbon below
+ * stays in sync.
+ *
+ * Uses CSS variables (`--text-primary`, `--bg-tertiary`, `--accent`) so
+ * the same component looks right in both light and dark themes.
+ */
+export interface MenuButtonProps {
+  label: string
+  active?: boolean
+  onClick: () => void
+  testid?: string
+  /** Optional aria controls — useful when the button opens a dropdown. */
+  ariaControls?: string
+}
+
+export const MenuButton = forwardRef<HTMLButtonElement, MenuButtonProps>(function MenuButton(
+  { label, active, onClick, testid, ariaControls },
+  ref,
+) {
+  return (
+    <button
+      ref={ref}
+      type="button"
+      onClick={onClick}
+      data-testid={testid}
+      aria-haspopup="menu"
+      aria-expanded={active}
+      aria-controls={ariaControls}
+      style={{
+        background: active ? 'var(--bg-tertiary)' : 'transparent',
+        color: 'var(--text-primary)',
+        border: 'none',
+        padding: '6px 12px',
+        fontSize: 13,
+        fontWeight: 500,
+        cursor: 'pointer',
+        borderRadius: 4,
+        outline: 'none',
+        transition: 'background 0.12s ease',
+      }}
+      onMouseEnter={(e) => {
+        if (!active) (e.currentTarget as HTMLElement).style.background = 'var(--bg-tertiary)'
+      }}
+      onMouseLeave={(e) => {
+        if (!active) (e.currentTarget as HTMLElement).style.background = 'transparent'
+      }}
+      onFocus={(e) => {
+        if (!active) (e.currentTarget as HTMLElement).style.background = 'var(--bg-tertiary)'
+      }}
+      onBlur={(e) => {
+        if (!active) (e.currentTarget as HTMLElement).style.background = 'transparent'
+      }}
+    >
+      {label}
+    </button>
+  )
+})
+
+/** Vertical separator between row-1 groups (menus / pinned tools / CTAs). */
+export function MenuSeparator() {
+  return (
+    <span
+      aria-hidden
+      style={{
+        display: 'inline-block',
+        width: 1,
+        height: 18,
+        background: 'var(--border)',
+        margin: '0 6px',
+      }}
+    />
+  )
+}
+
+/** Generic SVG-icon wrapper so menus can pass concise icon nodes. */
+export function MenuIcon({ children }: { children: ReactNode }) {
+  return (
+    <span
+      aria-hidden
+      style={{ display: 'inline-flex', alignItems: 'center', justifyContent: 'center' }}
+    >
+      {children}
+    </span>
+  )
+}

--- a/packages/ui/src/components/Toolbar/primitives/MenuButton.tsx
+++ b/packages/ui/src/components/Toolbar/primitives/MenuButton.tsx
@@ -4,17 +4,14 @@ import { forwardRef, type ReactNode } from 'react'
  * A row-1 menu trigger (#128) — File / Edit / Insert / Format / View /
  * Help. Looks like a text-only button until hovered or active. Active
  * state mirrors the user's currently-selected tab so the ribbon below
- * stays in sync.
- *
- * Uses CSS variables (`--text-primary`, `--bg-tertiary`, `--accent`) so
- * the same component looks right in both light and dark themes.
+ * stays in sync. Styling lives in `.tg-menu-tab` (App.css) so it
+ * outranks Tailwind preflight's button reset.
  */
 export interface MenuButtonProps {
   label: string
   active?: boolean
   onClick: () => void
   testid?: string
-  /** Optional aria controls — useful when the button opens a dropdown. */
   ariaControls?: string
 }
 
@@ -31,30 +28,7 @@ export const MenuButton = forwardRef<HTMLButtonElement, MenuButtonProps>(functio
       aria-haspopup="menu"
       aria-expanded={active}
       aria-controls={ariaControls}
-      style={{
-        background: active ? 'var(--bg-tertiary)' : 'transparent',
-        color: 'var(--text-primary)',
-        border: 'none',
-        padding: '6px 12px',
-        fontSize: 13,
-        fontWeight: 500,
-        cursor: 'pointer',
-        borderRadius: 4,
-        outline: 'none',
-        transition: 'background 0.12s ease',
-      }}
-      onMouseEnter={(e) => {
-        if (!active) (e.currentTarget as HTMLElement).style.background = 'var(--bg-tertiary)'
-      }}
-      onMouseLeave={(e) => {
-        if (!active) (e.currentTarget as HTMLElement).style.background = 'transparent'
-      }}
-      onFocus={(e) => {
-        if (!active) (e.currentTarget as HTMLElement).style.background = 'var(--bg-tertiary)'
-      }}
-      onBlur={(e) => {
-        if (!active) (e.currentTarget as HTMLElement).style.background = 'transparent'
-      }}
+      className={`tg-menu-tab${active ? ' tg-menu-tab--active' : ''}`}
     >
       {label}
     </button>

--- a/packages/ui/src/components/Toolbar/primitives/RibbonButton.tsx
+++ b/packages/ui/src/components/Toolbar/primitives/RibbonButton.tsx
@@ -4,13 +4,13 @@ import { type ReactNode, type CSSProperties } from 'react'
  * A single icon+label button used inside row-2 ribbon groups (#128).
  * Variants:
  *   - `default` — neutral text + icon, used for most actions.
- *   - `primary` — accent fill (e.g. Save), high visual weight.
+ *   - `primary` — accent fill (e.g. Upload), high visual weight.
  *   - `success` — green fill (used for the Save button on the menu bar).
  *   - `toggle` — active state lights up via `--bg-tertiary` background.
  *
- * Layout is two-line by default (icon above, label below) to match the
- * Word ribbon aesthetic; pass `compact` for a single-line variant when
- * a control lives in a tight cluster (e.g. zoom +/-).
+ * Styling lives in `.tg-ribbon-btn` (App.css). Inline styles can't
+ * override Tailwind v4 preflight's `button { background-color: transparent }`
+ * without `!important`, so we use CSS classes instead.
  */
 export interface RibbonButtonProps {
   label?: string
@@ -26,9 +26,7 @@ export interface RibbonButtonProps {
   /** Custom inline style overrides — used by the field-creation buttons
    *  that carry their type-specific colour. */
   style?: CSSProperties
-  /** Arbitrary `data-*` attributes forwarded to the underlying button.
-   *  Used e.g. by `PageLayoutMenu` to find its anchor via
-   *  `[data-page-layout-anchor="true"]`. */
+  /** Arbitrary `data-*` attributes forwarded to the underlying button. */
   dataAttrs?: Record<string, string>
 }
 
@@ -46,32 +44,15 @@ export function RibbonButton({
   style,
   dataAttrs,
 }: RibbonButtonProps) {
-  const base: CSSProperties = {
-    display: 'flex',
-    flexDirection: compact ? 'row' : 'column',
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: compact ? 4 : 2,
-    minWidth: compact ? 28 : 48,
-    padding: compact ? '4px 8px' : '4px 8px',
-    fontSize: 11,
-    fontWeight: 500,
-    color: variant === 'primary' || variant === 'success' ? '#fff' : 'var(--text-primary)',
-    background:
-      variant === 'primary'
-        ? 'var(--accent)'
-        : variant === 'success'
-          ? '#16a34a'
-          : active
-            ? 'var(--bg-tertiary)'
-            : 'transparent',
-    border: variant === 'primary' || variant === 'success' ? 'none' : '1px solid transparent',
-    borderRadius: 4,
-    cursor: disabled ? 'not-allowed' : 'pointer',
-    opacity: disabled ? 0.4 : 1,
-    transition: 'background 0.12s ease, border-color 0.12s ease',
-    whiteSpace: 'nowrap',
-  }
+  const cls = [
+    'tg-ribbon-btn',
+    compact ? 'tg-ribbon-btn--compact' : '',
+    variant === 'primary' ? 'tg-ribbon-btn--primary' : '',
+    variant === 'success' ? 'tg-ribbon-btn--success' : '',
+    active && (variant === 'toggle' || variant === 'default') ? 'tg-ribbon-btn--active' : '',
+  ]
+    .filter(Boolean)
+    .join(' ')
 
   return (
     <button
@@ -83,21 +64,8 @@ export function RibbonButton({
       aria-label={ariaLabel ?? label ?? title}
       data-testid={testid}
       {...(dataAttrs ?? {})}
-      style={{ ...base, ...style }}
-      onMouseEnter={(e) => {
-        if (disabled) return
-        const el = e.currentTarget as HTMLElement
-        if (variant === 'primary') el.style.background = 'var(--accent-hover)'
-        else if (variant === 'success') el.style.background = '#0a7a32'
-        else if (!active) el.style.background = 'var(--bg-tertiary)'
-      }}
-      onMouseLeave={(e) => {
-        if (disabled) return
-        const el = e.currentTarget as HTMLElement
-        if (variant === 'primary') el.style.background = 'var(--accent)'
-        else if (variant === 'success') el.style.background = '#16a34a'
-        else if (!active) el.style.background = 'transparent'
-      }}
+      className={cls}
+      style={style}
     >
       {icon && <span aria-hidden>{icon}</span>}
       {label && <span>{label}</span>}

--- a/packages/ui/src/components/Toolbar/primitives/RibbonButton.tsx
+++ b/packages/ui/src/components/Toolbar/primitives/RibbonButton.tsx
@@ -1,0 +1,106 @@
+import { type ReactNode, type CSSProperties } from 'react'
+
+/**
+ * A single icon+label button used inside row-2 ribbon groups (#128).
+ * Variants:
+ *   - `default` — neutral text + icon, used for most actions.
+ *   - `primary` — accent fill (e.g. Save), high visual weight.
+ *   - `success` — green fill (used for the Save button on the menu bar).
+ *   - `toggle` — active state lights up via `--bg-tertiary` background.
+ *
+ * Layout is two-line by default (icon above, label below) to match the
+ * Word ribbon aesthetic; pass `compact` for a single-line variant when
+ * a control lives in a tight cluster (e.g. zoom +/-).
+ */
+export interface RibbonButtonProps {
+  label?: string
+  icon?: ReactNode
+  onClick?: () => void
+  title?: string
+  disabled?: boolean
+  active?: boolean
+  variant?: 'default' | 'primary' | 'success' | 'toggle'
+  compact?: boolean
+  testid?: string
+  ariaLabel?: string
+  /** Custom inline style overrides — used by the field-creation buttons
+   *  that carry their type-specific colour. */
+  style?: CSSProperties
+  /** Arbitrary `data-*` attributes forwarded to the underlying button.
+   *  Used e.g. by `PageLayoutMenu` to find its anchor via
+   *  `[data-page-layout-anchor="true"]`. */
+  dataAttrs?: Record<string, string>
+}
+
+export function RibbonButton({
+  label,
+  icon,
+  onClick,
+  title,
+  disabled,
+  active,
+  variant = 'default',
+  compact,
+  testid,
+  ariaLabel,
+  style,
+  dataAttrs,
+}: RibbonButtonProps) {
+  const base: CSSProperties = {
+    display: 'flex',
+    flexDirection: compact ? 'row' : 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: compact ? 4 : 2,
+    minWidth: compact ? 28 : 48,
+    padding: compact ? '4px 8px' : '4px 8px',
+    fontSize: 11,
+    fontWeight: 500,
+    color: variant === 'primary' || variant === 'success' ? '#fff' : 'var(--text-primary)',
+    background:
+      variant === 'primary'
+        ? 'var(--accent)'
+        : variant === 'success'
+          ? '#16a34a'
+          : active
+            ? 'var(--bg-tertiary)'
+            : 'transparent',
+    border: variant === 'primary' || variant === 'success' ? 'none' : '1px solid transparent',
+    borderRadius: 4,
+    cursor: disabled ? 'not-allowed' : 'pointer',
+    opacity: disabled ? 0.4 : 1,
+    transition: 'background 0.12s ease, border-color 0.12s ease',
+    whiteSpace: 'nowrap',
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={disabled ? undefined : onClick}
+      title={title}
+      disabled={disabled}
+      aria-pressed={variant === 'toggle' ? active : undefined}
+      aria-label={ariaLabel ?? label ?? title}
+      data-testid={testid}
+      {...(dataAttrs ?? {})}
+      style={{ ...base, ...style }}
+      onMouseEnter={(e) => {
+        if (disabled) return
+        const el = e.currentTarget as HTMLElement
+        if (variant === 'primary') el.style.background = 'var(--accent-hover)'
+        else if (variant === 'success') el.style.background = '#0a7a32'
+        else if (!active) el.style.background = 'var(--bg-tertiary)'
+      }}
+      onMouseLeave={(e) => {
+        if (disabled) return
+        const el = e.currentTarget as HTMLElement
+        if (variant === 'primary') el.style.background = 'var(--accent)'
+        else if (variant === 'success') el.style.background = '#16a34a'
+        else if (!active) el.style.background = 'transparent'
+      }}
+    >
+      {icon && <span aria-hidden>{icon}</span>}
+      {label && <span>{label}</span>}
+    </button>
+  )
+}

--- a/packages/ui/src/components/Toolbar/primitives/RibbonGroup.tsx
+++ b/packages/ui/src/components/Toolbar/primitives/RibbonGroup.tsx
@@ -1,0 +1,44 @@
+import type { ReactNode } from 'react'
+
+/**
+ * Visual cluster inside the row-2 ribbon (#128). Mirrors Word's ribbon
+ * groups — a labelled box of related controls, separated from siblings
+ * by a subtle vertical divider. Label shrinks to the bottom so the
+ * cluster's primary controls dominate the eye.
+ */
+export interface RibbonGroupProps {
+  label?: string
+  children: ReactNode
+  testid?: string
+}
+
+export function RibbonGroup({ label, children, testid }: RibbonGroupProps) {
+  return (
+    <div
+      data-testid={testid}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        gap: 4,
+        padding: '4px 10px',
+        borderRight: '1px solid var(--border-light)',
+        minHeight: 56,
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>{children}</div>
+      {label && (
+        <div
+          style={{
+            fontSize: 10,
+            color: 'var(--text-muted)',
+            textTransform: 'uppercase',
+            letterSpacing: 0.4,
+          }}
+        >
+          {label}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/ui/src/components/Toolbar/ribbons/EditRibbon.tsx
+++ b/packages/ui/src/components/Toolbar/ribbons/EditRibbon.tsx
@@ -1,0 +1,38 @@
+import { useTemplateStore } from '../../../store/templateStore.js'
+import { RibbonGroup } from '../primitives/RibbonGroup.js'
+import { RibbonButton } from '../primitives/RibbonButton.js'
+import { UndoIcon, RedoIcon } from '../icons.js'
+
+/**
+ * Edit ribbon (#128). Undo / Redo today; placeholder slots for Copy /
+ * Paste / Delete come later as field-clipboard support lands.
+ */
+export function EditRibbon() {
+  const canUndo = useTemplateStore((s) => s.canUndo())
+  const canRedo = useTemplateStore((s) => s.canRedo())
+  const undo = useTemplateStore((s) => s.undo)
+  const redo = useTemplateStore((s) => s.redo)
+
+  return (
+    <div style={{ display: 'flex' }}>
+      <RibbonGroup label="History">
+        <RibbonButton
+          icon={<UndoIcon />}
+          label="Undo"
+          onClick={undo}
+          disabled={!canUndo}
+          title="Undo (Ctrl+Z)"
+          testid="ribbon-undo"
+        />
+        <RibbonButton
+          icon={<RedoIcon />}
+          label="Redo"
+          onClick={redo}
+          disabled={!canRedo}
+          title="Redo (Ctrl+Shift+Z)"
+          testid="ribbon-redo"
+        />
+      </RibbonGroup>
+    </div>
+  )
+}

--- a/packages/ui/src/components/Toolbar/ribbons/FileRibbon.tsx
+++ b/packages/ui/src/components/Toolbar/ribbons/FileRibbon.tsx
@@ -1,0 +1,67 @@
+import { useRef } from 'react'
+import { useTemplateStore } from '../../../store/templateStore.js'
+import { useUiStore } from '../../../store/uiStore.js'
+import { openTemplate } from '../../../utils/saveOpen.js'
+import { RibbonGroup } from '../primitives/RibbonGroup.js'
+import { RibbonButton } from '../primitives/RibbonButton.js'
+import { NewIcon, OpenIcon, BackgroundIcon } from '../icons.js'
+
+/**
+ * File ribbon (#128). Save lives in the pinned-CTA slot at the far right
+ * of the menu bar, not here — but New / Open / Change Background belong
+ * to the File category and live here so users can find them by clicking
+ * the File tab even though they're not visible on the pinned strip.
+ */
+export function FileRibbon() {
+  const openInputRef = useRef<HTMLInputElement>(null)
+  const setShowChangeBgDialog = useUiStore((s) => s.setShowChangeBgDialog)
+
+  async function handleOpenFile(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0]
+    if (!file) return
+    try {
+      await openTemplate(file)
+    } catch (err) {
+      alert(err instanceof Error ? err.message : 'Failed to open file')
+    }
+    e.target.value = ''
+  }
+
+  function handleNew() {
+    const ok = window.confirm('Start a new template? Your current unsaved work will be lost.')
+    if (!ok) return
+    useTemplateStore.getState().reset()
+    useUiStore.getState().clearSelection()
+  }
+
+  return (
+    <div style={{ display: 'flex' }}>
+      <RibbonGroup label="Document">
+        <RibbonButton
+          icon={<NewIcon />}
+          label="New"
+          onClick={handleNew}
+          title="Start a new blank template"
+          testid="toolbar-new"
+        />
+        <RibbonButton
+          icon={<OpenIcon />}
+          label="Open"
+          onClick={() => openInputRef.current?.click()}
+          title="Open a .tgbl template"
+          testid="toolbar-open"
+        />
+        <input ref={openInputRef} type="file" accept=".tgbl" hidden onChange={handleOpenFile} />
+      </RibbonGroup>
+      <RibbonGroup label="Page background">
+        <RibbonButton
+          icon={<BackgroundIcon />}
+          label="Change Background"
+          onClick={() => setShowChangeBgDialog(true)}
+          title="Change the current page's background"
+          testid="toolbar-change-background"
+        />
+      </RibbonGroup>
+    </div>
+  )
+}

--- a/packages/ui/src/components/Toolbar/ribbons/FormatRibbon.tsx
+++ b/packages/ui/src/components/Toolbar/ribbons/FormatRibbon.tsx
@@ -33,9 +33,9 @@ export function FormatRibbon() {
       </RibbonGroup>
       <RibbonGroup label="Typography">
         <RibbonButton
-          label="Fonts…"
+          label="Font Manager"
           onClick={() => setShowFontManager(true)}
-          title="Open the fonts manager"
+          title="Open the font manager"
           testid="ribbon-fonts"
         />
       </RibbonGroup>

--- a/packages/ui/src/components/Toolbar/ribbons/FormatRibbon.tsx
+++ b/packages/ui/src/components/Toolbar/ribbons/FormatRibbon.tsx
@@ -1,0 +1,44 @@
+import { useUiStore } from '../../../store/uiStore.js'
+import { RibbonGroup } from '../primitives/RibbonGroup.js'
+import { RibbonButton } from '../primitives/RibbonButton.js'
+
+/**
+ * Format ribbon (#128). Most formatting controls live in the
+ * field-properties panel today; this ribbon surfaces a deliberate
+ * subset of selection-aware shortcuts (panel toggle + Fonts manager)
+ * and degrades gracefully when nothing is selected — the buttons are
+ * either disabled or document-wide actions only.
+ *
+ * Future work (#62, #64): bring inline font / colour / alignment
+ * controls into this ribbon when a text field is selected.
+ */
+export function FormatRibbon() {
+  const showLeftPanel = useUiStore((s) => s.showLeftPanel)
+  const setShowLeftPanel = useUiStore((s) => s.setShowLeftPanel)
+  const setShowFontManager = useUiStore((s) => s.setShowFontManager)
+  const selectedFieldIds = useUiStore((s) => s.selectedFieldIds)
+  const hasSelection = selectedFieldIds.length > 0
+
+  return (
+    <div style={{ display: 'flex' }}>
+      <RibbonGroup label="Properties">
+        <RibbonButton
+          label={showLeftPanel ? 'Hide panel' : 'Show panel'}
+          onClick={() => setShowLeftPanel(!showLeftPanel)}
+          active={showLeftPanel}
+          variant="toggle"
+          title={hasSelection ? 'Show / hide the properties panel' : 'No field selected'}
+          testid="ribbon-toggle-properties"
+        />
+      </RibbonGroup>
+      <RibbonGroup label="Typography">
+        <RibbonButton
+          label="Fonts…"
+          onClick={() => setShowFontManager(true)}
+          title="Open the fonts manager"
+          testid="ribbon-fonts"
+        />
+      </RibbonGroup>
+    </div>
+  )
+}

--- a/packages/ui/src/components/Toolbar/ribbons/HelpRibbon.tsx
+++ b/packages/ui/src/components/Toolbar/ribbons/HelpRibbon.tsx
@@ -1,0 +1,34 @@
+import { RibbonGroup } from '../primitives/RibbonGroup.js'
+import { RibbonButton } from '../primitives/RibbonButton.js'
+
+/**
+ * Help ribbon (#128). Lightweight today — repo link + a stub for the
+ * keyboard-shortcuts dialog (#117). Lives on its own tab so power users
+ * can find these without crowding the everyday tabs.
+ */
+export function HelpRibbon() {
+  return (
+    <div style={{ display: 'flex' }}>
+      <RibbonGroup label="Resources">
+        <RibbonButton
+          label="GitHub"
+          onClick={() =>
+            window.open('https://github.com/JaiminPatel345/template-goblin', '_blank', 'noopener')
+          }
+          title="Open the TemplateGoblin repository on GitHub"
+          testid="ribbon-help-github"
+        />
+        <RibbonButton
+          label="Shortcuts"
+          onClick={() =>
+            alert(
+              'Keyboard shortcuts:\n  Ctrl+Z — Undo\n  Ctrl+Shift+Z — Redo\n  Ctrl+S — Save\n  Delete / Backspace — Remove selected field\n  Esc — Deselect',
+            )
+          }
+          title="View keyboard shortcuts"
+          testid="ribbon-help-shortcuts"
+        />
+      </RibbonGroup>
+    </div>
+  )
+}

--- a/packages/ui/src/components/Toolbar/ribbons/InsertRibbon.tsx
+++ b/packages/ui/src/components/Toolbar/ribbons/InsertRibbon.tsx
@@ -1,18 +1,28 @@
 import { useTemplateStore } from '../../../store/templateStore.js'
 import { useUiStore } from '../../../store/uiStore.js'
+import { defaultPageNumberConfig } from '@template-goblin/types'
 import { RibbonGroup } from '../primitives/RibbonGroup.js'
 import { RibbonButton } from '../primitives/RibbonButton.js'
 import { PageLayoutIcon } from '../icons.js'
 
 /**
- * Insert ribbon (#128). The most-used insert tools (Text / Image / Table)
- * live in the pinned slot on the menu bar so they're one click away from
- * every tab — this ribbon focuses on the heavier "page layout" insertions
- * (header / footer / page number) that share a single anchored menu.
+ * Insert ribbon (#128, follow-up). The most-used insert tools (Text /
+ * Image / Table) live in the pinned slot on the menu bar so they're one
+ * click away from every tab. This ribbon exposes Header / Footer /
+ * Page Number as three FIRST-CLASS toggles — one click to turn on, one
+ * click on the ⚙ to open detailed settings. Replaces the previous
+ * single "Page Layout" button that required three clicks to enable a
+ * header (open menu → pick Header → click Show).
  */
 export function InsertRibbon() {
   const locked = useTemplateStore((s) => s.meta.locked)
-  const pageLayoutMenuOpen = useUiStore((s) => s.pageLayoutMenu.kind !== 'closed')
+  const headerEnabled = useTemplateStore((s) => !!s.header?.enabled)
+  const footerEnabled = useTemplateStore((s) => !!s.footer?.enabled)
+  const pageNumberEnabled = useTemplateStore((s) => !!s.pageNumber?.enabled)
+  const setHeaderEnabled = useTemplateStore((s) => s.setHeaderEnabled)
+  const setFooterEnabled = useTemplateStore((s) => s.setFooterEnabled)
+  const setPageNumber = useTemplateStore((s) => s.setPageNumber)
+  const setPageLayoutSettings = useUiStore((s) => s.setPageLayoutSettings)
   const hasBackground = useTemplateStore(
     (s) =>
       s.backgroundDataUrl !== null ||
@@ -20,26 +30,87 @@ export function InsertRibbon() {
         (p) => p.index === 0 && (p.backgroundType === 'color' || p.backgroundType === 'image'),
       ),
   )
+  const disabled = locked || !hasBackground
 
-  function togglePageLayout() {
-    useUiStore
-      .getState()
-      .setPageLayoutMenu(pageLayoutMenuOpen ? { kind: 'closed' } : { kind: 'main' })
+  /**
+   * Tiny gear button rendered next to each band toggle. Opens the full
+   * settings modal (`BandSettingsModal`) for that target. If the band is
+   * currently disabled, also enables it so the user gets settings on a
+   * live band in one click rather than two.
+   */
+  function SettingsButton({
+    target,
+    testid,
+  }: {
+    target: 'header' | 'footer' | 'pageNumber'
+    testid: string
+  }) {
+    function handleClick(): void {
+      if (target === 'header' && !headerEnabled) setHeaderEnabled(true)
+      else if (target === 'footer' && !footerEnabled) setFooterEnabled(true)
+      else if (target === 'pageNumber' && !pageNumberEnabled)
+        setPageNumber(defaultPageNumberConfig())
+      setPageLayoutSettings(target)
+    }
+    return (
+      <RibbonButton
+        label="⚙"
+        onClick={handleClick}
+        disabled={disabled}
+        compact
+        title={`Open ${target} settings`}
+        testid={testid}
+        ariaLabel={`${target} settings`}
+        style={{
+          fontSize: 14,
+          minWidth: 26,
+          padding: '4px 6px',
+          color: 'var(--text-muted)',
+        }}
+      />
+    )
   }
 
   return (
     <div style={{ display: 'flex' }}>
-      <RibbonGroup label="Page elements">
+      <RibbonGroup label="Header">
         <RibbonButton
           icon={<PageLayoutIcon />}
-          label="Page Layout"
-          onClick={togglePageLayout}
-          active={pageLayoutMenuOpen}
-          disabled={locked || !hasBackground}
-          title="Page layout (header, footer, page number)"
-          testid="toolbar-page-layout"
-          dataAttrs={{ 'data-page-layout-anchor': 'true' }}
+          label={headerEnabled ? 'On' : 'Off'}
+          onClick={() => setHeaderEnabled(!headerEnabled)}
+          active={headerEnabled}
+          variant="toggle"
+          disabled={disabled}
+          title={headerEnabled ? 'Hide page-wide header' : 'Show a page-wide header'}
+          testid="ribbon-insert-header"
         />
+        <SettingsButton target="header" testid="ribbon-insert-header-settings" />
+      </RibbonGroup>
+      <RibbonGroup label="Footer">
+        <RibbonButton
+          icon={<PageLayoutIcon />}
+          label={footerEnabled ? 'On' : 'Off'}
+          onClick={() => setFooterEnabled(!footerEnabled)}
+          active={footerEnabled}
+          variant="toggle"
+          disabled={disabled}
+          title={footerEnabled ? 'Hide page-wide footer' : 'Show a page-wide footer'}
+          testid="ribbon-insert-footer"
+        />
+        <SettingsButton target="footer" testid="ribbon-insert-footer-settings" />
+      </RibbonGroup>
+      <RibbonGroup label="Page number">
+        <RibbonButton
+          icon={<PageLayoutIcon />}
+          label={pageNumberEnabled ? 'On' : 'Off'}
+          onClick={() => setPageNumber(pageNumberEnabled ? undefined : defaultPageNumberConfig())}
+          active={pageNumberEnabled}
+          variant="toggle"
+          disabled={disabled}
+          title={pageNumberEnabled ? 'Remove page numbers' : 'Add page numbers'}
+          testid="ribbon-insert-pagenumber"
+        />
+        <SettingsButton target="pageNumber" testid="ribbon-insert-pagenumber-settings" />
       </RibbonGroup>
     </div>
   )

--- a/packages/ui/src/components/Toolbar/ribbons/InsertRibbon.tsx
+++ b/packages/ui/src/components/Toolbar/ribbons/InsertRibbon.tsx
@@ -1,0 +1,46 @@
+import { useTemplateStore } from '../../../store/templateStore.js'
+import { useUiStore } from '../../../store/uiStore.js'
+import { RibbonGroup } from '../primitives/RibbonGroup.js'
+import { RibbonButton } from '../primitives/RibbonButton.js'
+import { PageLayoutIcon } from '../icons.js'
+
+/**
+ * Insert ribbon (#128). The most-used insert tools (Text / Image / Table)
+ * live in the pinned slot on the menu bar so they're one click away from
+ * every tab — this ribbon focuses on the heavier "page layout" insertions
+ * (header / footer / page number) that share a single anchored menu.
+ */
+export function InsertRibbon() {
+  const locked = useTemplateStore((s) => s.meta.locked)
+  const pageLayoutMenuOpen = useUiStore((s) => s.pageLayoutMenu.kind !== 'closed')
+  const hasBackground = useTemplateStore(
+    (s) =>
+      s.backgroundDataUrl !== null ||
+      s.pages.some(
+        (p) => p.index === 0 && (p.backgroundType === 'color' || p.backgroundType === 'image'),
+      ),
+  )
+
+  function togglePageLayout() {
+    useUiStore
+      .getState()
+      .setPageLayoutMenu(pageLayoutMenuOpen ? { kind: 'closed' } : { kind: 'main' })
+  }
+
+  return (
+    <div style={{ display: 'flex' }}>
+      <RibbonGroup label="Page elements">
+        <RibbonButton
+          icon={<PageLayoutIcon />}
+          label="Page Layout"
+          onClick={togglePageLayout}
+          active={pageLayoutMenuOpen}
+          disabled={locked || !hasBackground}
+          title="Page layout (header, footer, page number)"
+          testid="toolbar-page-layout"
+          dataAttrs={{ 'data-page-layout-anchor': 'true' }}
+        />
+      </RibbonGroup>
+    </div>
+  )
+}

--- a/packages/ui/src/components/Toolbar/ribbons/InsertRibbon.tsx
+++ b/packages/ui/src/components/Toolbar/ribbons/InsertRibbon.tsx
@@ -1,27 +1,24 @@
 import { useTemplateStore } from '../../../store/templateStore.js'
 import { useUiStore } from '../../../store/uiStore.js'
-import { defaultPageNumberConfig } from '@template-goblin/types'
 import { RibbonGroup } from '../primitives/RibbonGroup.js'
 import { RibbonButton } from '../primitives/RibbonButton.js'
 import { PageLayoutIcon } from '../icons.js'
 
 /**
- * Insert ribbon (#128, follow-up). The most-used insert tools (Text /
- * Image / Table) live in the pinned slot on the menu bar so they're one
- * click away from every tab. This ribbon exposes Header / Footer /
- * Page Number as three FIRST-CLASS toggles — one click to turn on, one
- * click on the ⚙ to open detailed settings. Replaces the previous
- * single "Page Layout" button that required three clicks to enable a
- * header (open menu → pick Header → click Show).
+ * Insert ribbon (#128). Three first-class buttons: Header / Footer /
+ * Page Number. Clicking any of them opens the settings popup
+ * (`BandSettingsModal`) — the Show/Hide toggle lives inside the popup
+ * as the first row, alongside the rest of that band's configuration.
+ * One click, one place, no extra affordances.
+ *
+ * The pinned Text / Image / Table tools live on the menu bar above and
+ * are always reachable regardless of which tab is active.
  */
 export function InsertRibbon() {
   const locked = useTemplateStore((s) => s.meta.locked)
   const headerEnabled = useTemplateStore((s) => !!s.header?.enabled)
   const footerEnabled = useTemplateStore((s) => !!s.footer?.enabled)
   const pageNumberEnabled = useTemplateStore((s) => !!s.pageNumber?.enabled)
-  const setHeaderEnabled = useTemplateStore((s) => s.setHeaderEnabled)
-  const setFooterEnabled = useTemplateStore((s) => s.setFooterEnabled)
-  const setPageNumber = useTemplateStore((s) => s.setPageNumber)
   const setPageLayoutSettings = useUiStore((s) => s.setPageLayoutSettings)
   const hasBackground = useTemplateStore(
     (s) =>
@@ -32,85 +29,39 @@ export function InsertRibbon() {
   )
   const disabled = locked || !hasBackground
 
-  /**
-   * Tiny gear button rendered next to each band toggle. Opens the full
-   * settings modal (`BandSettingsModal`) for that target. If the band is
-   * currently disabled, also enables it so the user gets settings on a
-   * live band in one click rather than two.
-   */
-  function SettingsButton({
-    target,
-    testid,
-  }: {
-    target: 'header' | 'footer' | 'pageNumber'
-    testid: string
-  }) {
-    function handleClick(): void {
-      if (target === 'header' && !headerEnabled) setHeaderEnabled(true)
-      else if (target === 'footer' && !footerEnabled) setFooterEnabled(true)
-      else if (target === 'pageNumber' && !pageNumberEnabled)
-        setPageNumber(defaultPageNumberConfig())
-      setPageLayoutSettings(target)
-    }
-    return (
-      <RibbonButton
-        label="⚙"
-        onClick={handleClick}
-        disabled={disabled}
-        compact
-        title={`Open ${target} settings`}
-        testid={testid}
-        ariaLabel={`${target} settings`}
-        style={{
-          fontSize: 14,
-          minWidth: 26,
-          padding: '4px 6px',
-          color: 'var(--text-muted)',
-        }}
-      />
-    )
-  }
-
   return (
     <div style={{ display: 'flex' }}>
-      <RibbonGroup label="Header">
+      <RibbonGroup label="Page elements">
         <RibbonButton
           icon={<PageLayoutIcon />}
-          label={headerEnabled ? 'On' : 'Off'}
-          onClick={() => setHeaderEnabled(!headerEnabled)}
+          label="Header"
+          onClick={() => setPageLayoutSettings('header')}
           active={headerEnabled}
-          variant="toggle"
+          variant={headerEnabled ? 'toggle' : 'default'}
           disabled={disabled}
-          title={headerEnabled ? 'Hide page-wide header' : 'Show a page-wide header'}
+          title="Configure the page-wide header"
           testid="ribbon-insert-header"
         />
-        <SettingsButton target="header" testid="ribbon-insert-header-settings" />
-      </RibbonGroup>
-      <RibbonGroup label="Footer">
         <RibbonButton
           icon={<PageLayoutIcon />}
-          label={footerEnabled ? 'On' : 'Off'}
-          onClick={() => setFooterEnabled(!footerEnabled)}
+          label="Footer"
+          onClick={() => setPageLayoutSettings('footer')}
           active={footerEnabled}
-          variant="toggle"
+          variant={footerEnabled ? 'toggle' : 'default'}
           disabled={disabled}
-          title={footerEnabled ? 'Hide page-wide footer' : 'Show a page-wide footer'}
+          title="Configure the page-wide footer"
           testid="ribbon-insert-footer"
         />
-        <SettingsButton target="footer" testid="ribbon-insert-footer-settings" />
-      </RibbonGroup>
-      <RibbonGroup label="Page number">
         <RibbonButton
           icon={<PageLayoutIcon />}
-          label={pageNumberEnabled ? 'On' : 'Off'}
-          onClick={() => setPageNumber(pageNumberEnabled ? undefined : defaultPageNumberConfig())}
+          label="Page Number"
+          onClick={() => setPageLayoutSettings('pageNumber')}
           active={pageNumberEnabled}
-          variant="toggle"
+          variant={pageNumberEnabled ? 'toggle' : 'default'}
           disabled={disabled}
-          title={pageNumberEnabled ? 'Remove page numbers' : 'Add page numbers'}
+          title="Configure page numbers"
           testid="ribbon-insert-pagenumber"
         />
-        <SettingsButton target="pageNumber" testid="ribbon-insert-pagenumber-settings" />
       </RibbonGroup>
     </div>
   )

--- a/packages/ui/src/components/Toolbar/ribbons/ViewRibbon.tsx
+++ b/packages/ui/src/components/Toolbar/ribbons/ViewRibbon.tsx
@@ -1,0 +1,93 @@
+import { useUiStore } from '../../../store/uiStore.js'
+import { RibbonGroup } from '../primitives/RibbonGroup.js'
+import { RibbonButton } from '../primitives/RibbonButton.js'
+import { MoonIcon, SunIcon, ZoomInIcon, ZoomOutIcon, PanelLeftIcon } from '../icons.js'
+
+/**
+ * View ribbon (#128). Display preferences: panel visibility, snap to
+ * grid, zoom level, theme toggle. Pulls the previously-scattered
+ * controls (showGrid, zoom, theme, panels) into one logical home.
+ */
+export function ViewRibbon() {
+  const showGrid = useUiStore((s) => s.showGrid)
+  const setShowGrid = useUiStore((s) => s.setShowGrid)
+  const zoom = useUiStore((s) => s.zoom)
+  const zoomIn = useUiStore((s) => s.zoomIn)
+  const zoomOut = useUiStore((s) => s.zoomOut)
+  const resetZoom = useUiStore((s) => s.resetZoom)
+  const theme = useUiStore((s) => s.theme)
+  const toggleTheme = useUiStore((s) => s.toggleTheme)
+  const showLeftPanel = useUiStore((s) => s.showLeftPanel)
+  const setShowLeftPanel = useUiStore((s) => s.setShowLeftPanel)
+  const showRightPanel = useUiStore((s) => s.showRightPanel)
+  const setShowRightPanel = useUiStore((s) => s.setShowRightPanel)
+
+  return (
+    <div style={{ display: 'flex' }}>
+      <RibbonGroup label="Panels">
+        <RibbonButton
+          icon={<PanelLeftIcon />}
+          label="Left"
+          onClick={() => setShowLeftPanel(!showLeftPanel)}
+          active={showLeftPanel}
+          variant="toggle"
+          title={showLeftPanel ? 'Hide properties panel' : 'Show properties panel'}
+          testid="toolbar-toggle-left-panel"
+        />
+        <RibbonButton
+          icon={<PanelLeftIcon />}
+          label="Right"
+          onClick={() => setShowRightPanel(!showRightPanel)}
+          active={showRightPanel}
+          variant="toggle"
+          title={showRightPanel ? 'Hide structure panel' : 'Show structure panel'}
+          testid="toolbar-toggle-right-panel"
+        />
+      </RibbonGroup>
+      <RibbonGroup label="Grid">
+        <RibbonButton
+          label="Snap"
+          onClick={() => setShowGrid(!showGrid)}
+          active={showGrid}
+          variant="toggle"
+          title="Snap fields to a regular grid"
+          testid="ribbon-snap"
+        />
+      </RibbonGroup>
+      <RibbonGroup label="Zoom">
+        <RibbonButton
+          icon={<ZoomOutIcon />}
+          onClick={zoomOut}
+          compact
+          title="Zoom out"
+          testid="ribbon-zoom-out"
+          ariaLabel="Zoom out"
+        />
+        <RibbonButton
+          label={`${Math.round(zoom * 100)}%`}
+          onClick={resetZoom}
+          compact
+          title="Reset zoom to 100%"
+          testid="ribbon-zoom-reset"
+        />
+        <RibbonButton
+          icon={<ZoomInIcon />}
+          onClick={zoomIn}
+          compact
+          title="Zoom in"
+          testid="ribbon-zoom-in"
+          ariaLabel="Zoom in"
+        />
+      </RibbonGroup>
+      <RibbonGroup label="Appearance">
+        <RibbonButton
+          icon={theme === 'light' ? <MoonIcon /> : <SunIcon />}
+          label={theme === 'light' ? 'Dark' : 'Light'}
+          onClick={toggleTheme}
+          title="Toggle theme"
+          testid="ribbon-theme"
+        />
+      </RibbonGroup>
+    </div>
+  )
+}

--- a/packages/ui/src/store/uiStore.ts
+++ b/packages/ui/src/store/uiStore.ts
@@ -49,6 +49,12 @@ export interface UiState {
   /** Whether the font manager dialog is open */
   showFontManager: boolean
   /**
+   * Which top-level tab is active in the menu bar (#128). The ribbon below
+   * the tab strip shows that tab's controls. Defaults to `'insert'` —
+   * empty canvases bias toward "add something next".
+   */
+  activeMenuTab: 'file' | 'edit' | 'insert' | 'format' | 'view' | 'help'
+  /**
    * Anchored Page Layout menu state (#61, follow-up).
    *
    * Mirrors the Word / Google Docs Insert → Header & Footer pattern:
@@ -125,6 +131,8 @@ export interface UiState {
   setShowPageSizeDialog: (show: boolean) => void
   setShowChangeBgDialog: (show: boolean) => void
   setShowFontManager: (show: boolean) => void
+  /** Switch the top-level menu tab (#128). The ribbon swaps to match. */
+  setActiveMenuTab: (tab: UiState['activeMenuTab']) => void
   /** Update the Page Layout menu state (toolbar-anchored dropdown). */
   setPageLayoutMenu: (
     next:
@@ -166,6 +174,7 @@ export const useUiStore = create<UiState>()(
       showPageSizeDialog: false,
       showChangeBgDialog: false,
       showFontManager: false,
+      activeMenuTab: 'insert' as const,
       pageLayoutMenu: { kind: 'closed' },
       pageLayoutSettings: null,
       pendingBackground: null,
@@ -214,6 +223,7 @@ export const useUiStore = create<UiState>()(
       setShowPageSizeDialog: (show) => set({ showPageSizeDialog: show }),
       setShowChangeBgDialog: (show) => set({ showChangeBgDialog: show }),
       setShowFontManager: (show) => set({ showFontManager: show }),
+      setActiveMenuTab: (tab) => set({ activeMenuTab: tab }),
       setPageLayoutMenu: (next) => set({ pageLayoutMenu: next }),
       setPageLayoutSettings: (target) =>
         set((state) => ({


### PR DESCRIPTION
## Summary

The single-row 657-line \`Toolbar.tsx\` crammed every action together with no grouping. Replaced with a two-row Word-style shell.

**Row 1 — Menu tab strip:**
File · Edit · Insert · Format · View · Help &nbsp;|&nbsp; pinned tools (Text · Image · Table) &nbsp;|&nbsp; Preview · Save · Lock

**Row 2 — Ribbon:** swaps to match the active tab.

Tabs:
- **File** — New · Open · Change Background
- **Edit** — Undo · Redo
- **Insert** — Header · Footer · Page Number (each opens a settings popup with the show/hide toggle + all options)
- **Format** — Properties panel toggle · Font Manager
- **View** — Toggle left/right panels · Snap · Zoom · Theme
- **Help** — GitHub · Shortcuts

Page Number placement can land in either Header or Footer regardless of whether the chosen band is currently enabled — the store auto-creates+enables the target band on placement pick.

## File structure under \`Toolbar/\`
\`Toolbar.tsx\` orchestrator + empty-state · \`MenuTabBar.tsx\` · \`RibbonBar.tsx\` · \`icons.tsx\` (inline SVGs, Hard Rule #7) · \`primitives/{MenuButton,RibbonButton,RibbonGroup}.tsx\` · \`ribbons/{File,Edit,Insert,Format,View,Help}Ribbon.tsx\`. Every new file under 200 LOC; Hard Rule #11 satisfied throughout.

## Theming

CSS variables (\`--bg-secondary\`, \`--bg-tertiary\`, \`--text-primary\`, \`--accent\`, …). Every button uses \`.tg-ribbon-btn\` or \`.tg-menu-tab\` classes so Tailwind v4 preflight's base-layer \`button { background-color: transparent }\` can't strip the active highlight (had to discover this the hard way — inline style with a CSS variable wasn't overriding preflight).

## Test plan

- [x] **30+ new Playwright tests** in \`e2e/navbar-redesign.spec.ts\` covering every navbar button: tab strip, pinned tools (incl. locked-disable + tab-persistence), CTAs (Preview/Save/Lock), each ribbon's actions, Page Number auto-create-band scenarios, theme styling
- [x] \`e2e/header-footer.spec.ts\` rewritten for the single-button popup flow (5 tests)
- [x] Existing band/colour/onboarding/page-dim/change-bg specs updated to the new selectors
- [x] Touched-area sweep: **87 pass / 1 unrelated skip** across 11 specs
- [x] 433 core unit + 507 UI unit + type-check + lint + production build all clean
- [x] Live Chrome verification: every tab swap, every CTA, every band toggle, light/dark theme switching, active-state highlight all painted correctly

Closes #128.