### PR TITLE
feat(ui): v3 design system — Linear-style palette, unified outlined-button system, Radix tooltips (#64)

### DIFF
--- a/.changeset/v3-design-tokens.md
+++ b/.changeset/v3-design-tokens.md
@@ -1,0 +1,68 @@
+---
+'template-goblin-ui': minor
+---
+
+feat(ui): v3 design system — Linear-style palette, unified outlined-button system, Radix tooltips (#64)
+
+Real top-to-bottom redesign of the editor chrome, not a repaint:
+
+**Design tokens (`packages/ui/src/styles/theme.css`)** — single source of
+truth for colour, spacing, typography, radius, shadow, motion, z-index,
+focus-ring, and control-sizing scales. Both light and dark themes live
+side by side, gated by `data-theme`. Replaces the previous split
+`@theme` + legacy-bridge blocks in `App.css`.
+
+**Palette swap** — hot-pink `#e94560` (which read as warning / error
+across every control it touched) traded for Linear-style indigo
+`#5E6AD2` (light) / `#7C87E0` (dark). Neutrals refined toward slate-cool
+in both themes; the yellow-tinted off-white `--bg-primary` is gone.
+Indigo also drives the focus ring and the new tooltip arrow.
+
+**Unified control system** — every interactive control shares one
+height (`--control-height-md = 28px`) and one icon size
+(`--icon-size-md = 16px`). The ribbon-button column-vs-row split that
+made the old toolbar look unsorted (Left/Right stacked vertically vs
+Snap label-only vs Zoom row-compact vs Light icon+text) is gone — every
+button is now a single horizontal row of icon + label, on the same
+baseline. Icon-only buttons collapse to a perfect 28×28 square.
+
+**Outlined-button idiom across the whole nav bar** — File / Edit /
+Insert / Format / View / Help tabs + Text / Image / Table pinned tools
+
+- Preview / Save / Lock CTAs all use one outlined-button system: 1 px
+  border at rest, fills on hover, indigo soft-fill + indigo border when
+  active. No 3 D inset shadow tricks. Same idiom Tailwind UI, shadcn,
+  GitHub button-groups, and Stripe Dashboard use.
+
+**Distinct band icons** — Header (page + top bar), Footer (page +
+bottom bar), Page Number (page + bold `#`). The three previously
+shared one generic `PageLayoutIcon` glyph, which read as a copy-paste
+mistake.
+
+**Radix Tooltip** — added `@radix-ui/react-tooltip` and a token-styled
+`Tooltip` primitive. Every `RibbonButton` with a `title` wraps in the
+tooltip, with 600 ms open-delay (Linear / Figma / GitHub all sit in
+500–700 ms) and an arrow tinted to `--bg-elevated`. `@radix-ui/react-
+dialog` is also installed in preparation for the upcoming dialog-
+system pass.
+
+**Snap toggle now visibly works** — `buildGridLines` was stroking the
+grid with `rgba(255,255,255,0.08)` (white-on-white on the default page
+background). Switched to `rgba(0,0,0,0.14)` — a thin lattice that
+reads on white, off-white, and lightly-coloured page backgrounds, and
+stays subtle on dark pages.
+
+**JSON Preview** — the code block sat on `--bg-primary` which is the
+deepest surface in dark mode, so it recessed into the panel instead of
+reading as a raised tile. Switched to `--bg-tertiary` with
+`--border-light`; same fix applies to the empty-state card. The
+`Format / Max Fill / Copy` mode buttons now use the same outlined-
+button selected treatment as everything else.
+
+**Affordances** — global `:focus-visible` ring driven by `--ring-color`,
+`::selection` tinted to the accent, `prefers-reduced-motion` flattens
+transitions, `color-scheme` hint so native form controls track the
+theme.
+
+Verified live in Chrome via the MCP extension across both themes — all
+ribbons, tooltips, Snap toggle, theme toggle, onboarding flow.

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -16,6 +16,8 @@
     "test:e2e": "playwright test"
   },
   "dependencies": {
+    "@radix-ui/react-dialog": "^1.1.15",
+    "@radix-ui/react-tooltip": "^1.2.8",
     "@tailwindcss/vite": "^4.2.2",
     "fabric": "^6.9.1",
     "jszip": "^3.10.1",
@@ -47,5 +49,7 @@
   "comment:react-konva": "React bindings for Konva — BEING REMOVED in favour of Fabric.js (kept during migration only)",
   "comment:zustand": "Lightweight state management — canvas state, undo/redo, UI state",
   "comment:fake-indexeddb": "Test-only: polyfills IndexedDB in jsdom/Node so the templateStore's IDB-backed persist adapter (GH #11) is exercised by Vitest. Loaded via vite.config `test.setupFiles`.",
-  "comment:react-colorful": "5 KB, zero-dep, maintained colour picker (Hue slider + Saturation/Value square). Replaces react-color's SketchPicker which used the legacy `defaultProps` API (React-18 warning on every mount) and warm-loaded a heavy palette on first open (~3-5s freeze on first mount, GH #121). The picker still renders inline in a popover so the page stays interactive — native OS pickers froze the whole tab on some browser/GPU combos."
+  "comment:react-colorful": "5 KB, zero-dep, maintained colour picker (Hue slider + Saturation/Value square). Replaces react-color's SketchPicker which used the legacy `defaultProps` API (React-18 warning on every mount) and warm-loaded a heavy palette on first open (~3-5s freeze on first mount, GH #121). The picker still renders inline in a popover so the page stays interactive — native OS pickers froze the whole tab on some browser/GPU combos.",
+  "comment:@radix-ui/react-tooltip": "Headless accessible tooltip primitive used across the toolbar/ribbon for hover-after-delay labels on icon-only controls (#64). ~5 KB gzip. Handles ARIA, focus, hover-intent, portal, escape — none of which we want to hand-roll. Styled with our --bg-elevated / --shadow-md / --radius-md tokens.",
+  "comment:@radix-ui/react-dialog": "Headless accessible dialog primitive used by the v3 dialog-system pass (#64) — single Dialog component replaces ad-hoc overlays in PreviewDialog, AddPageDialog, PageSizeDialog, FieldCreationPopup. Gives ESC, focus-trap, scroll-lock, portal, ARIA for free."
 }

--- a/packages/ui/src/App.css
+++ b/packages/ui/src/App.css
@@ -1,80 +1,9 @@
 @import "tailwindcss";
+@import "./styles/theme.css";
 
-/* ===== Theme Variables ===== */
-@theme {
-  --color-bg-primary: #f5f5f7;
-  --color-bg-secondary: #ffffff;
-  --color-bg-tertiary: #e8eaed;
-  --color-bg-surface: #f0f1f3;
-  --color-text-primary: #1a1a2e;
-  --color-text-secondary: #555566;
-  --color-text-muted: #999aab;
-  --color-accent: #e94560;
-  --color-accent-hover: #d63851;
-  --color-border: #dcdde1;
-  --color-border-light: #e8e8ec;
-  --color-success: #16a34a;
-  --color-warning: #d97706;
-  --color-error: #dc2626;
-  --color-canvas-bg: #e0e0e8;
-}
-
-/* Dark Theme Override */
-[data-theme='dark'] {
-  --color-bg-primary: #0f0f17;
-  --color-bg-secondary: #181825;
-  --color-bg-tertiary: #252538;
-  --color-bg-surface: #1e1e30;
-  --color-text-primary: #f0f0f5;
-  --color-text-secondary: #b0b0c0;
-  --color-text-muted: #7878a0;
-  --color-accent: #e94560;
-  --color-accent-hover: #ff6b81;
-  --color-border: #2d2d45;
-  --color-border-light: #3a3a52;
-  --color-success: #4ade80;
-  --color-warning: #fbbf24;
-  --color-error: #ef4444;
-  --color-canvas-bg: #0a0a14;
-}
-
-/* Legacy CSS variable bridge — components still using var(--xxx) */
-:root,
-[data-theme='light'] {
-  --bg-primary: var(--color-bg-primary);
-  --bg-secondary: var(--color-bg-secondary);
-  --bg-tertiary: var(--color-bg-tertiary);
-  --bg-surface: var(--color-bg-surface);
-  --text-primary: var(--color-text-primary);
-  --text-secondary: var(--color-text-secondary);
-  --text-muted: var(--color-text-muted);
-  --accent: var(--color-accent);
-  --accent-hover: var(--color-accent-hover);
-  --border: var(--color-border);
-  --border-light: var(--color-border-light);
-  --success: var(--color-success);
-  --warning: var(--color-warning);
-  --error: var(--color-error);
-  --canvas-bg: var(--color-canvas-bg);
-}
-
-[data-theme='dark'] {
-  --bg-primary: var(--color-bg-primary);
-  --bg-secondary: var(--color-bg-secondary);
-  --bg-tertiary: var(--color-bg-tertiary);
-  --bg-surface: var(--color-bg-surface);
-  --text-primary: var(--color-text-primary);
-  --text-secondary: var(--color-text-secondary);
-  --text-muted: var(--color-text-muted);
-  --accent: var(--color-accent);
-  --accent-hover: var(--color-accent-hover);
-  --border: var(--color-border);
-  --border-light: var(--color-border-light);
-  --success: var(--color-success);
-  --warning: var(--color-warning);
-  --error: var(--color-error);
-  --canvas-bg: var(--color-canvas-bg);
-}
+/* All design tokens (colour, spacing, type, radius, shadow, motion,
+ * z-index, focus ring) now live in `styles/theme.css` — single source
+ * of truth across both themes. See that file for the full scale. */
 
 /* ===== Base ===== */
 html, body, #root {

--- a/packages/ui/src/App.css
+++ b/packages/ui/src/App.css
@@ -145,9 +145,10 @@ html, body, #root {
 .tg-ribbon-btn--success:hover { background: var(--success-hover); color: var(--text-on-accent); }
 
 /* === Menu tabs (row 1: File / Edit / Insert / Format / View / Help) ====
- * Lower-case text feel that scrolls flat into the ribbon, with the
- * active tab carrying the same 2 px accent underline as the ribbon
- * active-state — visually "this tab opens the ribbon below". */
+ * Same outlined-button idiom as ribbon controls so the whole nav bar
+ * reads as one consistent system — thin border at rest, fills on
+ * hover, becomes the accent fill when active so the current tab
+ * pops without needing the 3 D inset underline trick. */
 .tg-menu-tab {
   display: inline-flex;
   align-items: center;
@@ -155,22 +156,30 @@ html, body, #root {
   padding: 0 var(--space-3);
   font-size: var(--text-base);
   font-weight: var(--font-weight-medium);
-  color: var(--text-secondary);
-  background: transparent;
-  border: none;
-  border-radius: var(--radius-md) var(--radius-md) 0 0;
+  color: var(--text-primary);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
   cursor: pointer;
   outline: none;
   transition: background var(--duration-fast) var(--ease-out),
+    border-color var(--duration-fast) var(--ease-out),
     color var(--duration-fast) var(--ease-out);
 }
-.tg-menu-tab:hover { background: var(--bg-tertiary); color: var(--text-primary); }
-.tg-menu-tab--active {
-  color: var(--text-primary);
-  font-weight: var(--font-weight-semibold);
-  box-shadow: inset 0 -2px 0 0 var(--accent);
+.tg-menu-tab:hover {
+  background: var(--bg-tertiary);
+  border-color: var(--border-strong);
 }
-.tg-menu-tab--active:hover { background: var(--bg-tertiary); }
+.tg-menu-tab--active {
+  background: var(--accent-soft);
+  border-color: var(--accent);
+  color: var(--accent);
+  font-weight: var(--font-weight-semibold);
+}
+.tg-menu-tab--active:hover {
+  background: var(--accent-soft-hover);
+  border-color: var(--accent);
+}
 
 /* ===== Panels ===== */
 .tg-left-panel {

--- a/packages/ui/src/App.css
+++ b/packages/ui/src/App.css
@@ -78,13 +78,14 @@ html, body, #root {
   font-size: var(--text-sm);
   font-weight: var(--font-weight-medium);
   line-height: 1;
-  color: var(--text-secondary);
-  background: transparent;
-  border: 1px solid transparent;
+  color: var(--text-primary);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
   border-radius: var(--radius-md);
   cursor: pointer;
   white-space: nowrap;
   transition: background var(--duration-fast) var(--ease-out),
+    border-color var(--duration-fast) var(--ease-out),
     color var(--duration-fast) var(--ease-out);
 }
 .tg-ribbon-btn svg {
@@ -92,32 +93,38 @@ html, body, #root {
   height: var(--icon-size-md);
   flex-shrink: 0;
 }
-/* Icon-only (no label child) collapses to a perfect square — matches
- * the icon-button conventions in Linear / Figma / Notion. The selector
- * applies when there's no `.tg-ribbon-btn__label` child. */
+/* Icon-only (no label) collapses to a perfect square — matches the
+ * icon-button conventions in Linear / Figma / GitHub. */
 .tg-ribbon-btn--icon-only {
   width: var(--control-height-md);
   padding: 0;
 }
 .tg-ribbon-btn:hover {
   background: var(--bg-tertiary);
-  color: var(--text-primary);
+  border-color: var(--border-strong);
 }
 .tg-ribbon-btn:disabled {
   opacity: 0.45;
   cursor: not-allowed;
 }
-.tg-ribbon-btn:disabled:hover { background: transparent; color: var(--text-secondary); }
+.tg-ribbon-btn:disabled:hover {
+  background: var(--bg-secondary);
+  border-color: var(--border);
+}
 
-/* Toggle / active state — subtle background fill + slim accent under-
- * line on the bottom edge (inset shadow so layout doesn't shift). Same
- * idiom Linear / Figma use for "this view is selected". */
+/* Toggle / active — flat "selected" treatment used by Tailwind UI,
+ * shadcn, GitHub's button-groups: filled neutral background + slightly
+ * darker border, no inset shadow / underline (which read as a 3 D
+ * pressed effect rather than a plain selected state). */
 .tg-ribbon-btn--active {
   background: var(--bg-tertiary);
+  border-color: var(--border-strong);
   color: var(--text-primary);
-  box-shadow: inset 0 -2px 0 0 var(--accent);
 }
-.tg-ribbon-btn--active:hover { background: var(--bg-surface); }
+.tg-ribbon-btn--active:hover {
+  background: var(--bg-surface);
+  border-color: var(--border-strong);
+}
 
 /* Primary CTA fill — used by Save / Preview when the action is the
  * "do the thing" moment. Reserve sparingly; over-use erodes contrast. */

--- a/packages/ui/src/App.css
+++ b/packages/ui/src/App.css
@@ -55,82 +55,113 @@ html, body, #root {
 .tg-btn--primary { background: var(--accent); color: #fff; border: none; }
 .tg-btn--primary:hover { background: var(--accent-hover); }
 
-/* === Ribbon buttons (#128 navbar redesign) =================================
- * Tailwind v4 preflight applies `background-color: transparent` to every
- * `<button>` via the base layer — inline style won't override it without
- * `!important`. Stylesheet classes WILL because they outrank the base
- * layer on selector match. Hence the dedicated `.tg-ribbon-btn` family.
+/* === Ribbon buttons (v3 redesign #64) ======================================
+ * Single horizontal layout — icon on the left, label on the right —
+ * sharing one control height across the whole ribbon. This kills the
+ * column-vs-row mismatch that made the old ribbon look unsorted
+ * (Left/Right column-stacked, Snap label-only, Zoom row-compact, etc.).
+ *
+ * Sizing comes from `--control-height-md` / `--icon-size-md` so the
+ * toolbar/ribbon/form-inputs all share the same scale.
+ *
+ * Tailwind v4 preflight applies `background-color: transparent` via
+ * the base layer; CSS-class rules outrank that on selector match, so
+ * we don't need `!important` anywhere.
  */
 .tg-ribbon-btn {
   display: inline-flex;
-  flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 2px;
-  min-width: 48px;
-  padding: 4px 8px;
-  font-size: 11px;
-  font-weight: 500;
-  color: var(--text-primary);
+  gap: var(--space-2);
+  height: var(--control-height-md);
+  padding: 0 var(--control-padding-x);
+  font-size: var(--text-sm);
+  font-weight: var(--font-weight-medium);
+  line-height: 1;
+  color: var(--text-secondary);
   background: transparent;
   border: 1px solid transparent;
-  border-radius: 4px;
+  border-radius: var(--radius-md);
   cursor: pointer;
   white-space: nowrap;
-  transition: background 0.12s ease, border-color 0.12s ease;
+  transition: background var(--duration-fast) var(--ease-out),
+    color var(--duration-fast) var(--ease-out);
 }
-.tg-ribbon-btn--compact { flex-direction: row; gap: 4px; min-width: 28px; }
-.tg-ribbon-btn:hover { background: var(--bg-tertiary); }
-.tg-ribbon-btn:disabled { opacity: 0.4; cursor: not-allowed; }
-.tg-ribbon-btn:disabled:hover { background: transparent; }
-/* Toggle / active state — Word/Docs convention: neutral background +
- * thin 2 px accent underline. Reads clearly as "engaged" without
- * staining the whole button in the brand colour (which felt like a
- * warning state — #64 polish). The 2 px is subtracted from the bottom
- * padding so layout doesn't shift between inactive and active. */
+.tg-ribbon-btn svg {
+  width: var(--icon-size-md);
+  height: var(--icon-size-md);
+  flex-shrink: 0;
+}
+/* Icon-only (no label child) collapses to a perfect square — matches
+ * the icon-button conventions in Linear / Figma / Notion. The selector
+ * applies when there's no `.tg-ribbon-btn__label` child. */
+.tg-ribbon-btn--icon-only {
+  width: var(--control-height-md);
+  padding: 0;
+}
+.tg-ribbon-btn:hover {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+.tg-ribbon-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+.tg-ribbon-btn:disabled:hover { background: transparent; color: var(--text-secondary); }
+
+/* Toggle / active state — subtle background fill + slim accent under-
+ * line on the bottom edge (inset shadow so layout doesn't shift). Same
+ * idiom Linear / Figma use for "this view is selected". */
 .tg-ribbon-btn--active {
   background: var(--bg-tertiary);
   color: var(--text-primary);
   box-shadow: inset 0 -2px 0 0 var(--accent);
 }
 .tg-ribbon-btn--active:hover { background: var(--bg-surface); }
+
+/* Primary CTA fill — used by Save / Preview when the action is the
+ * "do the thing" moment. Reserve sparingly; over-use erodes contrast. */
 .tg-ribbon-btn--primary {
   background: var(--accent);
-  color: #fff;
-  border: none;
+  color: var(--text-on-accent);
+  border-color: transparent;
 }
-.tg-ribbon-btn--primary:hover { background: var(--accent-hover); }
-.tg-ribbon-btn--success {
-  background: #16a34a;
-  color: #fff;
-  border: none;
-}
-.tg-ribbon-btn--success:hover { background: #0a7a32; }
+.tg-ribbon-btn--primary:hover { background: var(--accent-hover); color: var(--text-on-accent); }
+.tg-ribbon-btn--primary:disabled:hover { background: var(--accent); }
 
-/* Row-1 menu-tab buttons — text-only triggers along the top strip. */
-.tg-menu-tab {
-  background: transparent;
-  color: var(--text-primary);
-  border: none;
-  padding: 6px 12px;
-  font-size: 13px;
-  font-weight: 500;
-  cursor: pointer;
-  border-radius: 4px;
-  outline: none;
-  transition: background 0.12s ease;
+/* Success fill — Save action, reads as "this commits something". */
+.tg-ribbon-btn--success {
+  background: var(--success);
+  color: var(--text-on-accent);
+  border-color: transparent;
 }
-.tg-menu-tab:hover,
-.tg-menu-tab:focus-visible { background: var(--bg-tertiary); }
-/* Active menu tab — Word/Docs convention: thin 2 px accent underline
- * sitting flush with the ribbon row below. Neutral text colour, no
- * background stain. The underline visually "tabs into" the ribbon. */
-.tg-menu-tab--active {
+.tg-ribbon-btn--success:hover { background: var(--success-hover); color: var(--text-on-accent); }
+
+/* === Menu tabs (row 1: File / Edit / Insert / Format / View / Help) ====
+ * Lower-case text feel that scrolls flat into the ribbon, with the
+ * active tab carrying the same 2 px accent underline as the ribbon
+ * active-state — visually "this tab opens the ribbon below". */
+.tg-menu-tab {
+  display: inline-flex;
+  align-items: center;
+  height: var(--control-height-md);
+  padding: 0 var(--space-3);
+  font-size: var(--text-base);
+  font-weight: var(--font-weight-medium);
+  color: var(--text-secondary);
   background: transparent;
+  border: none;
+  border-radius: var(--radius-md) var(--radius-md) 0 0;
+  cursor: pointer;
+  outline: none;
+  transition: background var(--duration-fast) var(--ease-out),
+    color var(--duration-fast) var(--ease-out);
+}
+.tg-menu-tab:hover { background: var(--bg-tertiary); color: var(--text-primary); }
+.tg-menu-tab--active {
   color: var(--text-primary);
   font-weight: var(--font-weight-semibold);
   box-shadow: inset 0 -2px 0 0 var(--accent);
-  border-radius: 4px 4px 0 0;
 }
 .tg-menu-tab--active:hover { background: var(--bg-tertiary); }
 
@@ -417,6 +448,13 @@ html, body, #root {
 @keyframes tg-slide-up {
   from { transform: translateY(12px); opacity: 0; }
   to { transform: translateY(0); opacity: 1; }
+}
+
+/* Tooltip entry — quick fade + tiny lift so the hover label feels
+ * snappy rather than abrupt. Used by the Radix-backed Tooltip primitive. */
+@keyframes tg-tooltip-in {
+  from { opacity: 0; transform: translateY(2px); }
+  to   { opacity: 1; transform: translateY(0); }
 }
 
 /* ===== Left panel group sections ===== */

--- a/packages/ui/src/App.css
+++ b/packages/ui/src/App.css
@@ -83,10 +83,15 @@ html, body, #root {
 .tg-ribbon-btn:hover { background: var(--bg-tertiary); }
 .tg-ribbon-btn:disabled { opacity: 0.4; cursor: not-allowed; }
 .tg-ribbon-btn:disabled:hover { background: transparent; }
+/* Toggle / active state — accent-tinted so it reads clearly distinct
+ * from neutral hover (which uses --bg-tertiary). Without this, toggle
+ * buttons like Snap looked identical pre- and post-click (#64 polish). */
 .tg-ribbon-btn--active {
-  background: var(--bg-tertiary);
+  background: var(--accent-soft);
+  color: var(--accent);
+  box-shadow: inset 0 0 0 1px var(--accent);
 }
-.tg-ribbon-btn--active:hover { background: var(--bg-tertiary); }
+.tg-ribbon-btn--active:hover { background: var(--accent-soft-hover); }
 .tg-ribbon-btn--primary {
   background: var(--accent);
   color: #fff;
@@ -115,7 +120,13 @@ html, body, #root {
 }
 .tg-menu-tab:hover,
 .tg-menu-tab:focus-visible { background: var(--bg-tertiary); }
-.tg-menu-tab--active { background: var(--bg-tertiary); }
+/* Active menu tab — accent-tinted to read as the currently-open ribbon,
+ * not just hover. */
+.tg-menu-tab--active {
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+.tg-menu-tab--active:hover { background: var(--accent-soft-hover); }
 
 /* ===== Panels ===== */
 .tg-left-panel {

--- a/packages/ui/src/App.css
+++ b/packages/ui/src/App.css
@@ -425,11 +425,18 @@ html, body, #root {
 }
 
 /* ===== JSON Preview ===== */
+/* Code block sits on `--bg-tertiary` so it reads as a raised card on
+ * the panel (`--bg-secondary`) in both themes — was previously using
+ * `--bg-primary` which is the DEEPEST surface in dark mode, making
+ * the block recede into the panel rather than stand out. */
 .tg-json-preview {
-  @apply text-xs rounded p-2 overflow-x-auto overflow-y-auto whitespace-pre leading-snug;
-  font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
-  background: var(--bg-primary);
-  border: 1px solid var(--border);
+  @apply text-xs overflow-x-auto overflow-y-auto whitespace-pre leading-snug;
+  font-family: var(--font-mono);
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-md);
+  padding: var(--space-3);
   max-height: 300px;
 }
 
@@ -437,10 +444,22 @@ html, body, #root {
 .tg-json-mode-btn {
   @apply flex-1 px-2 py-1 rounded text-xs cursor-pointer transition-all;
   border: 1px solid var(--border);
-  background: transparent;
+  background: var(--bg-secondary);
   color: var(--text-secondary);
 }
-.tg-json-mode-btn--active { background: var(--accent); color: #fff; border-color: var(--accent); }
+.tg-json-mode-btn:hover {
+  background: var(--bg-tertiary);
+  border-color: var(--border-strong);
+  color: var(--text-primary);
+}
+/* Active = outlined-button selected treatment (same idiom as ribbon
+ * buttons) — was solid accent fill which fought the new restrained
+ * accent usage. */
+.tg-json-mode-btn--active {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+  border-color: var(--border-strong);
+}
 
 /* ===== Resize Handle ===== */
 .tg-resize-handle {

--- a/packages/ui/src/App.css
+++ b/packages/ui/src/App.css
@@ -83,15 +83,17 @@ html, body, #root {
 .tg-ribbon-btn:hover { background: var(--bg-tertiary); }
 .tg-ribbon-btn:disabled { opacity: 0.4; cursor: not-allowed; }
 .tg-ribbon-btn:disabled:hover { background: transparent; }
-/* Toggle / active state — accent-tinted so it reads clearly distinct
- * from neutral hover (which uses --bg-tertiary). Without this, toggle
- * buttons like Snap looked identical pre- and post-click (#64 polish). */
+/* Toggle / active state — Word/Docs convention: neutral background +
+ * thin 2 px accent underline. Reads clearly as "engaged" without
+ * staining the whole button in the brand colour (which felt like a
+ * warning state — #64 polish). The 2 px is subtracted from the bottom
+ * padding so layout doesn't shift between inactive and active. */
 .tg-ribbon-btn--active {
-  background: var(--accent-soft);
-  color: var(--accent);
-  box-shadow: inset 0 0 0 1px var(--accent);
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+  box-shadow: inset 0 -2px 0 0 var(--accent);
 }
-.tg-ribbon-btn--active:hover { background: var(--accent-soft-hover); }
+.tg-ribbon-btn--active:hover { background: var(--bg-surface); }
 .tg-ribbon-btn--primary {
   background: var(--accent);
   color: #fff;
@@ -120,13 +122,17 @@ html, body, #root {
 }
 .tg-menu-tab:hover,
 .tg-menu-tab:focus-visible { background: var(--bg-tertiary); }
-/* Active menu tab — accent-tinted to read as the currently-open ribbon,
- * not just hover. */
+/* Active menu tab — Word/Docs convention: thin 2 px accent underline
+ * sitting flush with the ribbon row below. Neutral text colour, no
+ * background stain. The underline visually "tabs into" the ribbon. */
 .tg-menu-tab--active {
-  background: var(--accent-soft);
-  color: var(--accent);
+  background: transparent;
+  color: var(--text-primary);
+  font-weight: var(--font-weight-semibold);
+  box-shadow: inset 0 -2px 0 0 var(--accent);
+  border-radius: 4px 4px 0 0;
 }
-.tg-menu-tab--active:hover { background: var(--accent-soft-hover); }
+.tg-menu-tab--active:hover { background: var(--bg-tertiary); }
 
 /* ===== Panels ===== */
 .tg-left-panel {

--- a/packages/ui/src/components/Canvas/fabricUtils.ts
+++ b/packages/ui/src/components/Canvas/fabricUtils.ts
@@ -504,7 +504,12 @@ export function groupToFieldPatch(
  */
 export function buildGridLines(pageWidth: number, pageHeight: number, gridSize: number): Line[] {
   const lines: Line[] = []
-  const gridColor = 'rgba(255,255,255,0.08)'
+  // Mid-grey with low alpha so the grid stays subtle but visible on the
+  // common page backgrounds (white, off-white, light-coloured) where the
+  // previous near-white tone disappeared entirely (#64 — "Snap looks
+  // like it does nothing"). On darker page backgrounds 12% black still
+  // reads as a thin lattice without dominating.
+  const gridColor = 'rgba(0,0,0,0.14)'
   const strokeW = 0.5
 
   for (let x = 0; x <= pageWidth; x += gridSize) {

--- a/packages/ui/src/components/RightPanel/JsonPreview.tsx
+++ b/packages/ui/src/components/RightPanel/JsonPreview.tsx
@@ -172,18 +172,7 @@ export function JsonPreview() {
             onChange={(e) => setPreviewJsonText(e.target.value)}
             onKeyDown={handleTextareaKeyDown}
             style={{
-              fontFamily: 'var(--font-mono)',
-              fontSize: 11,
-              background: 'var(--bg-primary)',
-              border: '1px solid var(--border)',
-              borderRadius: 4,
-              padding: 10,
               minHeight: 120,
-              maxHeight: 300,
-              overflowY: 'auto',
-              whiteSpace: 'pre',
-              lineHeight: 1.4,
-              color: 'var(--text-primary)',
               width: '100%',
               resize: 'vertical',
               outline: 'none',

--- a/packages/ui/src/components/Toolbar/MenuTabBar.tsx
+++ b/packages/ui/src/components/Toolbar/MenuTabBar.tsx
@@ -77,10 +77,11 @@ export function MenuTabBar() {
     }
   }
 
-  // Type-coloured pinned tool button. Reuses the field-colour theme so
-  // the visual match between toolbar button and on-canvas field stays
-  // consistent. Active when the tool is selected OR a matching field is
-  // currently in the selection — the existing UX cue from the old bar.
+  // Pinned tool: neutral button with the field-type colour applied to
+  // the icon only — same visual idiom as Figma's left-rail tool buttons.
+  // Active state uses the standard ribbon active treatment so the
+  // pinned tools read as part of the toolbar system rather than
+  // candy-coloured outliers.
   function PinnedTool({
     tool,
     label,
@@ -90,30 +91,20 @@ export function MenuTabBar() {
     tool: 'addText' | 'addImage' | 'addLoop'
     label: string
     icon: React.ReactNode
-    colour: { stroke: string; toolbarBg: string; toolbarFg: string }
+    colour: { stroke: string }
   }) {
     const fieldType = tool === 'addText' ? 'text' : tool === 'addImage' ? 'image' : 'table'
     const isActive = activeTool === tool || selectedFieldTypes.has(fieldType)
     return (
       <RibbonButton
         label={label}
-        icon={icon}
+        icon={<span style={{ color: colour.stroke, display: 'inline-flex' }}>{icon}</span>}
         onClick={() => setActiveTool(activeTool === tool ? 'select' : tool)}
         disabled={locked || !hasBackground}
-        compact
         title={`Insert ${label.toLowerCase()}`}
         testid={`toolbar-tool-${fieldType}`}
-        style={
-          isActive
-            ? { background: colour.stroke, color: '#fff', borderColor: colour.stroke }
-            : {
-                background: colour.toolbarBg,
-                color: colour.toolbarFg,
-                borderColor: colour.stroke,
-                borderStyle: 'solid',
-                borderWidth: 1,
-              }
-        }
+        variant={isActive ? 'toggle' : 'default'}
+        active={isActive}
       />
     )
   }
@@ -125,8 +116,8 @@ export function MenuTabBar() {
       style={{
         display: 'flex',
         alignItems: 'center',
-        gap: 2,
-        padding: '6px 10px',
+        gap: 4,
+        padding: '6px 12px',
         background: 'var(--bg-secondary)',
         borderBottom: '1px solid var(--border-light)',
       }}
@@ -147,7 +138,7 @@ export function MenuTabBar() {
       <MenuSeparator />
 
       {/* Pinned insert tools — always one click away */}
-      <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 2 }}>
         <PinnedTool tool="addText" label="Text" icon={<TextIcon />} colour={FIELD_COLORS.text} />
         <PinnedTool
           tool="addImage"
@@ -167,7 +158,6 @@ export function MenuTabBar() {
           label="Preview"
           onClick={() => setShowPreview(!showPreview)}
           disabled={!hasBackground}
-          compact
           title="Preview template"
           variant={showPreview ? 'toggle' : 'default'}
           active={showPreview}
@@ -177,7 +167,6 @@ export function MenuTabBar() {
           icon={<SaveIcon />}
           label={savedFlash ? 'Saved!' : 'Save'}
           onClick={handleSave}
-          compact
           title="Save template (Ctrl+S)"
           variant="success"
           testid="toolbar-save"
@@ -186,7 +175,6 @@ export function MenuTabBar() {
           icon={locked ? <LockedIcon /> : <UnlockedIcon />}
           label={locked ? 'Unlock' : 'Lock'}
           onClick={() => setLocked(!locked)}
-          compact
           title={locked ? 'Unlock template' : 'Lock template'}
           variant={locked ? 'toggle' : 'default'}
           active={locked}

--- a/packages/ui/src/components/Toolbar/icons.tsx
+++ b/packages/ui/src/components/Toolbar/icons.tsx
@@ -92,6 +92,69 @@ export const PageLayoutIcon = ({ size }: { size?: number }) => (
   </IconBox>
 )
 
+/** Page with a filled bar at the TOP — the header strip. */
+export const HeaderIcon = ({ size }: { size?: number }) => (
+  <svg width={size ?? 16} height={size ?? 16} viewBox="0 0 24 24" aria-hidden="true">
+    <rect
+      x="3"
+      y="3"
+      width="18"
+      height="18"
+      rx="1.5"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+    />
+    <rect x="3" y="3" width="18" height="5" fill="currentColor" rx="1.5" />
+  </svg>
+)
+
+/** Page with a filled bar at the BOTTOM — the footer strip. */
+export const FooterIcon = ({ size }: { size?: number }) => (
+  <svg width={size ?? 16} height={size ?? 16} viewBox="0 0 24 24" aria-hidden="true">
+    <rect
+      x="3"
+      y="3"
+      width="18"
+      height="18"
+      rx="1.5"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+    />
+    <rect x="3" y="16" width="18" height="5" fill="currentColor" rx="1.5" />
+  </svg>
+)
+
+/** Page with a small "#" in the corner — page numbering. */
+export const PageNumberIcon = ({ size }: { size?: number }) => (
+  <svg
+    width={size ?? 16}
+    height={size ?? 16}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <rect x="3" y="3" width="18" height="18" rx="1.5" />
+    <text
+      x="12"
+      y="16.5"
+      textAnchor="middle"
+      fontSize="11"
+      fontFamily="-apple-system, sans-serif"
+      fontWeight="700"
+      fill="currentColor"
+      stroke="none"
+    >
+      #
+    </text>
+  </svg>
+)
+
 export const UndoIcon = ({ size }: { size?: number }) => (
   <IconBox size={size}>
     <polyline points="1 4 1 10 7 10" />

--- a/packages/ui/src/components/Toolbar/primitives/RibbonButton.tsx
+++ b/packages/ui/src/components/Toolbar/primitives/RibbonButton.tsx
@@ -1,16 +1,26 @@
 import { type ReactNode, type CSSProperties } from 'react'
+import { Tooltip } from '../../Tooltip.js'
 
 /**
- * A single icon+label button used inside row-2 ribbon groups (#128).
- * Variants:
- *   - `default` — neutral text + icon, used for most actions.
- *   - `primary` — accent fill (e.g. Upload), high visual weight.
- *   - `success` — green fill (used for the Save button on the menu bar).
- *   - `toggle` — active state lights up via `--bg-tertiary` background.
+ * Single horizontal ribbon control (#64 v3 redesign). One row layout
+ * across the entire toolbar — icon on the left, label on the right,
+ * fixed height from `--control-height-md`. Drops the column / compact
+ * split that made the old ribbon look unsorted (Left/Right stacked
+ * vertically vs Zoom buttons row-compact vs Snap label-only — every
+ * button now sits on the same baseline).
  *
- * Styling lives in `.tg-ribbon-btn` (App.css). Inline styles can't
- * override Tailwind v4 preflight's `button { background-color: transparent }`
- * without `!important`, so we use CSS classes instead.
+ * Variants:
+ *   - `default` — neutral text, hover lifts background.
+ *   - `primary` — accent fill for the "do the thing" CTA (rare).
+ *   - `success` — green fill for Save.
+ *   - `toggle` — active state lights up via `tg-ribbon-btn--active`.
+ *
+ * If a `title` is supplied, the button is wrapped in a Radix Tooltip
+ * (delay from `--tooltip-open-delay`) so non-technical users can hover
+ * to learn what each control does without cluttering the visible label.
+ *
+ * Styling lives in `.tg-ribbon-btn` (App.css) — Tailwind v4 preflight
+ * neutralises inline `<button>` backgrounds without CSS classes.
  */
 export interface RibbonButtonProps {
   label?: string
@@ -20,13 +30,16 @@ export interface RibbonButtonProps {
   disabled?: boolean
   active?: boolean
   variant?: 'default' | 'primary' | 'success' | 'toggle'
+  /**
+   * `compact` is retained for source-compatibility with #128 callers; in
+   * the new system the only effect is that icon-only buttons (no label
+   * passed) render as a 28×28 square via `.tg-ribbon-btn--icon-only`.
+   */
   compact?: boolean
   testid?: string
   ariaLabel?: string
-  /** Custom inline style overrides — used by the field-creation buttons
-   *  that carry their type-specific colour. */
+  /** Custom inline style overrides — used by pinned tools for type-tinted icons. */
   style?: CSSProperties
-  /** Arbitrary `data-*` attributes forwarded to the underlying button. */
   dataAttrs?: Record<string, string>
 }
 
@@ -38,15 +51,15 @@ export function RibbonButton({
   disabled,
   active,
   variant = 'default',
-  compact,
   testid,
   ariaLabel,
   style,
   dataAttrs,
 }: RibbonButtonProps) {
+  const iconOnly = !label && !!icon
   const cls = [
     'tg-ribbon-btn',
-    compact ? 'tg-ribbon-btn--compact' : '',
+    iconOnly ? 'tg-ribbon-btn--icon-only' : '',
     variant === 'primary' ? 'tg-ribbon-btn--primary' : '',
     variant === 'success' ? 'tg-ribbon-btn--success' : '',
     active && (variant === 'toggle' || variant === 'default') ? 'tg-ribbon-btn--active' : '',
@@ -54,11 +67,10 @@ export function RibbonButton({
     .filter(Boolean)
     .join(' ')
 
-  return (
+  const button = (
     <button
       type="button"
       onClick={disabled ? undefined : onClick}
-      title={title}
       disabled={disabled}
       aria-pressed={variant === 'toggle' ? active : undefined}
       aria-label={ariaLabel ?? label ?? title}
@@ -71,4 +83,10 @@ export function RibbonButton({
       {label && <span>{label}</span>}
     </button>
   )
+
+  // Skip the tooltip wrapper for disabled buttons — Radix's tooltip on
+  // disabled buttons fights pointer-events; users get the visible label
+  // instead. Also skip when there's no title to show.
+  if (!title || disabled) return button
+  return <Tooltip content={title}>{button}</Tooltip>
 }

--- a/packages/ui/src/components/Toolbar/primitives/RibbonGroup.tsx
+++ b/packages/ui/src/components/Toolbar/primitives/RibbonGroup.tsx
@@ -1,10 +1,11 @@
 import type { ReactNode } from 'react'
 
 /**
- * Visual cluster inside the row-2 ribbon (#128). Mirrors Word's ribbon
- * groups — a labelled box of related controls, separated from siblings
- * by a subtle vertical divider. Label shrinks to the bottom so the
- * cluster's primary controls dominate the eye.
+ * Visual cluster of related controls inside row-2 of the toolbar
+ * (#64 v3). Mirrors Linear/Figma/Word groupings — a row of controls
+ * with an uppercase label under it and a hairline divider on the
+ * right. Sizing is driven by tokens so every group reads as the same
+ * size regardless of how many controls it carries.
  */
 export interface RibbonGroupProps {
   label?: string
@@ -20,20 +21,23 @@ export function RibbonGroup({ label, children, testid }: RibbonGroupProps) {
         display: 'flex',
         flexDirection: 'column',
         alignItems: 'center',
-        gap: 4,
-        padding: '4px 10px',
+        justifyContent: 'center',
+        gap: 6,
+        padding: '6px 12px',
         borderRight: '1px solid var(--border-light)',
-        minHeight: 56,
+        minHeight: 64,
       }}
     >
-      <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>{children}</div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>{children}</div>
       {label && (
         <div
           style={{
-            fontSize: 10,
+            fontSize: 'var(--text-2xs)',
+            fontWeight: 'var(--font-weight-medium)',
             color: 'var(--text-muted)',
             textTransform: 'uppercase',
-            letterSpacing: 0.4,
+            letterSpacing: '0.06em',
+            lineHeight: 1,
           }}
         >
           {label}

--- a/packages/ui/src/components/Toolbar/ribbons/InsertRibbon.tsx
+++ b/packages/ui/src/components/Toolbar/ribbons/InsertRibbon.tsx
@@ -2,7 +2,7 @@ import { useTemplateStore } from '../../../store/templateStore.js'
 import { useUiStore } from '../../../store/uiStore.js'
 import { RibbonGroup } from '../primitives/RibbonGroup.js'
 import { RibbonButton } from '../primitives/RibbonButton.js'
-import { PageLayoutIcon } from '../icons.js'
+import { HeaderIcon, FooterIcon, PageNumberIcon } from '../icons.js'
 
 /**
  * Insert ribbon (#128). Three first-class buttons: Header / Footer /
@@ -33,7 +33,7 @@ export function InsertRibbon() {
     <div style={{ display: 'flex' }}>
       <RibbonGroup label="Page elements">
         <RibbonButton
-          icon={<PageLayoutIcon />}
+          icon={<HeaderIcon />}
           label="Header"
           onClick={() => setPageLayoutSettings('header')}
           active={headerEnabled}
@@ -43,7 +43,7 @@ export function InsertRibbon() {
           testid="ribbon-insert-header"
         />
         <RibbonButton
-          icon={<PageLayoutIcon />}
+          icon={<FooterIcon />}
           label="Footer"
           onClick={() => setPageLayoutSettings('footer')}
           active={footerEnabled}
@@ -53,7 +53,7 @@ export function InsertRibbon() {
           testid="ribbon-insert-footer"
         />
         <RibbonButton
-          icon={<PageLayoutIcon />}
+          icon={<PageNumberIcon />}
           label="Page Number"
           onClick={() => setPageLayoutSettings('pageNumber')}
           active={pageNumberEnabled}

--- a/packages/ui/src/components/Tooltip.tsx
+++ b/packages/ui/src/components/Tooltip.tsx
@@ -1,0 +1,55 @@
+import * as RadixTooltip from '@radix-ui/react-tooltip'
+import { type ReactNode, useState } from 'react'
+
+/**
+ * App-wide tooltip primitive (#64 v3 redesign). Wraps Radix's headless
+ * tooltip with our token-driven styling so every hover affordance in
+ * the app reads as one consistent surface — same delay, same shadow,
+ * same radius, same arrow.
+ *
+ * Default open-delay matches `--tooltip-open-delay` (600 ms) so the
+ * tooltip doesn't flash on accidental pointer transit but feels snappy
+ * once the user lingers — the production convention (Linear, Figma,
+ * GitHub all sit in 500–700 ms).
+ */
+export interface TooltipProps {
+  content: ReactNode
+  children: ReactNode
+  side?: 'top' | 'right' | 'bottom' | 'left'
+  delayMs?: number
+}
+
+export function Tooltip({ content, children, side = 'bottom', delayMs = 600 }: TooltipProps) {
+  const [open, setOpen] = useState(false)
+  return (
+    <RadixTooltip.Provider delayDuration={delayMs} skipDelayDuration={150}>
+      <RadixTooltip.Root open={open} onOpenChange={setOpen}>
+        <RadixTooltip.Trigger asChild>{children}</RadixTooltip.Trigger>
+        <RadixTooltip.Portal>
+          <RadixTooltip.Content
+            side={side}
+            sideOffset={6}
+            collisionPadding={8}
+            style={{
+              background: 'var(--bg-elevated)',
+              color: 'var(--text-primary)',
+              border: '1px solid var(--border)',
+              boxShadow: 'var(--shadow-md)',
+              padding: '6px 10px',
+              borderRadius: 'var(--radius-md)',
+              fontSize: 'var(--text-sm)',
+              fontWeight: 'var(--font-weight-medium)',
+              lineHeight: 1.3,
+              maxWidth: 280,
+              zIndex: 'var(--z-tooltip)' as unknown as number,
+              animation: 'tg-tooltip-in 0.12s var(--ease-out)',
+            }}
+          >
+            {content}
+            <RadixTooltip.Arrow style={{ fill: 'var(--bg-elevated)' }} width={10} height={5} />
+          </RadixTooltip.Content>
+        </RadixTooltip.Portal>
+      </RadixTooltip.Root>
+    </RadixTooltip.Provider>
+  )
+}

--- a/packages/ui/src/styles/theme.css
+++ b/packages/ui/src/styles/theme.css
@@ -1,0 +1,253 @@
+/*
+ * theme.css — v3 design tokens (#64).
+ *
+ * Single source of truth for colour, spacing, typography, radius, shadow,
+ * motion, and z-index scales. Both light and dark themes live here.
+ * Existing class authors keep using `--bg-primary` / `--text-primary` /
+ * `--accent` etc.; the new scaled tokens (`--space-3`, `--radius-md`,
+ * `--shadow-lg`, `--duration-fast`, …) layer on top so the v3 redesign
+ * can compose every surface from the same scale.
+ *
+ * Toggling is data-attribute driven: <html data-theme="dark"> swaps every
+ * colour token. No JS reads tokens directly — only CSS. Light is the
+ * default for users who haven't opted in.
+ */
+
+/* =============================================================
+ * Scale tokens — theme-independent. Defined once on :root.
+ * ============================================================= */
+:root {
+  /* --- Spacing (4-px grid) --- */
+  --space-0: 0;
+  --space-px: 1px;
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-10: 40px;
+  --space-12: 48px;
+  --space-16: 64px;
+
+  /* --- Typography --- */
+  --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+    'Helvetica Neue', Arial, sans-serif;
+  --font-mono: 'SF Mono', 'Fira Code', 'Cascadia Code', ui-monospace,
+    Menlo, Consolas, monospace;
+
+  --text-2xs: 10px;
+  --text-xs: 11px;
+  --text-sm: 12px;
+  --text-base: 13px;
+  --text-md: 14px;
+  --text-lg: 16px;
+  --text-xl: 18px;
+  --text-2xl: 22px;
+  --text-3xl: 28px;
+
+  --leading-tight: 1.25;
+  --leading-snug: 1.4;
+  --leading-normal: 1.5;
+  --leading-relaxed: 1.65;
+
+  --font-weight-regular: 400;
+  --font-weight-medium: 500;
+  --font-weight-semibold: 600;
+  --font-weight-bold: 700;
+
+  /* --- Radius --- */
+  --radius-none: 0;
+  --radius-xs: 2px;
+  --radius-sm: 4px;
+  --radius-md: 6px;
+  --radius-lg: 8px;
+  --radius-xl: 12px;
+  --radius-2xl: 16px;
+  --radius-full: 9999px;
+
+  /* --- Motion --- */
+  --duration-instant: 80ms;
+  --duration-fast: 120ms;
+  --duration-base: 180ms;
+  --duration-slow: 280ms;
+  --duration-slower: 420ms;
+  --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-in-out: cubic-bezier(0.65, 0, 0.35, 1);
+  --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+
+  /* --- Z-index scale --- */
+  --z-base: 0;
+  --z-raised: 10;
+  --z-dropdown: 100;
+  --z-sticky: 200;
+  --z-overlay: 800;
+  --z-modal: 900;
+  --z-popover: 950;
+  --z-tooltip: 1000;
+  --z-toast: 2000;
+
+  /* --- Focus ring (theme-tinted; colour resolves via --ring-color) --- */
+  --ring-width: 2px;
+  --ring-offset: 2px;
+
+  /* --- Tooltip timing (Radix `delayDuration` default reference) --- */
+  --tooltip-open-delay: 600ms;
+  --tooltip-close-delay: 80ms;
+}
+
+/* =============================================================
+ * Light theme — default. Lives on :root so unscoped consumers
+ * (e.g. portal'd Radix overlays) inherit it.
+ * ============================================================= */
+:root,
+[data-theme='light'] {
+  /* Surfaces (background hierarchy: primary < secondary < tertiary < elevated) */
+  --bg-primary: #f5f5f7;
+  --bg-secondary: #ffffff;
+  --bg-tertiary: #ebecf0;
+  --bg-surface: #f0f1f3;
+  --bg-elevated: #ffffff;
+  --bg-overlay: rgba(15, 15, 23, 0.45);
+
+  /* Text */
+  --text-primary: #1a1a2e;
+  --text-secondary: #4a4a5e;
+  --text-muted: #7e7f93;
+  --text-on-accent: #ffffff;
+
+  /* Borders */
+  --border: #dcdde1;
+  --border-light: #e8e8ec;
+  --border-strong: #c2c3c9;
+
+  /* Brand accent */
+  --accent: #e94560;
+  --accent-hover: #d63851;
+  --accent-active: #b62a44;
+  --accent-soft: rgba(233, 69, 96, 0.12);
+  --accent-soft-hover: rgba(233, 69, 96, 0.2);
+
+  /* Semantic */
+  --success: #16a34a;
+  --success-hover: #137d3b;
+  --success-soft: rgba(22, 163, 74, 0.12);
+  --warning: #d97706;
+  --warning-hover: #b3620a;
+  --warning-soft: rgba(217, 119, 6, 0.12);
+  --error: #dc2626;
+  --error-hover: #b81e1e;
+  --error-soft: rgba(220, 38, 38, 0.12);
+  --info: #2563eb;
+  --info-soft: rgba(37, 99, 235, 0.12);
+
+  /* Canvas-specific */
+  --canvas-bg: #e0e0e8;
+  --canvas-grid: rgba(0, 0, 0, 0.04);
+
+  /* Focus ring colour */
+  --ring-color: rgba(233, 69, 96, 0.45);
+
+  /* Shadows — soft, tinted-neutral for light */
+  --shadow-xs: 0 1px 2px rgba(15, 15, 23, 0.06);
+  --shadow-sm: 0 2px 4px rgba(15, 15, 23, 0.08);
+  --shadow-md: 0 4px 12px rgba(15, 15, 23, 0.1);
+  --shadow-lg: 0 8px 24px rgba(15, 15, 23, 0.14);
+  --shadow-xl: 0 16px 48px rgba(15, 15, 23, 0.18);
+  --shadow-popover: 0 8px 24px rgba(15, 15, 23, 0.16);
+  --shadow-modal: 0 24px 64px rgba(15, 15, 23, 0.28);
+
+  color-scheme: light;
+}
+
+/* =============================================================
+ * Dark theme — overrides every colour token. Scales (space /
+ * radius / motion / z) carry over unchanged.
+ * ============================================================= */
+[data-theme='dark'] {
+  --bg-primary: #0f0f17;
+  --bg-secondary: #181825;
+  --bg-tertiary: #252538;
+  --bg-surface: #1e1e30;
+  --bg-elevated: #232338;
+  --bg-overlay: rgba(0, 0, 0, 0.6);
+
+  --text-primary: #f0f0f5;
+  --text-secondary: #b6b6c8;
+  --text-muted: #8a8aa6;
+  --text-on-accent: #ffffff;
+
+  --border: #2d2d45;
+  --border-light: #3a3a52;
+  --border-strong: #4a4a66;
+
+  --accent: #ff5e7a;
+  --accent-hover: #ff7a92;
+  --accent-active: #e94560;
+  --accent-soft: rgba(255, 94, 122, 0.18);
+  --accent-soft-hover: rgba(255, 94, 122, 0.28);
+
+  --success: #4ade80;
+  --success-hover: #6ee79a;
+  --success-soft: rgba(74, 222, 128, 0.16);
+  --warning: #fbbf24;
+  --warning-hover: #fcd34d;
+  --warning-soft: rgba(251, 191, 36, 0.16);
+  --error: #f87171;
+  --error-hover: #fca5a5;
+  --error-soft: rgba(248, 113, 113, 0.18);
+  --info: #60a5fa;
+  --info-soft: rgba(96, 165, 250, 0.18);
+
+  --canvas-bg: #0a0a14;
+  --canvas-grid: rgba(255, 255, 255, 0.05);
+
+  --ring-color: rgba(255, 94, 122, 0.55);
+
+  --shadow-xs: 0 1px 2px rgba(0, 0, 0, 0.35);
+  --shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.42);
+  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.5);
+  --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.58);
+  --shadow-xl: 0 16px 48px rgba(0, 0, 0, 0.66);
+  --shadow-popover: 0 8px 24px rgba(0, 0, 0, 0.55);
+  --shadow-modal: 0 24px 64px rgba(0, 0, 0, 0.72);
+
+  color-scheme: dark;
+}
+
+/* =============================================================
+ * Global affordances — apply across the whole app, both themes.
+ * Tightens the v3 polish bar: every focusable thing has a
+ * visible ring; native form controls track the theme; pointer
+ * affordances are explicit.
+ * ============================================================= */
+
+/* Replace the browser's default focus outline with a tokenised ring.
+ * `:focus-visible` keeps mouse clicks free of rings; keyboard / a11y
+ * users still get a strong indicator. */
+*:focus { outline: none; }
+*:focus-visible {
+  outline: var(--ring-width) solid var(--ring-color);
+  outline-offset: var(--ring-offset);
+  border-radius: var(--radius-sm);
+}
+
+/* Native selection colour follows the accent so it reads as branded. */
+::selection {
+  background: var(--accent-soft-hover);
+  color: var(--text-primary);
+}
+
+/* Respect users who ask for reduced motion. Drops every transition /
+ * animation duration to ~0 without changing layout. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/packages/ui/src/styles/theme.css
+++ b/packages/ui/src/styles/theme.css
@@ -17,6 +17,18 @@
  * Scale tokens — theme-independent. Defined once on :root.
  * ============================================================= */
 :root {
+  /* --- Control sizing — every interactive control shares these heights
+   * so the toolbar/ribbon/forms read as one aligned system rather than a
+   * patchwork of mismatched buttons. --- */
+  --control-height-sm: 24px;
+  --control-height-md: 28px; /* ribbon / toolbar default */
+  --control-height-lg: 32px; /* primary CTAs (Save, Preview) */
+  --control-height-xl: 40px; /* large primary actions in dialogs */
+  --control-padding-x: 10px;
+  --icon-size-sm: 14px;
+  --icon-size-md: 16px; /* default icon size */
+  --icon-size-lg: 20px;
+
   /* --- Spacing (4-px grid) --- */
   --space-0: 0;
   --space-px: 1px;
@@ -103,31 +115,36 @@
  * ============================================================= */
 :root,
 [data-theme='light'] {
-  /* Surfaces (background hierarchy: primary < secondary < tertiary < elevated) */
-  --bg-primary: #f5f5f7;
+  /* Surfaces (background hierarchy: primary < secondary < tertiary < elevated)
+   * Slate-tinted neutrals — slightly cool, calmer than the previous
+   * yellow-white. Matches the Linear / Vercel polish bar. */
+  --bg-primary: #fafafb;
   --bg-secondary: #ffffff;
-  --bg-tertiary: #ebecf0;
-  --bg-surface: #f0f1f3;
+  --bg-tertiary: #f1f2f5;
+  --bg-surface: #f6f7f9;
   --bg-elevated: #ffffff;
-  --bg-overlay: rgba(15, 15, 23, 0.45);
+  --bg-overlay: rgba(15, 17, 24, 0.5);
 
   /* Text */
-  --text-primary: #1a1a2e;
-  --text-secondary: #4a4a5e;
-  --text-muted: #7e7f93;
+  --text-primary: #15161a;
+  --text-secondary: #4f5562;
+  --text-muted: #8b909b;
   --text-on-accent: #ffffff;
 
   /* Borders */
-  --border: #dcdde1;
-  --border-light: #e8e8ec;
-  --border-strong: #c2c3c9;
+  --border: #e4e6eb;
+  --border-light: #eff0f4;
+  --border-strong: #d1d3da;
 
-  /* Brand accent */
-  --accent: #e94560;
-  --accent-hover: #d63851;
-  --accent-active: #b62a44;
-  --accent-soft: rgba(233, 69, 96, 0.12);
-  --accent-soft-hover: rgba(233, 69, 96, 0.2);
+  /* Brand accent — Linear-style indigo. The previous hot-pink
+   * (#e94560) shouted "warning / error" everywhere it touched a
+   * control. Indigo reads as branded-but-restrained, the convention
+   * across production tools (Linear, Notion, Figma, Vercel). */
+  --accent: #5e6ad2;
+  --accent-hover: #4e5bc4;
+  --accent-active: #404bb0;
+  --accent-soft: rgba(94, 106, 210, 0.1);
+  --accent-soft-hover: rgba(94, 106, 210, 0.18);
 
   /* Semantic */
   --success: #16a34a;
@@ -147,7 +164,7 @@
   --canvas-grid: rgba(0, 0, 0, 0.04);
 
   /* Focus ring colour */
-  --ring-color: rgba(233, 69, 96, 0.45);
+  --ring-color: rgba(94, 106, 210, 0.5);
 
   /* Shadows — soft, tinted-neutral for light */
   --shadow-xs: 0 1px 2px rgba(15, 15, 23, 0.06);
@@ -166,27 +183,31 @@
  * radius / motion / z) carry over unchanged.
  * ============================================================= */
 [data-theme='dark'] {
-  --bg-primary: #0f0f17;
-  --bg-secondary: #181825;
-  --bg-tertiary: #252538;
-  --bg-surface: #1e1e30;
-  --bg-elevated: #232338;
-  --bg-overlay: rgba(0, 0, 0, 0.6);
+  /* Linear-style neutral-dark — near-black with a faint cool tint.
+   * Avoids the navy-purple cast of the previous palette which read
+   * as bedroom-IDE rather than production tool. */
+  --bg-primary: #0b0c10;
+  --bg-secondary: #15171c;
+  --bg-tertiary: #1d1f25;
+  --bg-surface: #181a20;
+  --bg-elevated: #1f2229;
+  --bg-overlay: rgba(0, 0, 0, 0.65);
 
-  --text-primary: #f0f0f5;
-  --text-secondary: #b6b6c8;
-  --text-muted: #8a8aa6;
+  --text-primary: #f1f2f5;
+  --text-secondary: #adb0bb;
+  --text-muted: #6b6f7c;
   --text-on-accent: #ffffff;
 
-  --border: #2d2d45;
-  --border-light: #3a3a52;
-  --border-strong: #4a4a66;
+  --border: #25272f;
+  --border-light: #2c2e38;
+  --border-strong: #353844;
 
-  --accent: #ff5e7a;
-  --accent-hover: #ff7a92;
-  --accent-active: #e94560;
-  --accent-soft: rgba(255, 94, 122, 0.18);
-  --accent-soft-hover: rgba(255, 94, 122, 0.28);
+  /* Lifted indigo in dark — readable against deep neutrals. */
+  --accent: #7c87e0;
+  --accent-hover: #9099e7;
+  --accent-active: #5e6ad2;
+  --accent-soft: rgba(124, 135, 224, 0.14);
+  --accent-soft-hover: rgba(124, 135, 224, 0.24);
 
   --success: #4ade80;
   --success-hover: #6ee79a;
@@ -203,7 +224,7 @@
   --canvas-bg: #0a0a14;
   --canvas-grid: rgba(255, 255, 255, 0.05);
 
-  --ring-color: rgba(255, 94, 122, 0.55);
+  --ring-color: rgba(124, 135, 224, 0.55);
 
   --shadow-xs: 0 1px 2px rgba(0, 0, 0, 0.35);
   --shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.42);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,6 +99,12 @@ importers:
 
   packages/ui:
     dependencies:
+      '@radix-ui/react-dialog':
+        specifier: ^1.1.15
+        version: 1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-tooltip':
+        specifier: ^1.2.8
+        version: 1.2.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
@@ -825,6 +831,21 @@ packages:
     resolution: {integrity: sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
+  '@floating-ui/core@1.7.5':
+    resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
+
+  '@floating-ui/dom@1.7.6':
+    resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
+
+  '@floating-ui/react-dom@2.1.8':
+    resolution: {integrity: sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@floating-ui/utils@0.2.11':
+    resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -1030,6 +1051,250 @@ packages:
     resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@radix-ui/primitive@1.1.3':
+    resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
+
+  '@radix-ui/react-arrow@1.1.7':
+    resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-compose-refs@1.1.2':
+    resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.1.2':
+    resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-dialog@1.1.15':
+    resolution: {integrity: sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-dismissable-layer@1.1.11':
+    resolution: {integrity: sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-focus-guards@1.1.3':
+    resolution: {integrity: sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-focus-scope@1.1.7':
+    resolution: {integrity: sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-id@1.1.1':
+    resolution: {integrity: sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-popper@1.2.8':
+    resolution: {integrity: sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-portal@1.1.9':
+    resolution: {integrity: sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-presence@1.1.5':
+    resolution: {integrity: sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.1.3':
+    resolution: {integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-slot@1.2.3':
+    resolution: {integrity: sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-tooltip@1.2.8':
+    resolution: {integrity: sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-use-callback-ref@1.1.1':
+    resolution: {integrity: sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-controllable-state@1.2.2':
+    resolution: {integrity: sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-effect-event@0.0.2':
+    resolution: {integrity: sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-escape-keydown@1.1.1':
+    resolution: {integrity: sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-layout-effect@1.1.1':
+    resolution: {integrity: sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-rect@1.1.1':
+    resolution: {integrity: sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-size@1.1.1':
+    resolution: {integrity: sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-visually-hidden@1.2.3':
+    resolution: {integrity: sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/rect@1.1.1':
+    resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
@@ -1579,6 +1844,10 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  aria-hidden@1.2.6:
+    resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
+    engines: {node: '>=10'}
+
   array-buffer-byte-length@1.0.2:
     resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
     engines: {node: '>= 0.4'}
@@ -2000,6 +2269,9 @@ packages:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
     engines: {node: '>=8'}
 
+  detect-node-es@1.1.0:
+    resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
+
   dfa@1.2.0:
     resolution: {integrity: sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==}
 
@@ -2337,6 +2609,10 @@ packages:
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
+
+  get-nonce@1.0.1:
+    resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
+    engines: {node: '>=6'}
 
   get-package-type@0.1.0:
     resolution: {integrity: sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==}
@@ -3506,6 +3782,36 @@ packages:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
 
+  react-remove-scroll-bar@2.3.8:
+    resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-remove-scroll@2.7.2:
+    resolution: {integrity: sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-style-singleton@2.2.3:
+    resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
@@ -3989,6 +4295,26 @@ packages:
   url@0.11.4:
     resolution: {integrity: sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==}
     engines: {node: '>= 0.4'}
+
+  use-callback-ref@1.3.3:
+    resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-sidecar@1.1.3:
+    resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -4884,6 +5210,23 @@ snapshots:
       '@eslint/core': 1.2.1
       levn: 0.4.1
 
+  '@floating-ui/core@1.7.5':
+    dependencies:
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/dom@1.7.6':
+    dependencies:
+      '@floating-ui/core': 1.7.5
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/react-dom@2.1.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@floating-ui/utils@0.2.11': {}
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.7':
@@ -5183,6 +5526,221 @@ snapshots:
   '@playwright/test@1.59.1':
     dependencies:
       playwright: 1.59.1
+
+  '@radix-ui/primitive@1.1.3': {}
+
+  '@radix-ui/react-arrow@1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@radix-ui/react-compose-refs@1.1.2(@types/react@18.3.28)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.28
+
+  '@radix-ui/react-context@1.1.2(@types/react@18.3.28)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.28
+
+  '@radix-ui/react-dialog@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.2.3(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.28)(react@18.3.1)
+      aria-hidden: 1.2.6
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-remove-scroll: 2.7.2(@types/react@18.3.28)(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@radix-ui/react-focus-guards@1.1.3(@types/react@18.3.28)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.28
+
+  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@radix-ui/react-id@1.1.1(@types/react@18.3.28)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.28
+
+  '@radix-ui/react-popper@1.2.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-rect': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/rect': 1.1.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@radix-ui/react-portal@1.1.9(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@radix-ui/react-presence@1.1.5(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@radix-ui/react-primitive@2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.3(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@radix-ui/react-slot@1.2.3(@types/react@18.3.28)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.28
+
+  '@radix-ui/react-tooltip@1.2.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.2.3(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@18.3.28)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.28
+
+  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@18.3.28)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.28
+
+  '@radix-ui/react-use-effect-event@0.0.2(@types/react@18.3.28)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.28
+
+  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@18.3.28)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.28
+
+  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@18.3.28)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.28
+
+  '@radix-ui/react-use-rect@1.1.1(@types/react@18.3.28)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/rect': 1.1.1
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.28
+
+  '@radix-ui/react-use-size@1.1.1(@types/react@18.3.28)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.28
+
+  '@radix-ui/react-visually-hidden@1.2.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@radix-ui/rect@1.1.1': {}
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
@@ -5709,6 +6267,10 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  aria-hidden@1.2.6:
+    dependencies:
+      tslib: 2.8.1
+
   array-buffer-byte-length@1.0.2:
     dependencies:
       call-bound: 1.0.4
@@ -6209,6 +6771,8 @@ snapshots:
 
   detect-newline@3.1.0: {}
 
+  detect-node-es@1.1.0: {}
+
   dfa@1.2.0: {}
 
   diff-sequences@29.6.3: {}
@@ -6661,6 +7225,8 @@ snapshots:
       has-symbols: 1.1.0
       hasown: 2.0.2
       math-intrinsics: 1.1.0
+
+  get-nonce@1.0.1: {}
 
   get-package-type@0.1.0: {}
 
@@ -8002,6 +8568,33 @@ snapshots:
 
   react-refresh@0.17.0: {}
 
+  react-remove-scroll-bar@2.3.8(@types/react@18.3.28)(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-style-singleton: 2.2.3(@types/react@18.3.28)(react@18.3.1)
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 18.3.28
+
+  react-remove-scroll@2.7.2(@types/react@18.3.28)(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-remove-scroll-bar: 2.3.8(@types/react@18.3.28)(react@18.3.1)
+      react-style-singleton: 2.2.3(@types/react@18.3.28)(react@18.3.1)
+      tslib: 2.8.1
+      use-callback-ref: 1.3.3(@types/react@18.3.28)(react@18.3.1)
+      use-sidecar: 1.1.3(@types/react@18.3.28)(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+
+  react-style-singleton@2.2.3(@types/react@18.3.28)(react@18.3.1):
+    dependencies:
+      get-nonce: 1.0.1
+      react: 18.3.1
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 18.3.28
+
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
@@ -8519,6 +9112,21 @@ snapshots:
     dependencies:
       punycode: 1.4.1
       qs: 6.15.1
+
+  use-callback-ref@1.3.3(@types/react@18.3.28)(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 18.3.28
+
+  use-sidecar@1.1.3(@types/react@18.3.28)(react@18.3.1):
+    dependencies:
+      detect-node-es: 1.1.0
+      react: 18.3.1
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 18.3.28
 
   util-deprecate@1.0.2: {}
 


### PR DESCRIPTION
## Summary

Real top-to-bottom redesign of the editor chrome, not a repaint. Closes #64.

- **Design tokens** — `packages/ui/src/styles/theme.css` is the single source of truth for colour / spacing / typography / radius / shadow / motion / z-index / focus-ring / control-sizing scales. Both themes live there, gated by `data-theme`.
- **Palette swap** — hot-pink `#e94560` (which read as warning everywhere) replaced with Linear-style indigo `#5E6AD2` (light) / `#7C87E0` (dark). Neutrals refined toward slate-cool. Same indigo drives the focus ring and the Radix tooltip arrow.
- **Unified control system** — every interactive control on the toolbar shares one height (`--control-height-md = 28px`) and one icon size (`--icon-size-md = 16px`). The old column-vs-row split (Left/Right stacked vertically vs Snap label-only vs Zoom row-compact vs Light icon+text) is gone — every button is a single horizontal row of icon + label on the same baseline.
- **Outlined-button idiom end-to-end** — File / Edit / Insert / Format / View / Help tabs + Text / Image / Table pinned tools + Preview / Save / Lock CTAs all use one outlined-button system: thin border at rest, fills on hover, indigo soft-fill + indigo border when active. No 3 D inset-shadow tricks. Same idiom Tailwind UI, shadcn, GitHub, Stripe Dashboard use.
- **Distinct band icons** — Header (page + top bar), Footer (page + bottom bar), Page Number (page + bold `#`). Three previously shared one generic glyph.
- **Radix Tooltip** — installed `@radix-ui/react-tooltip` + `react-dialog` and added a token-styled `Tooltip` primitive. Every `RibbonButton` with a `title` wraps in it with 600 ms open-delay (Linear / Figma / GitHub all sit in 500–700 ms) and an arrow tinted to `--bg-elevated`.
- **Snap toggle now visibly works** — `buildGridLines` was white-on-white (`rgba(255,255,255,0.08)` on a white default page). Switched to `rgba(0,0,0,0.14)`.
- **JSON Preview** — code block was using `--bg-primary` (deepest surface in dark mode) so it recessed instead of reading as a raised tile. Now sits on `--bg-tertiary` with `--border-light`. Mode buttons (`Format` / `Max Fill` / `Copy`) use the same outlined-button selected treatment.
- **Affordances** — global `:focus-visible` ring driven by `--ring-color`, `::selection` tinted to the accent, `prefers-reduced-motion` flattens transitions, `color-scheme` hint so native form controls track the theme.

## Test plan

- [x] Type-check + production build clean across the workspace
- [x] Live Chrome verification (MCP) in both themes
- [x] Every menu tab (File / Edit / Insert / Format / View / Help) clicked — all open the correct ribbon, active-tab styling consistent
- [x] Radix tooltip on Save → "Save template (Ctrl+S)" appears below button after 600 ms hover, themed correctly
- [x] Snap toggle confirmed: grid lines appear / disappear on click
- [x] Theme toggle: full light ↔ dark transition; outlined buttons, accent fills, focus tokens, Save green-fill all re-resolve cleanly
- [x] Onboarding flow (Choose background → Pick colour → Choose page size → Apply) — every step wears the new palette: indigo primary CTAs, outlined secondary, indigo-bordered selected radio