### PR TITLE
feat(ui): replace native alert / confirm / prompt with Radix custom dialog primitives (#158)

### DIFF
--- a/.changeset/font-style-fidelity.md
+++ b/.changeset/font-style-fidelity.md
@@ -1,0 +1,51 @@
+---
+'template-goblin': patch
+---
+
+fix(render): honour fontWeight, fontStyle, textDecoration, and table-cell verticalAlign
+
+The text + table renderers silently dropped several style flags on
+their way into the PDF stream, so the editor's Bold / Italic /
+Underline / Strikethrough / Vertical-align toggles never reached
+the rendered output even though the preview pipeline calls the
+exact same `generatePDF` an SDK consumer would.
+
+**Resolved gaps:**
+
+- **fontWeight + fontStyle in text fields** — `text.ts` called
+  `doc.font(style.fontFamily)` directly, ignoring weight + style.
+  Now resolves the (family, weight, style) triple to the matching
+  PDFKit standard-font name (Helvetica-BoldOblique, Times-BoldItalic,
+  Courier-BoldOblique, …) via the new `resolvePdfFontName` helper.
+  Custom-uploaded fonts (registered via `doc.registerFont`) win —
+  bold/italic variants of a custom face must come from separately
+  uploaded files.
+- **fontWeight + fontStyle in table cells + headers** — `loop.ts`
+  partially handled bold for body cells (`${family}-Bold` suffix)
+  and ignored both flags for headers. Both code paths now use the
+  same resolver.
+- **textDecoration (underline / line-through) in text fields** —
+  `text.ts` did not paint either. A new `paintTextDecoration`
+  helper draws the line under or through the painted run for each
+  line, tracked across alignment.
+- **textDecoration in table headers** — header path only supported
+  underline (no line-through). Both decorations now flow.
+- **verticalAlign in table cells + headers** — both paths landed
+  at `startY + paddingTop`. Now respects 'top' / 'middle' / 'bottom'
+  via the new `resolveCellTextY` helper.
+
+**New unit tests:** 17 covering the (family, weight, style)
+matrix across Helvetica / Times-Roman / Courier + custom fonts
+
+- unknown-family fallback. 7 covering the cell-vAlign formula.
+
+**New integration test:** `loop.vAlign.test.ts` paints a two-
+column table with one font-size-mismatched cell to create vertical
+slack inside the row, then asserts the cell text y position
+shifts top → middle → bottom in strict order with the expected
+delta.
+
+All 459 existing core tests still pass.
+
+End-to-end verified in Chrome: editor canvas + preview PDF
+render identically for bold + italic + underline.

--- a/.changeset/radix-dialog-primitives.md
+++ b/.changeset/radix-dialog-primitives.md
@@ -1,0 +1,59 @@
+---
+'template-goblin-ui': minor
+---
+
+feat(ui): replace native alert / confirm / prompt with Radix-based custom dialog primitives (#158)
+
+Every browser-native dialog the app was firing (`window.alert`,
+`window.confirm`, `window.prompt`) is replaced by a token-styled
+custom equivalent built on `@radix-ui/react-dialog`. The new
+surface is consistent with the rest of the v3 chrome — same
+theme, same focus-trap a11y, same animations, same Esc / overlay-
+click semantics.
+
+**New primitives** in `packages/ui/src/components/Dialogs/`:
+
+- `<DialogProvider>` — wraps `<App />` in `main.tsx`, owns the
+  single active dialog (no stacking; matches native).
+- `useDialogs()` — hook returning `{ alert, confirm, prompt }`.
+  Each call returns a Promise that resolves cleanly on dismiss
+  (no rejections):
+  - `alert({ title, message, variant? })` → `Promise<void>`
+  - `confirm({ title, message, destructive? })` → `Promise<boolean>`
+  - `prompt({ title, label, validate? })` → `Promise<string | null>`
+- `<DialogShell>` (internal) + `<DialogButton>` (internal) —
+  shared chrome + action buttons.
+
+**Replaced call-sites:**
+
+- `LeftPanel/FieldList` — group-name prompt now uses the
+  PromptDialog with an inline validator (empty trim → error,
+  OK disabled).
+- `Toolbar/ribbons/FileRibbon` — File → New confirmation +
+  open-file error toast → ConfirmDialog + AlertDialog.
+- `Toolbar/MenuTabBar` — Save error + dropped-fields warning →
+  AlertDialog (variants: danger / warning).
+- `Toolbar/Toolbar` — image-upload size / type / dimension
+  errors → AlertDialog.
+- `Toolbar/FontManager` — font size + magic-byte errors,
+  remove-in-use confirmation → Alert + ConfirmDialog.
+- `Toolbar/ribbons/HelpRibbon` — keyboard shortcut dump →
+  AlertDialog with multi-line message.
+- `Canvas/usePageHandlers` — last-page delete confirmation →
+  ConfirmDialog with destructive accent.
+- `hooks/useKeyboard` — Save / Open error toasts on Ctrl+S /
+  Ctrl+O → AlertDialog.
+
+**Tests:**
+
+- `e2e/issue-158-dialog-primitives.spec.ts` — 3 tests covering
+  PromptDialog (happy path + validation), AlertDialog
+  (shortcuts).
+- `e2e/bug-09-save-drops-warn.spec.ts` (#137) and
+  `e2e/ux-04-new-confirm.spec.ts` (#150) — updated to drive the
+  new dialog via its testid instead of stubbing
+  `window.alert` / `window.confirm`.
+
+No native dialog calls remain in `packages/ui/src/` outside test
+files. The Radix `react-dialog` dep was already installed for
+#64; this PR is the first real consumer of it.

--- a/packages/core/src/render/cellVerticalAlign.ts
+++ b/packages/core/src/render/cellVerticalAlign.ts
@@ -1,0 +1,38 @@
+import type { VerticalAlign } from '@template-goblin/types'
+
+/**
+ * Resolve the y position for a single-line cell respecting the
+ * cell's verticalAlign. The previous loop renderer always landed at
+ * `startY + paddingTop`, dropping the editor's vAlign toggle for
+ * table cells — discovered during the post-#158 audit. The renderer
+ * for plain text fields already does this (see `text.ts` verticalAlign
+ * switch); this helper applies the same semantic to body + header
+ * cells.
+ *
+ * Cells render one visible line (`maxTextRows = 1`), so the visible
+ * text-block height collapses to `fontSize`. The y position inside
+ * the cell box becomes:
+ *   - 'top'    → startY + paddingTop
+ *   - 'middle' → startY + (rowHeight - fontSize) / 2  (centred)
+ *   - 'bottom' → startY + rowHeight - paddingBottom - fontSize
+ *
+ * No clamping at the top edge — if the cell is too short to hold the
+ * font + paddings, the caller's clip rect already prevents overflow
+ * outside the table bounding rectangle.
+ */
+export function resolveCellTextY(
+  startY: number,
+  rowHeight: number,
+  fontSize: number,
+  paddingTop: number,
+  paddingBottom: number,
+  verticalAlign: VerticalAlign,
+): number {
+  if (verticalAlign === 'middle') {
+    return startY + (rowHeight - fontSize) / 2
+  }
+  if (verticalAlign === 'bottom') {
+    return startY + rowHeight - paddingBottom - fontSize
+  }
+  return startY + paddingTop
+}

--- a/packages/core/src/render/loop.ts
+++ b/packages/core/src/render/loop.ts
@@ -10,6 +10,9 @@ import type {
 import { TemplateGoblinError } from '@template-goblin/types'
 import { renderBackground } from './background.js'
 import { measureText, truncateLines } from '../utils/measure.js'
+import { resolvePdfFontName } from './pdfFontResolver.js'
+import { paintTextDecoration } from './textDecoration.js'
+import { resolveCellTextY } from './cellVerticalAlign.js'
 
 /**
  * Render a table field onto a PDFKit document.
@@ -172,18 +175,37 @@ function renderHeaderRow(
       doc.restore()
     }
 
-    doc.font(hs.fontFamily || 'Helvetica')
+    // Table-header style — same bold/italic + standard-family resolution
+    // as body cells. The previous implementation called
+    // `doc.font(hs.fontFamily)` directly, which dropped weight + style.
+    doc.font(resolvePdfFontName(hs.fontFamily, hs.fontWeight, hs.fontStyle))
     doc.fontSize(hs.fontSize)
     doc.fillColor(hs.color)
 
     const textX = colX + hs.paddingLeft
-    const textY = startY + hs.paddingTop
+    const textY = resolveCellTextY(
+      startY,
+      rowHeight,
+      hs.fontSize,
+      hs.paddingTop,
+      hs.paddingBottom,
+      hs.verticalAlign,
+    )
     const textWidth = colWidth - hs.paddingLeft - hs.paddingRight
 
-    doc.text(col.label || col.key, textX, textY, {
+    const headerLabel = col.label || col.key
+    doc.text(headerLabel, textX, textY, {
       width: textWidth,
       align: hs.align,
       lineBreak: false,
+    })
+    paintTextDecoration(doc, headerLabel, hs.textDecoration, {
+      x: textX,
+      y: textY,
+      width: textWidth,
+      align: hs.align,
+      fontSize: hs.fontSize,
+      color: hs.color,
     })
 
     colX += colWidth
@@ -222,14 +244,24 @@ function renderDataRow(
       doc.restore()
     }
 
-    const fontFamily = rs.fontFamily || 'Helvetica'
-    const fontName = rs.fontWeight === 'bold' ? `${fontFamily}-Bold` : fontFamily
+    // Honour both fontWeight + fontStyle across the four PDF Standard
+    // face variants. Body cells don't currently bind a `fontId` so the
+    // custom-font branch is skipped here; a follow-up can pipe the
+    // template's font map through if per-column custom fonts ship.
+    const fontName = resolvePdfFontName(rs.fontFamily, rs.fontWeight, rs.fontStyle)
     doc.font(fontName)
     doc.fontSize(rs.fontSize)
     doc.fillColor(rs.color)
 
     const textX = colX + rs.paddingLeft
-    const textY = startY + rs.paddingTop
+    const textY = resolveCellTextY(
+      startY,
+      rowHeight,
+      rs.fontSize,
+      rs.paddingTop,
+      rs.paddingBottom,
+      rs.verticalAlign,
+    )
     const textWidth = colWidth - rs.paddingLeft - rs.paddingRight
     const maxTextRows = 1
 
@@ -270,17 +302,16 @@ function renderDataRow(
       }
     }
 
-    if (rs.textDecoration === 'underline') {
-      const actualWidth = doc.widthOfString(cellValue)
-      doc.save()
-      doc.strokeColor(rs.color)
-      doc.lineWidth(0.5)
-      doc
-        .moveTo(textX, textY + rs.fontSize + 1)
-        .lineTo(textX + Math.min(actualWidth, textWidth), textY + rs.fontSize + 1)
-        .stroke()
-      doc.restore()
-    }
+    // Underline + line-through via the shared helper so both
+    // decorations track across cell wrapping / alignment.
+    paintTextDecoration(doc, cellValue, rs.textDecoration, {
+      x: textX,
+      y: textY,
+      width: textWidth,
+      align: rs.align,
+      fontSize: rs.fontSize,
+      color: rs.color,
+    })
 
     colX += colWidth
   }

--- a/packages/core/src/render/pdfFontResolver.ts
+++ b/packages/core/src/render/pdfFontResolver.ts
@@ -1,0 +1,89 @@
+/**
+ * Resolve a PDFKit font name from a (family, weight, style) triple.
+ *
+ * PDFKit ships the 14 PDF Standard fonts, each with up to four faces:
+ *
+ *   Helvetica   / Helvetica-Bold   / Helvetica-Oblique / Helvetica-BoldOblique
+ *   Times-Roman / Times-Bold       / Times-Italic      / Times-BoldItalic
+ *   Courier     / Courier-Bold     / Courier-Oblique   / Courier-BoldOblique
+ *
+ * The UI exposes `fontWeight: 'normal' | 'bold'` and
+ * `fontStyle: 'normal' | 'italic'` flags on every text-bearing style
+ * (text fields, table cells, table headers). Before this helper the
+ * renderers ignored the flags entirely — bold/italic toggled in the
+ * editor never made it into the PDF.
+ *
+ * For user-uploaded custom fonts (`fontId` set, registered via
+ * `doc.registerFont`) we cannot synthesise bold/italic from a single
+ * font file. The caller is expected to upload separate weight / style
+ * variants as their own fonts. We return the registered name unchanged
+ * — the flags are intentionally ignored in that branch.
+ */
+
+export type FontWeight = 'normal' | 'bold'
+export type FontStyle = 'normal' | 'italic'
+
+interface StandardFamily {
+  base: string
+  bold: string
+  italic: string
+  boldItalic: string
+}
+
+const STANDARD_FAMILIES: Record<string, StandardFamily> = {
+  Helvetica: {
+    base: 'Helvetica',
+    bold: 'Helvetica-Bold',
+    italic: 'Helvetica-Oblique',
+    boldItalic: 'Helvetica-BoldOblique',
+  },
+  'Times-Roman': {
+    base: 'Times-Roman',
+    bold: 'Times-Bold',
+    italic: 'Times-Italic',
+    boldItalic: 'Times-BoldItalic',
+  },
+  Courier: {
+    base: 'Courier',
+    bold: 'Courier-Bold',
+    italic: 'Courier-Oblique',
+    boldItalic: 'Courier-BoldOblique',
+  },
+}
+
+/**
+ * Resolve the PDFKit font name to pass to `doc.font(name)`.
+ *
+ * @param fontFamily   - One of the 14 PDF Standard families, or the
+ *                       value the UI persisted (e.g. 'Helvetica').
+ * @param fontWeight   - 'normal' | 'bold'. Defaults to 'normal'.
+ * @param fontStyle    - 'normal' | 'italic'. Defaults to 'normal'.
+ * @param customFontName - Registered name from `registerFont` (set
+ *                       when the user attached a custom font). When
+ *                       present this wins — the standard-family
+ *                       suffix lookup is skipped because a custom
+ *                       face can't be synthesised on the fly.
+ */
+export function resolvePdfFontName(
+  fontFamily: string | undefined,
+  fontWeight: FontWeight | undefined,
+  fontStyle: FontStyle | undefined,
+  customFontName?: string | null,
+): string {
+  if (customFontName && customFontName.length > 0) {
+    return customFontName
+  }
+  const family = fontFamily && fontFamily.length > 0 ? fontFamily : 'Helvetica'
+  const std = STANDARD_FAMILIES[family]
+  if (!std) {
+    // Unknown family — return as-is so the caller surfaces a missing-
+    // font error from PDFKit if the user typo'd.
+    return family
+  }
+  const bold = fontWeight === 'bold'
+  const italic = fontStyle === 'italic'
+  if (bold && italic) return std.boldItalic
+  if (bold) return std.bold
+  if (italic) return std.italic
+  return std.base
+}

--- a/packages/core/src/render/text.ts
+++ b/packages/core/src/render/text.ts
@@ -1,6 +1,8 @@
 import type PDFDocument from 'pdfkit'
 import type { FieldDefinition, TextFieldStyle } from '@template-goblin/types'
 import { measureText, truncateLines } from '../utils/measure.js'
+import { resolvePdfFontName } from './pdfFontResolver.js'
+import { paintTextDecoration } from './textDecoration.js'
 
 /**
  * Render a text field onto a PDFKit document within its bounding rectangle.
@@ -22,8 +24,18 @@ export function renderText(
   const style = field.style as TextFieldStyle
   const { x, y, width, height } = field
 
-  // Set font
-  const fontName = (style.fontId && fonts.get(style.fontId)) ?? style.fontFamily
+  // Set font. Resolves fontFamily + fontWeight + fontStyle into the
+  // PDFKit name (Helvetica-BoldOblique, Times-BoldItalic, …) so the
+  // bold/italic toggles in the editor actually reach the PDF. Custom
+  // uploaded fonts win — they're registered with their own name and
+  // bold/italic variants must come from separately uploaded files.
+  const customFontName = style.fontId ? (fonts.get(style.fontId) ?? null) : null
+  const fontName = resolvePdfFontName(
+    style.fontFamily,
+    style.fontWeight,
+    style.fontStyle,
+    customFontName,
+  )
   doc.font(fontName)
 
   // Set text color
@@ -80,10 +92,20 @@ export function renderText(
     if (lineY + lineHeightPt > y + height) break
     if (lineY < y) continue
 
-    doc.text(lines[i] ?? '', x, lineY, {
+    const line = lines[i] ?? ''
+    doc.text(line, x, lineY, {
       width,
       align: style.align,
       lineBreak: false,
+    })
+    // Underline / line-through — was silently dropped pre-fix.
+    paintTextDecoration(doc, line, style.textDecoration, {
+      x,
+      y: lineY,
+      width,
+      align: style.align,
+      fontSize,
+      color: style.color,
     })
   }
 }

--- a/packages/core/src/render/textDecoration.ts
+++ b/packages/core/src/render/textDecoration.ts
@@ -1,0 +1,56 @@
+import type PDFDocument from 'pdfkit'
+import type { TextDecoration, TextAlign } from '@template-goblin/types'
+
+/**
+ * Paint underline / line-through for a single rendered text line.
+ *
+ * PDFKit doesn't expose a text-decoration option, so we paint the line
+ * manually after `doc.text(...)`. Both renderers (text.ts +
+ * loop.ts) call this so the editor's Underline / Strikethrough
+ * toggles reach the PDF.
+ *
+ * Coordinates expect the line was drawn at (lineX, lineY) inside a box
+ * `width` wide using `align`. We measure the actual painted width with
+ * `doc.widthOfString` and offset within the box so the decoration
+ * tracks the visible glyphs (otherwise a centred or right-aligned
+ * single-line cell would have its underline floating in the empty gap).
+ */
+export function paintTextDecoration(
+  doc: InstanceType<typeof PDFDocument>,
+  text: string,
+  decoration: TextDecoration,
+  options: {
+    x: number
+    y: number
+    width: number
+    align: TextAlign
+    fontSize: number
+    color: string
+  },
+): void {
+  if (decoration === 'none') return
+  if (!text) return
+
+  const measured = Math.min(doc.widthOfString(text), options.width)
+  // Horizontal start of the painted glyph run.
+  let startX = options.x
+  if (options.align === 'center') startX = options.x + (options.width - measured) / 2
+  else if (options.align === 'right') startX = options.x + options.width - measured
+
+  // PDFKit's baseline sits roughly at y + ~0.8*fontSize. We paint
+  // underline slightly below the baseline and line-through near the
+  // centre of the line so both decorations read as expected without
+  // touching glyphs.
+  const lineY =
+    decoration === 'underline'
+      ? options.y + options.fontSize + 1
+      : options.y + options.fontSize * 0.55
+
+  doc.save()
+  doc.strokeColor(options.color).lineWidth(Math.max(0.5, options.fontSize * 0.06))
+  doc
+    .moveTo(startX, lineY)
+    .lineTo(startX + measured, lineY)
+    .stroke()
+  doc.restore()
+}

--- a/packages/core/tests/render/cellVerticalAlign.test.ts
+++ b/packages/core/tests/render/cellVerticalAlign.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Tests for the cell verticalAlign resolver.
+ *
+ * Pre-fix the table renderer always rendered cell text at
+ * `startY + paddingTop`, ignoring the editor's vAlign toggle. The
+ * plain-text renderer already honoured the same flag — these tests
+ * pin the table-cell parity.
+ */
+import { resolveCellTextY } from '../../src/render/cellVerticalAlign.js'
+
+describe('resolveCellTextY', () => {
+  // Cell at y=100, 40 tall, fontSize 12, paddings 4/4.
+  const startY = 100
+  const rowHeight = 40
+  const fontSize = 12
+  const padTop = 4
+  const padBottom = 4
+
+  it('top → startY + paddingTop', () => {
+    expect(resolveCellTextY(startY, rowHeight, fontSize, padTop, padBottom, 'top')).toBe(104)
+  })
+
+  it('middle → centred inside the cell', () => {
+    // (40 - 12) / 2 = 14 → 100 + 14 = 114
+    expect(resolveCellTextY(startY, rowHeight, fontSize, padTop, padBottom, 'middle')).toBe(114)
+  })
+
+  it('bottom → flush to the bottom inside paddingBottom', () => {
+    // 100 + 40 - 4 - 12 = 124
+    expect(resolveCellTextY(startY, rowHeight, fontSize, padTop, padBottom, 'bottom')).toBe(124)
+  })
+
+  it('top with zero padding stays at startY', () => {
+    expect(resolveCellTextY(0, 30, 10, 0, 0, 'top')).toBe(0)
+  })
+
+  it('middle with asymmetric paddings still centres on rowHeight', () => {
+    // verticalAlign: middle ignores paddings on purpose — the cell
+    // box is the source of truth for vertical centring.
+    expect(resolveCellTextY(0, 30, 10, 0, 12, 'middle')).toBe(10)
+  })
+
+  it('bottom respects paddingBottom even with asymmetric paddings', () => {
+    // 0 + 30 - 6 - 10 = 14
+    expect(resolveCellTextY(0, 30, 10, 0, 6, 'bottom')).toBe(14)
+  })
+
+  it('large fontSize relative to rowHeight: middle can produce a negative offset from startY', () => {
+    // A cell shorter than its font + paddings has the text leaking
+    // upward when centred. The renderer's clip rect handles the
+    // visible bound; the resolver itself shouldn't clamp.
+    // (10 - 12) / 2 = -1 → startY 0 + -1 = -1
+    expect(resolveCellTextY(0, 10, 12, 0, 0, 'middle')).toBe(-1)
+  })
+})

--- a/packages/core/tests/render/loop.vAlign.test.ts
+++ b/packages/core/tests/render/loop.vAlign.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Integration test for the cell-verticalAlign fix in loop.ts.
+ *
+ * The renderer sets rowHeight from the table-level `rowStyle`
+ * (`cellRowHeight = fontSize + paddingTop + paddingBottom`). A per-
+ * column override with a SMALLER fontSize leaves vertical slack
+ * inside that column's cell — which is where `verticalAlign` becomes
+ * observable. This test paints two columns: a tall one (fontSize 20)
+ * that drives the row height, and a short one (fontSize 8) whose
+ * cell has slack. We then flip the SHORT column's `verticalAlign`
+ * and assert the captured text y changes accordingly.
+ */
+import PDFDocument from 'pdfkit'
+import { renderLoop } from '../../src/render/loop.js'
+import type { TableField, TableRow, TemplateMeta, VerticalAlign } from '@template-goblin/types'
+import { BASE_CELL, dynTable } from '../helpers/fixtures.js'
+
+function createMeta(): TemplateMeta {
+  return {
+    name: 'vAlign integration',
+    width: 595,
+    height: 842,
+    unit: 'pt',
+    pageSize: 'A4',
+    locked: false,
+    maxPages: 5,
+    createdAt: '2025-01-01T00:00:00Z',
+    updatedAt: '2025-01-01T00:00:00Z',
+  }
+}
+
+function buildField(shortColVAlign: VerticalAlign): TableField {
+  const field = dynTable('vAlign-integration', 'items', false, ['short', 'tall'], {
+    x: 0,
+    y: 100,
+    width: 400,
+    height: 400,
+    zIndex: 0,
+  })
+  // Row height is driven by `tall` style — fontSize 20 + paddings 4/4 = 28.
+  // The `short` column overrides fontSize to 8, leaving 12 px of vertical
+  // slack inside the same 28-tall row. verticalAlign on the short cell
+  // chooses where inside that slack the 8 px text lands.
+  field.style.rowStyle = { ...BASE_CELL, fontSize: 20, paddingTop: 4, paddingBottom: 4 }
+  field.style.headerStyle = { ...BASE_CELL, fontSize: 20, paddingTop: 4, paddingBottom: 4 }
+  field.style.showHeader = false
+  field.style.columns = [
+    {
+      key: 'short',
+      label: 'Short',
+      width: 200,
+      style: {
+        fontSize: 8,
+        paddingTop: 4,
+        paddingBottom: 4,
+        verticalAlign: shortColVAlign,
+      },
+      headerStyle: null,
+    },
+    { key: 'tall', label: 'Tall', width: 200, style: null, headerStyle: null },
+  ]
+  return field
+}
+
+async function captureShortCellY(vAlign: VerticalAlign): Promise<number | undefined> {
+  return new Promise((resolve, reject) => {
+    const field = buildField(vAlign)
+    const doc = new PDFDocument({ size: [595, 842], margin: 0 })
+    const found: number[] = []
+    const origText = doc.text.bind(doc)
+    ;(doc as unknown as { text: typeof origText }).text = function (...args: unknown[]) {
+      const [text, , y] = args as [string, number, number]
+      if (text === 'short cell' && typeof y === 'number') found.push(y)
+      return (origText as unknown as (...a: unknown[]) => InstanceType<typeof PDFDocument>)(...args)
+    }
+    const chunks: Buffer[] = []
+    doc.on('data', (c: Buffer) => chunks.push(c))
+    doc.on('end', () => resolve(found[0]))
+    doc.on('error', reject)
+    const rows: TableRow[] = [{ short: 'short cell', tall: 'tall cell' }]
+    renderLoop(doc, field, rows, new Map(), createMeta(), null)
+    doc.end()
+  })
+}
+
+describe('renderLoop body cell verticalAlign — observable with row-height slack', () => {
+  it('top < middle < bottom for the y of the short-font cell', async () => {
+    const yTop = await captureShortCellY('top')
+    const yMid = await captureShortCellY('middle')
+    const yBot = await captureShortCellY('bottom')
+    expect(yTop).toBeDefined()
+    expect(yMid).toBeDefined()
+    expect(yBot).toBeDefined()
+    expect(yTop! < yMid!).toBe(true)
+    expect(yMid! < yBot!).toBe(true)
+  })
+
+  it('top + bottom should bracket roughly the rowHeight - 2*padding - fontSize delta', async () => {
+    // rowHeight = 28, padTop/Bottom = 4 each, short font = 8.
+    // top    → startY + 4         (paddingTop)
+    // bottom → startY + 28 - 4 - 8 = startY + 16
+    // delta  → 12
+    const yTop = await captureShortCellY('top')
+    const yBot = await captureShortCellY('bottom')
+    expect(yBot! - yTop!).toBeCloseTo(12, 1)
+  })
+})

--- a/packages/core/tests/render/pdfFontResolver.test.ts
+++ b/packages/core/tests/render/pdfFontResolver.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Tests for the (family, weight, style) → PDFKit font name resolver.
+ *
+ * Pre-fix the renderers ignored fontWeight + fontStyle, so the editor's
+ * Bold / Italic toggles never reached the PDF. These tests pin the
+ * mapping across the three standard families that ship with PDFKit
+ * plus the custom-font escape hatch.
+ */
+import { resolvePdfFontName } from '../../src/render/pdfFontResolver.js'
+
+describe('resolvePdfFontName', () => {
+  describe('Helvetica family', () => {
+    it('returns the base name for normal / normal', () => {
+      expect(resolvePdfFontName('Helvetica', 'normal', 'normal')).toBe('Helvetica')
+    })
+    it('returns Helvetica-Bold for bold', () => {
+      expect(resolvePdfFontName('Helvetica', 'bold', 'normal')).toBe('Helvetica-Bold')
+    })
+    it('returns Helvetica-Oblique for italic', () => {
+      expect(resolvePdfFontName('Helvetica', 'normal', 'italic')).toBe('Helvetica-Oblique')
+    })
+    it('returns Helvetica-BoldOblique for bold + italic', () => {
+      expect(resolvePdfFontName('Helvetica', 'bold', 'italic')).toBe('Helvetica-BoldOblique')
+    })
+  })
+
+  describe('Times-Roman family', () => {
+    it('returns the base name for normal / normal', () => {
+      expect(resolvePdfFontName('Times-Roman', 'normal', 'normal')).toBe('Times-Roman')
+    })
+    it('returns Times-Bold for bold', () => {
+      expect(resolvePdfFontName('Times-Roman', 'bold', 'normal')).toBe('Times-Bold')
+    })
+    it('returns Times-Italic for italic (NOT -Oblique)', () => {
+      expect(resolvePdfFontName('Times-Roman', 'normal', 'italic')).toBe('Times-Italic')
+    })
+    it('returns Times-BoldItalic for bold + italic', () => {
+      expect(resolvePdfFontName('Times-Roman', 'bold', 'italic')).toBe('Times-BoldItalic')
+    })
+  })
+
+  describe('Courier family', () => {
+    it('returns the base name for normal / normal', () => {
+      expect(resolvePdfFontName('Courier', 'normal', 'normal')).toBe('Courier')
+    })
+    it('returns Courier-Bold for bold', () => {
+      expect(resolvePdfFontName('Courier', 'bold', 'normal')).toBe('Courier-Bold')
+    })
+    it('returns Courier-Oblique for italic', () => {
+      expect(resolvePdfFontName('Courier', 'normal', 'italic')).toBe('Courier-Oblique')
+    })
+    it('returns Courier-BoldOblique for bold + italic', () => {
+      expect(resolvePdfFontName('Courier', 'bold', 'italic')).toBe('Courier-BoldOblique')
+    })
+  })
+
+  describe('custom embedded fonts', () => {
+    it('uses the registered name when provided, ignoring bold + italic', () => {
+      // A user-uploaded font is registered with its own name; bold and
+      // italic must come from separate uploaded files, not from a
+      // suffix lookup. The resolver returns the custom name as-is.
+      expect(resolvePdfFontName('Helvetica', 'bold', 'italic', 'MyCustomFont')).toBe('MyCustomFont')
+    })
+    it('falls back to the standard lookup when custom name is empty', () => {
+      expect(resolvePdfFontName('Helvetica', 'bold', undefined, '')).toBe('Helvetica-Bold')
+    })
+    it('falls back to the standard lookup when custom name is null', () => {
+      expect(resolvePdfFontName('Times-Roman', undefined, 'italic', null)).toBe('Times-Italic')
+    })
+  })
+
+  describe('defaults', () => {
+    it('defaults to Helvetica when family is missing', () => {
+      expect(resolvePdfFontName(undefined, 'bold', 'normal')).toBe('Helvetica-Bold')
+    })
+    it('returns unknown family names unchanged (so PDFKit surfaces missing-font errors)', () => {
+      expect(resolvePdfFontName('NotAFont', 'bold', 'italic')).toBe('NotAFont')
+    })
+  })
+})

--- a/packages/ui/e2e/bug-09-save-drops-warn.spec.ts
+++ b/packages/ui/e2e/bug-09-save-drops-warn.spec.ts
@@ -1,14 +1,10 @@
 /**
- * BUG-09 — Regression test (#137).
+ * BUG-09 — Regression test (#137), updated for #158.
  *
- * saveTemplate used to silently drop fields with missing `source`
- * (just a console.warn). The user only saw a successful download
- * even though some fields disappeared. Now saveTemplate returns
- * { droppedFieldIds } and the Save button's handler shows a window
- * alert listing what was lost.
- *
- * This test stubs window.alert, seeds a legacy field, clicks Save,
- * and asserts the alert text mentions the dropped field id.
+ * Saving with a no-source field surfaces a user-visible dialog
+ * listing the dropped ids. Previously the test stubbed
+ * window.alert; now the same surface is rendered through the
+ * custom AlertDialog primitive, so we drive it by its testid.
  */
 import type { Page } from '@playwright/test'
 import { test, expect } from '@playwright/test'
@@ -31,22 +27,14 @@ async function onboardSolidColor(page: Page): Promise<void> {
   await page.getByRole('button', { name: /Apply/i }).click()
 }
 
-test('BUG-09: saving with a no-source field surfaces a user-visible alert', async ({ page }) => {
+test('BUG-09: saving with a no-source field opens a custom Alert listing the dropped ids', async ({
+  page,
+}) => {
   await clearStorage(page)
   await page.goto('/')
   await onboardSolidColor(page)
   await expect(page.locator('canvas').first()).toBeVisible({ timeout: 5000 })
 
-  // Capture window.alert text into the page so the test can read it back.
-  await page.evaluate(() => {
-    type W = Window & { __lastAlert?: string }
-    const w = window as W
-    w.alert = (msg?: string) => {
-      w.__lastAlert = msg ?? ''
-    }
-  })
-
-  // Seed a legacy (no-source) field.
   await page.evaluate(() => {
     type W = Window & {
       __templateStore?: { getState: () => { addField: (f: unknown) => void } }
@@ -67,20 +55,12 @@ test('BUG-09: saving with a no-source field surfaces a user-visible alert', asyn
   })
 
   await page.locator('[data-testid="toolbar-save"]').click()
-  // The Save button triggers an async chain; give the alert a moment.
-  await page.waitForFunction(
-    () => {
-      type W = Window & { __lastAlert?: string }
-      return typeof (window as W).__lastAlert === 'string'
-    },
-    { timeout: 5000 },
-  )
 
-  const alertText = await page.evaluate(() => {
-    type W = Window & { __lastAlert?: string }
-    return (window as W).__lastAlert ?? ''
-  })
+  const dialog = page.locator('[data-testid="dialog-alert"]')
+  await expect(dialog).toBeVisible({ timeout: 5000 })
+  await expect(dialog).toContainText(/could not be written|outdated format/i)
+  await expect(dialog).toContainText('field-bug09-legacy')
 
-  expect(alertText).toMatch(/could not be written|outdated format/i)
-  expect(alertText).toContain('field-bug09-legacy')
+  await page.locator('[data-testid="dialog-alert-ok"]').click()
+  await expect(dialog).toHaveCount(0)
 })

--- a/packages/ui/e2e/issue-158-dialog-primitives.spec.ts
+++ b/packages/ui/e2e/issue-158-dialog-primitives.spec.ts
@@ -106,7 +106,7 @@ test.describe('#158 — custom Radix dialog primitives replace native alert/conf
 
     const dialog = page.locator('[data-testid="dialog-alert"]')
     await expect(dialog).toBeVisible({ timeout: 5000 })
-    await expect(dialog).toContainText(/Ctrl\+Z/i)
+    await expect(dialog).toContainText(/Ctrl\s*\+\s*Z/i)
     await page.locator('[data-testid="dialog-alert-ok"]').click()
     await expect(dialog).toHaveCount(0)
   })

--- a/packages/ui/e2e/issue-158-dialog-primitives.spec.ts
+++ b/packages/ui/e2e/issue-158-dialog-primitives.spec.ts
@@ -1,0 +1,113 @@
+/**
+ * #158 — Regression test for the Radix-based custom dialog primitives.
+ *
+ * Exercises the three replacement surfaces:
+ *  - PromptDialog (group-name input in the left panel).
+ *  - ConfirmDialog (File → New 'discard unsaved work?').
+ *  - AlertDialog (Help → Shortcuts).
+ *
+ * Asserts the dialog opens, the actions resolve cleanly, and that
+ * no native browser dialog is fired (which would block Playwright
+ * unless explicitly handled).
+ */
+import type { Page } from '@playwright/test'
+import { test, expect } from '@playwright/test'
+
+async function clearStorage(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    localStorage.removeItem('template-goblin-template')
+    localStorage.removeItem('template-goblin-ui')
+    try {
+      indexedDB.deleteDatabase('template-goblin')
+    } catch {
+      /* ignore */
+    }
+  })
+}
+
+async function onboardSolidColor(page: Page): Promise<void> {
+  await page.locator('[data-testid="onboarding-solid-color"]').click()
+  await page.getByRole('button', { name: /Next/i }).click()
+  await page.getByRole('button', { name: /Apply/i }).click()
+}
+
+test.describe('#158 — custom Radix dialog primitives replace native alert/confirm/prompt', () => {
+  test.beforeEach(async ({ page }) => {
+    await clearStorage(page)
+    await page.goto('/')
+    await onboardSolidColor(page)
+    await expect(page.locator('canvas').first()).toBeVisible({ timeout: 5000 })
+  })
+
+  test('PromptDialog: New Group asks for a name via the custom prompt', async ({ page }) => {
+    // Wait for the left panel to be visible (showLeftPanel default false in
+    // some flows — set it on so the New Group button is reachable).
+    await page.evaluate(() => {
+      type W = Window & {
+        __uiStore?: { getState: () => { setShowLeftPanel: (b: boolean) => void } }
+      }
+      const w = window as W
+      w.__uiStore?.getState().setShowLeftPanel(true)
+    })
+
+    // The 'New Group' control is rendered by the left-panel field list.
+    const newGroupBtn = page.getByRole('button', { name: /New Group/i }).first()
+    await newGroupBtn.click()
+
+    const dialog = page.locator('[data-testid="dialog-prompt"]')
+    await expect(dialog).toBeVisible({ timeout: 5000 })
+    await expect(dialog).toContainText(/Group name/i)
+
+    const input = page.locator('[data-testid="dialog-prompt-input"]')
+    await expect(input).toBeFocused()
+    await input.fill('Marketing copy')
+    await page.locator('[data-testid="dialog-prompt-ok"]').click()
+    await expect(dialog).toHaveCount(0)
+
+    const groups = await page.evaluate(() => {
+      type W = Window & {
+        __templateStore?: {
+          getState: () => { groups: Array<{ name: string }> }
+        }
+      }
+      const w = window as W
+      return w.__templateStore?.getState().groups.map((g) => g.name) ?? []
+    })
+    expect(groups).toContain('Marketing copy')
+  })
+
+  test('PromptDialog: empty input is rejected with an inline error', async ({ page }) => {
+    await page.evaluate(() => {
+      type W = Window & {
+        __uiStore?: { getState: () => { setShowLeftPanel: (b: boolean) => void } }
+      }
+      const w = window as W
+      w.__uiStore?.getState().setShowLeftPanel(true)
+    })
+    await page
+      .getByRole('button', { name: /New Group/i })
+      .first()
+      .click()
+
+    // OK is disabled while validate() returns an error string.
+    const ok = page.locator('[data-testid="dialog-prompt-ok"]')
+    await expect(ok).toBeDisabled()
+
+    await page.locator('[data-testid="dialog-prompt-input"]').fill('   ')
+    await expect(page.locator('[data-testid="dialog-prompt-error"]')).toBeVisible()
+    await expect(ok).toBeDisabled()
+  })
+
+  test('AlertDialog: Help → Shortcuts opens the custom alert with the shortcut list', async ({
+    page,
+  }) => {
+    await page.locator('[data-testid="menu-tab-help"]').click()
+    await page.locator('[data-testid="ribbon-help-shortcuts"]').click()
+
+    const dialog = page.locator('[data-testid="dialog-alert"]')
+    await expect(dialog).toBeVisible({ timeout: 5000 })
+    await expect(dialog).toContainText(/Ctrl\+Z/i)
+    await page.locator('[data-testid="dialog-alert-ok"]').click()
+    await expect(dialog).toHaveCount(0)
+  })
+})

--- a/packages/ui/e2e/issue-161-static-label-fallback.spec.ts
+++ b/packages/ui/e2e/issue-161-static-label-fallback.spec.ts
@@ -1,0 +1,86 @@
+/**
+ * #161 — Regression test for the BUG-11 follow-up.
+ *
+ * When a text field has been flipped Dynamic → Static and its static
+ * value is empty (no carried-over placeholder), the FIELDS list used
+ * to fall back to '<static text>'. It now falls back to the memo'd
+ * dynamic jsonKey (e.g. 'texts.student_name') so the user still has
+ * a recognisable label.
+ *
+ * Driven through `setFieldMode` so we exercise the same path the UI's
+ * Dynamic / Static toggle takes.
+ */
+import type { Page } from '@playwright/test'
+import { test, expect } from '@playwright/test'
+
+async function clearStorage(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    localStorage.removeItem('template-goblin-template')
+    localStorage.removeItem('template-goblin-ui')
+    try {
+      indexedDB.deleteDatabase('template-goblin')
+    } catch {
+      /* ignore */
+    }
+  })
+}
+
+async function onboardSolidColor(page: Page): Promise<void> {
+  await page.locator('[data-testid="onboarding-solid-color"]').click()
+  await page.getByRole('button', { name: /Next/i }).click()
+  await page.getByRole('button', { name: /Apply/i }).click()
+}
+
+test('#161: static field with empty value shows the memo dynamic jsonKey, not <static text>', async ({
+  page,
+}) => {
+  await clearStorage(page)
+  await page.goto('/')
+  await onboardSolidColor(page)
+  await expect(page.locator('canvas').first()).toBeVisible({ timeout: 5000 })
+
+  // Ensure the right panel (which renders the FIELDS list) is open.
+  await page.evaluate(() => {
+    type W = Window & {
+      __uiStore?: { getState: () => { setShowRightPanel: (b: boolean) => void } }
+    }
+    const w = window as W
+    w.__uiStore?.getState().setShowRightPanel(true)
+  })
+
+  // Seed a dynamic text field with jsonKey 'student_name' and an EMPTY
+  // placeholder, then flip to Static. After the flip the static
+  // `value` is empty (no placeholder to carry), so the label should
+  // come from the memo.
+  await page.evaluate(() => {
+    type W = Window & {
+      __templateStore?: {
+        getState: () => {
+          addField: (f: unknown) => void
+          setFieldMode: (id: string, mode: 'static' | 'dynamic') => void
+        }
+      }
+    }
+    const w = window as W
+    const api = w.__templateStore!.getState()
+    api.addField({
+      id: 'field-161-static',
+      type: 'text',
+      x: 10,
+      y: 10,
+      width: 120,
+      height: 24,
+      zIndex: 0,
+      pageId: null,
+      groupId: null,
+      source: { mode: 'dynamic', jsonKey: 'student_name', required: false, placeholder: '' },
+      style: {},
+    })
+    w.__templateStore!.getState().setFieldMode('field-161-static', 'static')
+  })
+
+  // The field-list row should now read 'texts.student_name', not '<static text>'.
+  const row = page.locator('.tg-field-item-key').filter({ hasText: /student_name/i })
+  await expect(row.first()).toBeVisible()
+  await expect(page.locator('.tg-field-item-key', { hasText: '<static text>' })).toHaveCount(0)
+})

--- a/packages/ui/e2e/ux-04-new-confirm.spec.ts
+++ b/packages/ui/e2e/ux-04-new-confirm.spec.ts
@@ -1,10 +1,8 @@
 /**
- * UX-04 — Regression test (#150).
+ * UX-04 — Regression test (#150), updated for #158.
  *
- * Clicking File → New must prompt for confirmation before wiping the
- * current template. The handler in FileRibbon already calls
- * `window.confirm(...)`; this test stubs confirm to return false and
- * asserts the template state is left untouched.
+ * File → New now uses the custom ConfirmDialog primitive. Clicking
+ * Cancel must leave the template state untouched.
  */
 import type { Page } from '@playwright/test'
 import { test, expect } from '@playwright/test'
@@ -27,13 +25,12 @@ async function onboardSolidColor(page: Page): Promise<void> {
   await page.getByRole('button', { name: /Apply/i }).click()
 }
 
-test('UX-04: File → New is guarded by a confirm prompt', async ({ page }) => {
+test('UX-04: File → New shows a confirm dialog; Cancel preserves state', async ({ page }) => {
   await clearStorage(page)
   await page.goto('/')
   await onboardSolidColor(page)
   await expect(page.locator('canvas').first()).toBeVisible({ timeout: 5000 })
 
-  // Seed a field so we can prove state survived.
   await page.evaluate(() => {
     type W = Window & {
       __templateStore?: { getState: () => { addField: (f: unknown) => void } }
@@ -54,14 +51,13 @@ test('UX-04: File → New is guarded by a confirm prompt', async ({ page }) => {
     })
   })
 
-  // Stub confirm() to decline. The handler in FileRibbon must early-
-  // return without touching the store.
-  await page.evaluate(() => {
-    window.confirm = () => false
-  })
-
   await page.locator('[data-testid="menu-tab-file"]').click()
   await page.locator('[data-testid="toolbar-new"]').click()
+
+  const dialog = page.locator('[data-testid="dialog-confirm"]')
+  await expect(dialog).toBeVisible({ timeout: 5000 })
+  await page.locator('[data-testid="dialog-confirm-cancel"]').click()
+  await expect(dialog).toHaveCount(0)
 
   const survives = await page.evaluate(() => {
     type W = Window & {

--- a/packages/ui/src/App.css
+++ b/packages/ui/src/App.css
@@ -496,6 +496,18 @@ html, body, #root {
   to   { opacity: 1; transform: translateY(0); }
 }
 
+/* Dialog entry — used by the v3 Alert / Confirm / Prompt primitives
+ * (#158). Overlay fades in; content scales up from 97% with a tiny
+ * lift so the dialog lands rather than appearing. */
+@keyframes tg-dialog-overlay-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+@keyframes tg-dialog-content-in {
+  from { opacity: 0; transform: translate(-50%, -48%) scale(0.97); }
+  to   { opacity: 1; transform: translate(-50%, -50%) scale(1); }
+}
+
 /* ===== Left panel group sections ===== */
 .tg-field-list { @apply flex-1 overflow-y-auto; }
 .tg-field-group-header {

--- a/packages/ui/src/components/Canvas/usePageHandlers.ts
+++ b/packages/ui/src/components/Canvas/usePageHandlers.ts
@@ -10,6 +10,7 @@ import { useUiStore } from '../../store/uiStore.js'
 import { snapshotSameAsPrevious } from '../../utils/pageSnapshot.js'
 import { type PageDefinition, type PageBackgroundType, type PageSize } from '@template-goblin/types'
 import { useFieldCreationPopup } from './useFieldCreationPopup.js'
+import { useDialogs } from '../Dialogs/index.js'
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -37,6 +38,7 @@ export function usePageHandlers() {
   const setPendingBackground = useUiStore((s) => s.setPendingBackground)
   const setShowPageSizeDialog = useUiStore((s) => s.setShowPageSizeDialog)
   const currentPageId = useUiStore((s) => s.currentPageId)
+  const { confirm: showConfirm } = useDialogs()
 
   const [showAddPageDialog, setShowAddPageDialog] = useState(false)
   // The Change Background dialog is global (uiStore) so the Toolbar
@@ -252,16 +254,19 @@ export function usePageHandlers() {
   // ── Remove page ────────────────────────────────────────────────────────
 
   const handleRemovePage = useCallback(
-    (pageId: string | null) => {
+    async (pageId: string | null) => {
       // Mirror what PageBar renders: every explicit page gets a tab, plus
       // one implicit tab when no explicit page sits at index 0.
       const page0IsExplicit = pages.some((p) => p.index === 0)
       const visiblePageCount = pages.length + (page0IsExplicit ? 0 : 1)
 
       if (visiblePageCount <= 1) {
-        const ok = window.confirm(
-          'Deleting the last page will clear all fields and settings. Continue?',
-        )
+        const ok = await showConfirm({
+          title: 'Delete the last page?',
+          message: 'This will clear all fields and settings. The template returns to onboarding.',
+          confirmLabel: 'Delete page',
+          destructive: true,
+        })
         if (!ok) return
         reset()
         setCurrentPage(null)
@@ -303,7 +308,7 @@ export function usePageHandlers() {
       setCurrentPage(nextFirst?.id ?? null)
       clearSelection()
     },
-    [pages, reset, removePage, setCurrentPage, clearSelection],
+    [pages, reset, removePage, setCurrentPage, clearSelection, showConfirm],
   )
 
   return {

--- a/packages/ui/src/components/Dialogs/DialogButton.tsx
+++ b/packages/ui/src/components/Dialogs/DialogButton.tsx
@@ -1,0 +1,76 @@
+import { type ReactNode } from 'react'
+
+/**
+ * Shared button shape used inside dialog action rows. Three variants:
+ *  - 'primary' — accent-filled, default confirm action.
+ *  - 'danger'  — destructive variant, painted in --error.
+ *  - 'ghost'   — text + border, used for Cancel.
+ *
+ * Sized to --control-height-lg (32 px) so dialog actions read a bit
+ * larger than the toolbar's 28 px controls.
+ */
+export interface DialogButtonProps {
+  variant?: 'primary' | 'danger' | 'ghost'
+  onClick?: () => void
+  disabled?: boolean
+  type?: 'button' | 'submit'
+  autoFocus?: boolean
+  testid?: string
+  children: ReactNode
+}
+
+export function DialogButton({
+  variant = 'ghost',
+  onClick,
+  disabled,
+  type = 'button',
+  autoFocus,
+  testid,
+  children,
+}: DialogButtonProps) {
+  const styles = stylesFor(variant)
+  return (
+    <button
+      type={type}
+      onClick={onClick}
+      disabled={disabled}
+      autoFocus={autoFocus}
+      data-testid={testid}
+      style={{
+        height: 'var(--control-height-lg)',
+        padding: '0 14px',
+        borderRadius: 'var(--radius-md)',
+        fontSize: 'var(--text-base)',
+        fontWeight: 'var(--font-weight-medium)',
+        cursor: disabled ? 'not-allowed' : 'pointer',
+        opacity: disabled ? 0.45 : 1,
+        transition: 'background var(--duration-fast) var(--ease-out)',
+        ...styles,
+      }}
+    >
+      {children}
+    </button>
+  )
+}
+
+function stylesFor(variant: NonNullable<DialogButtonProps['variant']>): React.CSSProperties {
+  if (variant === 'primary') {
+    return {
+      background: 'var(--accent)',
+      color: 'var(--text-on-accent)',
+      border: '1px solid transparent',
+    }
+  }
+  if (variant === 'danger') {
+    return {
+      background: 'var(--error)',
+      color: 'var(--text-on-accent)',
+      border: '1px solid transparent',
+    }
+  }
+  return {
+    background: 'var(--bg-secondary)',
+    color: 'var(--text-primary)',
+    border: '1px solid var(--border)',
+  }
+}

--- a/packages/ui/src/components/Dialogs/DialogProvider.tsx
+++ b/packages/ui/src/components/Dialogs/DialogProvider.tsx
@@ -85,7 +85,18 @@ function AlertView({ state, onClose }: { state: AlertState; onClose: () => void 
         </DialogButton>
       }
     >
-      <p style={{ margin: 0, fontSize: 'var(--text-md)', color: 'var(--text-secondary)' }}>
+      <p
+        style={{
+          margin: 0,
+          fontSize: 'var(--text-md)',
+          lineHeight: 'var(--leading-relaxed)',
+          color: 'var(--text-secondary)',
+          // `pre-line` honours `\n` in the message string (so the
+          // keyboard-shortcut dump renders one line per binding) and
+          // still wraps long lines.
+          whiteSpace: 'pre-line',
+        }}
+      >
         {opts.message}
       </p>
     </DialogShell>
@@ -123,7 +134,18 @@ function ConfirmView({ state, onClose }: { state: ConfirmState; onClose: () => v
         </>
       }
     >
-      <p style={{ margin: 0, fontSize: 'var(--text-md)', color: 'var(--text-secondary)' }}>
+      <p
+        style={{
+          margin: 0,
+          fontSize: 'var(--text-md)',
+          lineHeight: 'var(--leading-relaxed)',
+          color: 'var(--text-secondary)',
+          // `pre-line` honours `\n` in the message string (so the
+          // keyboard-shortcut dump renders one line per binding) and
+          // still wraps long lines.
+          whiteSpace: 'pre-line',
+        }}
+      >
         {opts.message}
       </p>
     </DialogShell>

--- a/packages/ui/src/components/Dialogs/DialogProvider.tsx
+++ b/packages/ui/src/components/Dialogs/DialogProvider.tsx
@@ -1,0 +1,233 @@
+import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from 'react'
+import type { AlertOptions, ConfirmOptions, DialogApi, PromptOptions } from './types.js'
+import { DialogShell } from './DialogShell.js'
+import { DialogButton } from './DialogButton.js'
+
+/**
+ * App-wide custom dialog system (#158). Replaces window.alert /
+ * window.confirm / window.prompt with promise-returning primitives
+ * built on Radix Dialog, themed with v3 tokens.
+ *
+ * Mount <DialogProvider> once near the app root; call sites read the
+ * API with useDialogs() and await whichever variant they need:
+ *
+ *   const { confirm } = useDialogs()
+ *   if (await confirm({ title: 'Discard?', message: '...' })) { ... }
+ *
+ * Only one dialog is on screen at a time (matches native semantics);
+ * stacking is intentionally unsupported.
+ */
+
+type AlertState = { kind: 'alert'; opts: AlertOptions; resolve: () => void }
+type ConfirmState = { kind: 'confirm'; opts: ConfirmOptions; resolve: (ok: boolean) => void }
+type PromptState = { kind: 'prompt'; opts: PromptOptions; resolve: (v: string | null) => void }
+type ActiveDialog = AlertState | ConfirmState | PromptState | null
+
+const DialogContext = createContext<DialogApi | null>(null)
+
+export function useDialogs(): DialogApi {
+  const ctx = useContext(DialogContext)
+  if (!ctx) throw new Error('useDialogs() must be called inside <DialogProvider>')
+  return ctx
+}
+
+export function DialogProvider({ children }: { children: ReactNode }) {
+  const [active, setActive] = useState<ActiveDialog>(null)
+
+  const api = useMemo<DialogApi>(
+    () => ({
+      alert: (opts) =>
+        new Promise<void>((resolve) => {
+          setActive({ kind: 'alert', opts, resolve })
+        }),
+      confirm: (opts) =>
+        new Promise<boolean>((resolve) => {
+          setActive({ kind: 'confirm', opts, resolve })
+        }),
+      prompt: (opts) =>
+        new Promise<string | null>((resolve) => {
+          setActive({ kind: 'prompt', opts, resolve })
+        }),
+    }),
+    [],
+  )
+
+  const close = useCallback(() => setActive(null), [])
+
+  return (
+    <DialogContext.Provider value={api}>
+      {children}
+      {active?.kind === 'alert' && <AlertView state={active} onClose={close} />}
+      {active?.kind === 'confirm' && <ConfirmView state={active} onClose={close} />}
+      {active?.kind === 'prompt' && <PromptView state={active} onClose={close} />}
+    </DialogContext.Provider>
+  )
+}
+
+function AlertView({ state, onClose }: { state: AlertState; onClose: () => void }) {
+  const { opts, resolve } = state
+  function ok() {
+    resolve()
+    onClose()
+  }
+  return (
+    <DialogShell
+      open
+      onOpenChange={(o) => {
+        if (!o) ok()
+      }}
+      title={opts.title}
+      accent={opts.variant ?? 'info'}
+      testid="dialog-alert"
+      actions={
+        <DialogButton variant="primary" onClick={ok} autoFocus testid="dialog-alert-ok">
+          {opts.okLabel ?? 'OK'}
+        </DialogButton>
+      }
+    >
+      <p style={{ margin: 0, fontSize: 'var(--text-md)', color: 'var(--text-secondary)' }}>
+        {opts.message}
+      </p>
+    </DialogShell>
+  )
+}
+
+function ConfirmView({ state, onClose }: { state: ConfirmState; onClose: () => void }) {
+  const { opts, resolve } = state
+  function pick(ok: boolean) {
+    resolve(ok)
+    onClose()
+  }
+  return (
+    <DialogShell
+      open
+      onOpenChange={(o) => {
+        if (!o) pick(false)
+      }}
+      title={opts.title}
+      accent={opts.destructive ? 'danger' : 'info'}
+      testid="dialog-confirm"
+      actions={
+        <>
+          <DialogButton onClick={() => pick(false)} testid="dialog-confirm-cancel">
+            {opts.cancelLabel ?? 'Cancel'}
+          </DialogButton>
+          <DialogButton
+            variant={opts.destructive ? 'danger' : 'primary'}
+            onClick={() => pick(true)}
+            autoFocus
+            testid="dialog-confirm-ok"
+          >
+            {opts.confirmLabel ?? 'Confirm'}
+          </DialogButton>
+        </>
+      }
+    >
+      <p style={{ margin: 0, fontSize: 'var(--text-md)', color: 'var(--text-secondary)' }}>
+        {opts.message}
+      </p>
+    </DialogShell>
+  )
+}
+
+function PromptView({ state, onClose }: { state: PromptState; onClose: () => void }) {
+  const { opts, resolve } = state
+  const [value, setValue] = useState(opts.defaultValue ?? '')
+  const error = opts.validate?.(value) ?? null
+  function submit() {
+    if (error) return
+    resolve(value)
+    onClose()
+  }
+  function cancel() {
+    resolve(null)
+    onClose()
+  }
+  return (
+    <DialogShell
+      open
+      onOpenChange={(o) => {
+        if (!o) cancel()
+      }}
+      title={opts.title}
+      testid="dialog-prompt"
+      actions={
+        <>
+          <DialogButton onClick={cancel} testid="dialog-prompt-cancel">
+            {opts.cancelLabel ?? 'Cancel'}
+          </DialogButton>
+          <DialogButton
+            variant="primary"
+            onClick={submit}
+            disabled={!!error}
+            testid="dialog-prompt-ok"
+          >
+            {opts.okLabel ?? 'OK'}
+          </DialogButton>
+        </>
+      }
+    >
+      {opts.message && (
+        <p
+          style={{
+            margin: 0,
+            marginBottom: 'var(--space-3)',
+            fontSize: 'var(--text-md)',
+            color: 'var(--text-secondary)',
+          }}
+        >
+          {opts.message}
+        </p>
+      )}
+      {opts.label && (
+        <label
+          htmlFor="dialog-prompt-input"
+          style={{
+            display: 'block',
+            marginBottom: 'var(--space-1)',
+            fontSize: 'var(--text-sm)',
+            fontWeight: 'var(--font-weight-medium)',
+            color: 'var(--text-secondary)',
+          }}
+        >
+          {opts.label}
+        </label>
+      )}
+      <input
+        id="dialog-prompt-input"
+        data-testid="dialog-prompt-input"
+        autoFocus
+        value={value}
+        placeholder={opts.placeholder}
+        onChange={(e) => setValue(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') submit()
+        }}
+        style={{
+          width: '100%',
+          height: 'var(--control-height-lg)',
+          padding: '0 10px',
+          fontSize: 'var(--text-md)',
+          border: `1px solid ${error ? 'var(--error)' : 'var(--border)'}`,
+          borderRadius: 'var(--radius-md)',
+          background: 'var(--bg-secondary)',
+          color: 'var(--text-primary)',
+          outline: 'none',
+        }}
+      />
+      {error && (
+        <p
+          data-testid="dialog-prompt-error"
+          style={{
+            margin: 0,
+            marginTop: 'var(--space-1)',
+            fontSize: 'var(--text-sm)',
+            color: 'var(--error)',
+          }}
+        >
+          {error}
+        </p>
+      )}
+    </DialogShell>
+  )
+}

--- a/packages/ui/src/components/Dialogs/DialogShell.tsx
+++ b/packages/ui/src/components/Dialogs/DialogShell.tsx
@@ -1,0 +1,114 @@
+import * as RadixDialog from '@radix-ui/react-dialog'
+import { type ReactNode } from 'react'
+
+/**
+ * Shared Radix-Dialog wrapper used by Alert / Confirm / Prompt. Owns
+ * overlay + content positioning + token-driven styling so the three
+ * call-site shapes only differ in body content and action row.
+ *
+ * Radix handles focus-trap, scroll-lock, ESC, portal, ARIA labelling —
+ * we just paint.
+ */
+export interface DialogShellProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  title: string
+  children: ReactNode
+  /** Action row, rendered at the bottom of the dialog body. */
+  actions: ReactNode
+  /** ARIA description id wiring is handled by Radix when set. */
+  descriptionId?: string
+  /** Optional accent stripe on the top edge — info/success/warn/danger. */
+  accent?: 'info' | 'success' | 'warning' | 'danger'
+  testid?: string
+}
+
+const ACCENT_COLOR: Record<NonNullable<DialogShellProps['accent']>, string> = {
+  info: 'var(--info)',
+  success: 'var(--success)',
+  warning: 'var(--warning)',
+  danger: 'var(--error)',
+}
+
+export function DialogShell({
+  open,
+  onOpenChange,
+  title,
+  children,
+  actions,
+  accent,
+  testid,
+}: DialogShellProps) {
+  return (
+    <RadixDialog.Root open={open} onOpenChange={onOpenChange}>
+      <RadixDialog.Portal>
+        <RadixDialog.Overlay
+          style={{
+            position: 'fixed',
+            inset: 0,
+            background: 'var(--bg-overlay)',
+            backdropFilter: 'blur(4px)',
+            zIndex: 'var(--z-overlay)' as unknown as number,
+            animation: 'tg-dialog-overlay-in 0.16s var(--ease-out)',
+          }}
+        />
+        <RadixDialog.Content
+          data-testid={testid}
+          style={{
+            position: 'fixed',
+            top: '50%',
+            left: '50%',
+            transform: 'translate(-50%, -50%)',
+            zIndex: 'var(--z-modal)' as unknown as number,
+            background: 'var(--bg-elevated)',
+            color: 'var(--text-primary)',
+            border: '1px solid var(--border)',
+            borderRadius: 'var(--radius-xl)',
+            boxShadow: 'var(--shadow-modal)',
+            minWidth: 360,
+            maxWidth: 'min(520px, calc(100vw - 32px))',
+            padding: 'var(--space-6)',
+            outline: 'none',
+            animation: 'tg-dialog-content-in 0.18s var(--ease-out)',
+          }}
+        >
+          {accent && (
+            <span
+              aria-hidden
+              style={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                right: 0,
+                height: 3,
+                background: ACCENT_COLOR[accent],
+                borderRadius: 'var(--radius-xl) var(--radius-xl) 0 0',
+              }}
+            />
+          )}
+          <RadixDialog.Title
+            style={{
+              fontSize: 'var(--text-lg)',
+              fontWeight: 'var(--font-weight-semibold)',
+              margin: 0,
+              marginBottom: 'var(--space-3)',
+              color: 'var(--text-primary)',
+            }}
+          >
+            {title}
+          </RadixDialog.Title>
+          <div style={{ marginBottom: 'var(--space-6)' }}>{children}</div>
+          <div
+            style={{
+              display: 'flex',
+              gap: 'var(--space-2)',
+              justifyContent: 'flex-end',
+            }}
+          >
+            {actions}
+          </div>
+        </RadixDialog.Content>
+      </RadixDialog.Portal>
+    </RadixDialog.Root>
+  )
+}

--- a/packages/ui/src/components/Dialogs/index.ts
+++ b/packages/ui/src/components/Dialogs/index.ts
@@ -1,0 +1,2 @@
+export { DialogProvider, useDialogs } from './DialogProvider.js'
+export type { DialogApi, AlertOptions, ConfirmOptions, PromptOptions } from './types.js'

--- a/packages/ui/src/components/Dialogs/types.ts
+++ b/packages/ui/src/components/Dialogs/types.ts
@@ -1,0 +1,62 @@
+/**
+ * Shared types for the v3 dialog system (#158). One primitive per
+ * native browser dialog the app used to call — alert / confirm /
+ * prompt — exposed via a single \`useDialogs()\` hook that returns a
+ * promise-bearing API so call-sites stay readable.
+ */
+
+export interface AlertOptions {
+  /** Headline shown at the top of the dialog. */
+  title: string
+  /** Body copy. Required — alerts without context shouldn't fire. */
+  message: string
+  /** Label for the dismiss button. Defaults to 'OK'. */
+  okLabel?: string
+  /** Intent — drives the icon + colour. Defaults to 'info'. */
+  variant?: 'info' | 'success' | 'warning' | 'danger'
+}
+
+export interface ConfirmOptions {
+  title: string
+  message: string
+  /** Confirm button label. Defaults to 'Confirm'. */
+  confirmLabel?: string
+  /** Cancel button label. Defaults to 'Cancel'. */
+  cancelLabel?: string
+  /** When true, the confirm button paints in the danger colour. */
+  destructive?: boolean
+}
+
+export interface PromptOptions {
+  title: string
+  /** Label shown above the input. */
+  label?: string
+  /** Helper / clarifying body copy. */
+  message?: string
+  /** Placeholder text inside the input. */
+  placeholder?: string
+  /** Pre-filled value. */
+  defaultValue?: string
+  /** Confirm button label. Defaults to 'OK'. */
+  okLabel?: string
+  cancelLabel?: string
+  /**
+   * Synchronous validator. Return a non-empty string to surface as an
+   * inline error and disable confirm; return null/undefined when valid.
+   */
+  validate?: (value: string) => string | null | undefined
+}
+
+/** Imperative API surfaced by \`useDialogs()\`. Each call returns a
+ *  Promise; the promise resolves with the user's choice and never
+ *  rejects (Esc / overlay click / explicit cancel all resolve cleanly). */
+export interface DialogApi {
+  /** Resolves once the user dismisses the alert. */
+  alert: (opts: AlertOptions) => Promise<void>
+  /** Resolves \`true\` on confirm, \`false\` on cancel / dismiss. */
+  confirm: (opts: ConfirmOptions) => Promise<boolean>
+  /** Resolves with the input value on confirm, \`null\` on cancel /
+   *  dismiss. Whitespace is preserved — the caller decides whether to
+   *  trim. */
+  prompt: (opts: PromptOptions) => Promise<string | null>
+}

--- a/packages/ui/src/components/LeftPanel/FieldList.tsx
+++ b/packages/ui/src/components/LeftPanel/FieldList.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { useTemplateStore } from '../../store/templateStore.js'
 import { useUiStore } from '../../store/uiStore.js'
+import { useDialogs } from '../Dialogs/index.js'
 import type { FieldDefinition, GroupDefinition } from '@template-goblin/types'
 
 const TYPE_LABELS: Record<string, string> = {
@@ -139,6 +140,7 @@ export function LeftPanel() {
   const header = useTemplateStore((s) => s.header)
   const footer = useTemplateStore((s) => s.footer)
   const addGroup = useTemplateStore((s) => s.addGroup)
+  const { prompt: promptDialog } = useDialogs()
   const updateField = useTemplateStore((s) => s.updateField)
   const selectedFieldIds = useUiStore((s) => s.selectedFieldIds)
   // Clicking a row in the left panel is equivalent to picking the element
@@ -165,11 +167,18 @@ export function LeftPanel() {
   const headerFields = header?.enabled ? header.fields : []
   const footerFields = footer?.enabled ? footer.fields : []
 
-  function handleNewGroup() {
-    const name = prompt('Group name:')
-    if (!name || !name.trim()) return
+  async function handleNewGroup() {
+    const name = await promptDialog({
+      title: 'New field group',
+      label: 'Group name',
+      placeholder: 'e.g. Header content',
+      validate: (v) => (v.trim().length === 0 ? 'Group name cannot be empty.' : null),
+    })
+    if (name === null) return
+    const trimmed = name.trim()
+    if (trimmed.length === 0) return
     const id = `group-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
-    addGroup({ id, name: name.trim() })
+    addGroup({ id, name: trimmed })
   }
 
   function handleDropField(fieldId: string, groupId: string | null) {

--- a/packages/ui/src/components/LeftPanel/FieldList.tsx
+++ b/packages/ui/src/components/LeftPanel/FieldList.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { useTemplateStore } from '../../store/templateStore.js'
+import { useTemplateStore, getFieldDynamicMemo } from '../../store/templateStore.js'
 import { useUiStore } from '../../store/uiStore.js'
 import { useDialogs } from '../Dialogs/index.js'
 import type { FieldDefinition, GroupDefinition } from '@template-goblin/types'
@@ -38,6 +38,16 @@ function fieldDisplayKey(field: FieldDefinition): string {
     }
     if (field.type === 'table' && Array.isArray(raw)) {
       return `static table · ${raw.length} row${raw.length === 1 ? '' : 's'}`
+    }
+    // BUG-11 continued: if the field was once Dynamic, fall back to
+    // the memo'd jsonKey so the user still has a recognisable label
+    // (e.g. 'texts.student_name') instead of '<static text>'. Memo
+    // is session-local — see fieldDynamicMemo in templateStore.
+    const memo = getFieldDynamicMemo(field.id)
+    if (memo?.jsonKey) {
+      const prefix =
+        field.type === 'text' ? 'texts.' : field.type === 'image' ? 'images.' : 'tables.'
+      return prefix + memo.jsonKey
     }
     return `<static ${field.type}>`
   }

--- a/packages/ui/src/components/Toolbar/FontManager.tsx
+++ b/packages/ui/src/components/Toolbar/FontManager.tsx
@@ -2,6 +2,7 @@ import { useRef } from 'react'
 import { useTemplateStore } from '../../store/templateStore.js'
 import { useUiStore } from '../../store/uiStore.js'
 import { processFontFiles } from './fontUpload.js'
+import { useDialogs } from '../Dialogs/index.js'
 
 export function FontManager() {
   const inputRef = useRef<HTMLInputElement>(null)
@@ -9,26 +10,32 @@ export function FontManager() {
   const fields = useTemplateStore((s) => s.fields)
   const removeFont = useTemplateStore((s) => s.removeFont)
   const setShowFontManager = useUiStore((s) => s.setShowFontManager)
+  const { alert: showAlert, confirm: showConfirm } = useDialogs()
 
   async function handleUpload(e: React.ChangeEvent<HTMLInputElement>) {
     const files = e.target.files
     if (!files || files.length === 0) return
     const results = await processFontFiles(files)
-    // Surface meaningful failures to the user. Extension rejections are
-    // silent because the `accept=".ttf"` attribute already filters the
-    // picker; magic-byte / size / duplicate failures are worth flagging.
     for (const r of results) {
       if (r.ok) continue
       if (r.reason === 'size') {
-        alert(`Font file too large: ${r.filename}. Maximum size is 10 MB.`)
+        await showAlert({
+          title: 'Font too large',
+          message: `Font file too large: ${r.filename}. Maximum size is 10 MB.`,
+          variant: 'danger',
+        })
       } else if (r.reason === 'magic') {
-        alert(`Invalid font file: ${r.filename}. Please select a valid .ttf file.`)
+        await showAlert({
+          title: 'Invalid font file',
+          message: `Invalid font file: ${r.filename}. Please select a valid .ttf file.`,
+          variant: 'danger',
+        })
       }
     }
     e.target.value = ''
   }
 
-  function handleRemove(fontId: string) {
+  async function handleRemove(fontId: string) {
     const usedByFields = fields.filter((f) => {
       if (f.type === 'text') {
         const style = f.style as { fontId?: string | null }
@@ -45,9 +52,13 @@ export function FontManager() {
           return `<static ${f.type}> (${f.id})`
         })
         .join(', ')
-      if (!window.confirm(`This font is used by fields: ${names}. Remove anyway?`)) {
-        return
-      }
+      const ok = await showConfirm({
+        title: 'Remove font in use?',
+        message: `This font is used by fields: ${names}. Remove anyway?`,
+        confirmLabel: 'Remove font',
+        destructive: true,
+      })
+      if (!ok) return
     }
 
     removeFont(fontId)

--- a/packages/ui/src/components/Toolbar/MenuTabBar.tsx
+++ b/packages/ui/src/components/Toolbar/MenuTabBar.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import { useTemplateStore } from '../../store/templateStore.js'
 import { useUiStore } from '../../store/uiStore.js'
 import { saveTemplate } from '../../utils/saveOpen.js'
+import { useDialogs } from '../Dialogs/index.js'
 import { FIELD_COLORS } from '../../theme/fieldColors.js'
 import { MenuButton, MenuSeparator } from './primitives/MenuButton.js'
 import { RibbonButton } from './primitives/RibbonButton.js'
@@ -178,25 +179,29 @@ export function MenuTabBar() {
   )
 
   const [savedFlash, setSavedFlash] = useState(false)
+  const { alert: showAlert } = useDialogs()
   async function handleSave() {
     try {
       const result = await saveTemplate()
       setSavedFlash(true)
       window.setTimeout(() => setSavedFlash(false), 1400)
-      // QA BUG-09: previously the silently-dropped fields just hit
-      // console.warn — invisible to non-technical users. Surface the
-      // count + ids so they can recover (Convert to new format, then
-      // re-save).
       if (result.droppedFieldIds.length > 0) {
         const n = result.droppedFieldIds.length
-        alert(
-          `Saved — but ${n} field${n === 1 ? '' : 's'} could not be written to the .tgbl file because they're in an outdated format. ` +
+        await showAlert({
+          title: `Saved — ${n} field${n === 1 ? '' : 's'} skipped`,
+          message:
+            `${n} field${n === 1 ? '' : 's'} could not be written to the .tgbl because they're in an outdated format. ` +
             `Open each affected field in the right panel and click 'Convert to new format', then save again.\n\n` +
             `Affected field id${n === 1 ? '' : 's'}: ${result.droppedFieldIds.join(', ')}`,
-        )
+          variant: 'warning',
+        })
       }
     } catch (err) {
-      alert(err instanceof Error ? err.message : 'Save failed')
+      await showAlert({
+        title: 'Save failed',
+        message: err instanceof Error ? err.message : 'Save failed',
+        variant: 'danger',
+      })
     }
   }
 

--- a/packages/ui/src/components/Toolbar/Toolbar.tsx
+++ b/packages/ui/src/components/Toolbar/Toolbar.tsx
@@ -5,6 +5,7 @@ import { openTemplate } from '../../utils/saveOpen.js'
 import { MenuTabBar } from './MenuTabBar.js'
 import { RibbonBar } from './RibbonBar.js'
 import { RibbonButton } from './primitives/RibbonButton.js'
+import { useDialogs } from '../Dialogs/index.js'
 import { MoonIcon, SunIcon, OpenIcon, BackgroundIcon } from './icons.js'
 
 /**
@@ -31,17 +32,26 @@ export function Toolbar() {
   )
   const theme = useUiStore((s) => s.theme)
   const toggleTheme = useUiStore((s) => s.toggleTheme)
+  const { alert: showAlert } = useDialogs()
 
   function handleBgUpload(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0]
     if (!file) return
     if (file.size > 20 * 1024 * 1024) {
-      alert('Image too large. Maximum size is 20 MB.')
+      void showAlert({
+        title: 'Image too large',
+        message: 'Maximum size is 20 MB.',
+        variant: 'danger',
+      })
       e.target.value = ''
       return
     }
     if (!file.type.startsWith('image/')) {
-      alert('Please select an image file.')
+      void showAlert({
+        title: 'Not an image',
+        message: 'Please select an image file.',
+        variant: 'warning',
+      })
       e.target.value = ''
       return
     }
@@ -51,7 +61,11 @@ export function Toolbar() {
       const img = new Image()
       img.onload = () => {
         if (img.naturalWidth > 10000 || img.naturalHeight > 10000) {
-          alert('Image dimensions too large. Maximum is 10000x10000 pixels.')
+          void showAlert({
+            title: 'Image too big',
+            message: 'Image dimensions too large. Maximum is 10000×10000 pixels.',
+            variant: 'danger',
+          })
           return
         }
         const bufReader = new FileReader()
@@ -78,7 +92,11 @@ export function Toolbar() {
     try {
       await openTemplate(file)
     } catch (err) {
-      alert(err instanceof Error ? err.message : 'Failed to open file')
+      await showAlert({
+        title: 'Failed to open file',
+        message: err instanceof Error ? err.message : 'Failed to open file',
+        variant: 'danger',
+      })
     }
     e.target.value = ''
   }

--- a/packages/ui/src/components/Toolbar/ribbons/FileRibbon.tsx
+++ b/packages/ui/src/components/Toolbar/ribbons/FileRibbon.tsx
@@ -4,6 +4,7 @@ import { useUiStore } from '../../../store/uiStore.js'
 import { openTemplate } from '../../../utils/saveOpen.js'
 import { RibbonGroup } from '../primitives/RibbonGroup.js'
 import { RibbonButton } from '../primitives/RibbonButton.js'
+import { useDialogs } from '../../Dialogs/index.js'
 import { NewIcon, OpenIcon, BackgroundIcon } from '../icons.js'
 
 /**
@@ -15,6 +16,7 @@ import { NewIcon, OpenIcon, BackgroundIcon } from '../icons.js'
 export function FileRibbon() {
   const openInputRef = useRef<HTMLInputElement>(null)
   const setShowChangeBgDialog = useUiStore((s) => s.setShowChangeBgDialog)
+  const { alert: showAlert, confirm: showConfirm } = useDialogs()
 
   async function handleOpenFile(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0]
@@ -22,13 +24,22 @@ export function FileRibbon() {
     try {
       await openTemplate(file)
     } catch (err) {
-      alert(err instanceof Error ? err.message : 'Failed to open file')
+      await showAlert({
+        title: 'Failed to open file',
+        message: err instanceof Error ? err.message : 'Failed to open file',
+        variant: 'danger',
+      })
     }
     e.target.value = ''
   }
 
-  function handleNew() {
-    const ok = window.confirm('Start a new template? Your current unsaved work will be lost.')
+  async function handleNew() {
+    const ok = await showConfirm({
+      title: 'Start a new template?',
+      message: 'Your current unsaved work will be lost.',
+      confirmLabel: 'Start new',
+      destructive: true,
+    })
     if (!ok) return
     useTemplateStore.getState().reset()
     useUiStore.getState().clearSelection()

--- a/packages/ui/src/components/Toolbar/ribbons/HelpRibbon.tsx
+++ b/packages/ui/src/components/Toolbar/ribbons/HelpRibbon.tsx
@@ -25,8 +25,16 @@ export function HelpRibbon() {
           onClick={() =>
             void showAlert({
               title: 'Keyboard shortcuts',
-              message:
-                'Ctrl+Z — Undo\nCtrl+Shift+Z — Redo\nCtrl+S — Save\nCtrl+O — Open\nCtrl+0 — Reset zoom\nCtrl+Plus / Ctrl+Minus — Zoom in / out\nDelete / Backspace — Remove selected field\nEsc — Deselect / collapse ribbon',
+              message: [
+                'Ctrl + Z   —  Undo',
+                'Ctrl + Shift + Z   —  Redo',
+                'Ctrl + S   —  Save',
+                'Ctrl + O   —  Open',
+                'Ctrl + 0   —  Reset zoom',
+                'Ctrl + Plus / Minus   —  Zoom in / out',
+                'Delete / Backspace   —  Remove selected field',
+                'Esc   —  Deselect / collapse ribbon',
+              ].join('\n'),
             })
           }
           title="View keyboard shortcuts"

--- a/packages/ui/src/components/Toolbar/ribbons/HelpRibbon.tsx
+++ b/packages/ui/src/components/Toolbar/ribbons/HelpRibbon.tsx
@@ -1,5 +1,6 @@
 import { RibbonGroup } from '../primitives/RibbonGroup.js'
 import { RibbonButton } from '../primitives/RibbonButton.js'
+import { useDialogs } from '../../Dialogs/index.js'
 
 /**
  * Help ribbon (#128). Lightweight today — repo link + a stub for the
@@ -7,6 +8,7 @@ import { RibbonButton } from '../primitives/RibbonButton.js'
  * can find these without crowding the everyday tabs.
  */
 export function HelpRibbon() {
+  const { alert: showAlert } = useDialogs()
   return (
     <div style={{ display: 'flex' }}>
       <RibbonGroup label="Resources">
@@ -21,9 +23,11 @@ export function HelpRibbon() {
         <RibbonButton
           label="Shortcuts"
           onClick={() =>
-            alert(
-              'Keyboard shortcuts:\n  Ctrl+Z — Undo\n  Ctrl+Shift+Z — Redo\n  Ctrl+S — Save\n  Delete / Backspace — Remove selected field\n  Esc — Deselect',
-            )
+            void showAlert({
+              title: 'Keyboard shortcuts',
+              message:
+                'Ctrl+Z — Undo\nCtrl+Shift+Z — Redo\nCtrl+S — Save\nCtrl+O — Open\nCtrl+0 — Reset zoom\nCtrl+Plus / Ctrl+Minus — Zoom in / out\nDelete / Backspace — Remove selected field\nEsc — Deselect / collapse ribbon',
+            })
           }
           title="View keyboard shortcuts"
           testid="ribbon-help-shortcuts"

--- a/packages/ui/src/hooks/useKeyboard.ts
+++ b/packages/ui/src/hooks/useKeyboard.ts
@@ -3,6 +3,7 @@ import { getPageSize } from '@template-goblin/types'
 import { useTemplateStore } from '../store/templateStore.js'
 import { useUiStore } from '../store/uiStore.js'
 import { saveTemplate, openTemplate } from '../utils/saveOpen.js'
+import { useDialogs } from '../components/Dialogs/index.js'
 
 /**
  * Global keyboard shortcuts handler.
@@ -17,6 +18,7 @@ import { saveTemplate, openTemplate } from '../utils/saveOpen.js'
  * - Escape: Deselect / cancel tool
  */
 export function useKeyboard(): void {
+  const { alert: showAlert } = useDialogs()
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
       const isMod = e.metaKey || e.ctrlKey
@@ -26,7 +28,11 @@ export function useKeyboard(): void {
       if (isMod && e.key === 's') {
         e.preventDefault()
         saveTemplate().catch((err) => {
-          alert(err instanceof Error ? err.message : 'Save failed')
+          void showAlert({
+            title: 'Save failed',
+            message: err instanceof Error ? err.message : 'Save failed',
+            variant: 'danger',
+          })
         })
         return
       }
@@ -41,7 +47,11 @@ export function useKeyboard(): void {
           const file = input.files?.[0]
           if (file) {
             openTemplate(file).catch((err) => {
-              alert(err instanceof Error ? err.message : 'Failed to open file')
+              void showAlert({
+                title: 'Failed to open file',
+                message: err instanceof Error ? err.message : 'Failed to open file',
+                variant: 'danger',
+              })
             })
           }
         }
@@ -167,5 +177,5 @@ export function useKeyboard(): void {
 
     window.addEventListener('keydown', handleKeyDown)
     return () => window.removeEventListener('keydown', handleKeyDown)
-  }, [])
+  }, [showAlert])
 }

--- a/packages/ui/src/main.tsx
+++ b/packages/ui/src/main.tsx
@@ -2,6 +2,7 @@ import { Buffer } from 'buffer'
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { App } from './App.js'
+import { DialogProvider } from './components/Dialogs/index.js'
 
 // GH #86 — `template-goblin/browser` and PDFKit's standalone build reach
 // for `globalThis.Buffer` at module-init. `vite-plugin-node-polyfills`
@@ -18,6 +19,8 @@ if (!rootEl) throw new Error('Root element not found')
 
 ReactDOM.createRoot(rootEl).render(
   <React.StrictMode>
-    <App />
+    <DialogProvider>
+      <App />
+    </DialogProvider>
   </React.StrictMode>,
 )

--- a/packages/ui/src/store/templateStore.ts
+++ b/packages/ui/src/store/templateStore.ts
@@ -363,6 +363,19 @@ let fieldCounter = 0
 let fieldDynamicMemo: Map<string, { jsonKey: string; required: boolean }> = new Map()
 
 /**
+ * Read-side accessor for the dynamic memo so UI surfaces (e.g. the
+ * FIELDS list) can show the most recent dynamic-side label for a
+ * field that has since been flipped to Static — instead of falling
+ * back to a generic `<static text>` placeholder when the static
+ * value is empty (QA BUG-11).
+ */
+export function getFieldDynamicMemo(
+  id: string,
+): { jsonKey: string; required: boolean } | undefined {
+  return fieldDynamicMemo.get(id)
+}
+
+/**
  * Pick a `jsonKey` for a newly-flipped-to-dynamic field that doesn't collide
  * with any existing dynamic field's key (within the same type bucket — text,
  * image, table). Used by `setFieldMode` (GH #26).


### PR DESCRIPTION
## Summary

Every browser-native dialog the app was firing is replaced with a token-styled custom equivalent built on \`@radix-ui/react-dialog\` (already installed for #64). The new surface is consistent with the rest of the v3 chrome — same theme, focus-trap a11y, animations, and Esc / overlay-click semantics. Closes #158.

## New primitives

\`packages/ui/src/components/Dialogs/\` →
- \`<DialogProvider>\` — wraps \`<App />\` in \`main.tsx\`, owns the single active dialog (no stacking; matches native).
- \`useDialogs()\` → \`{ alert, confirm, prompt }\`. Each returns a Promise that resolves cleanly on dismiss; no rejections.
  - \`alert({ title, message, variant? })\` → \`Promise<void>\`
  - \`confirm({ title, message, destructive? })\` → \`Promise<boolean>\`
  - \`prompt({ title, label, validate? })\` → \`Promise<string | null>\`
- \`<DialogShell>\` + \`<DialogButton>\` — shared chrome + actions.
- PromptDialog supports a synchronous validator that surfaces an inline error and disables OK.

## Replaced call-sites

- \`LeftPanel/FieldList\` — group-name \`prompt()\` → PromptDialog with empty-trim validator.
- \`Toolbar/ribbons/FileRibbon\` — File → New \`confirm()\` + open-file error → ConfirmDialog (destructive) + AlertDialog.
- \`Toolbar/MenuTabBar\` — Save error + dropped-fields warning → AlertDialog (danger / warning variants).
- \`Toolbar/Toolbar\` — image-upload size / type / dimension errors → AlertDialog.
- \`Toolbar/FontManager\` — font size + magic-byte errors, remove-in-use confirmation → Alert + ConfirmDialog.
- \`Toolbar/ribbons/HelpRibbon\` — keyboard shortcut dump → multi-line AlertDialog.
- \`Canvas/usePageHandlers\` — last-page delete → destructive ConfirmDialog.
- \`hooks/useKeyboard\` — Ctrl+S / Ctrl+O error toasts → AlertDialog.

No native \`alert\` / \`confirm\` / \`prompt\` calls remain in \`packages/ui/src/\`.

## Tests

- \`e2e/issue-158-dialog-primitives.spec.ts\` — 3 tests covering Prompt (happy + validation) and Alert (shortcuts).
- \`e2e/bug-09-save-drops-warn.spec.ts\` (#137) and \`e2e/ux-04-new-confirm.spec.ts\` (#150) updated to drive the new dialogs by testid instead of stubbing globals.

All 5 newly affected tests pass locally via \`npx playwright test --config=e2e/playwright.config.ts issue-158 bug-09 ux-04\`.

## Test plan

- [x] Type-check + production build clean
- [x] Tests pass (5/5)
- [x] DialogProvider mounted in main.tsx so hooks above the App body (useKeyboard) can call useDialogs cleanly