### PR TITLE
feat(preview): auto-inject placeholder base64 in JSON Preview + Render image fix (#165)

### DIFF
--- a/.changeset/preview-image-base64.md
+++ b/.changeset/preview-image-base64.md
@@ -1,0 +1,54 @@
+---
+'template-goblin-ui': minor
+---
+
+feat(preview): auto-inject placeholder base64 in JSON Preview + fix Render image type (#165)
+
+The JSON Preview panel used to emit the bare placeholder filename
+(or the literal `<base64-image-data>` for required-with-no-
+placeholder) for every dynamic image field. Developers reading the
+panel for the expected schema couldn't tell what the runtime image
+bucket actually contained, and the Preview dialog opened with
+the same too-thin shape.
+
+`generateExampleJson` now accepts an optional
+`imageDataUrls: Map<filename, dataUrl>`. When a dynamic image
+field's placeholder is in the map, the emitted value is the data
+URL's first 80 chars + a recognisable sentinel suffix
+`...<placeholder>` so the panel reads as real image data without
+flooding the textarea with multi-KB base64.
+
+`JsonPreview` and `PreviewDialog` both pass the existing
+`buildImageDataUrlMap(staticImageDataUrls, placeholderBuffers)`
+result into the generator. The right-panel pin + the Preview
+dialog now display the same shape.
+
+`PreviewDialog.handleRender` does two things to make Render work
+end-to-end:
+
+- Seeds every dynamic image field with the FULL data URL from
+  the same map (was previously seeding the raw ArrayBuffer and
+  relying on the parsed.images overlay to overwrite with a
+  filename string — fragile and broke once the truncated value
+  was preserved).
+- Skips parsed.images entries that end in the sentinel suffix so
+  the user clicking Render without editing the JSON keeps the
+  full placeholder data URL.
+
+Tests:
+
+- 8 new vitest cases in jsonGenerator.test.ts covering the
+  truncation, the fallback-to-filename, the no-map case, the
+  required-no-placeholder + non-required cases, and the
+  `isPlaceholderImageSentinel` helper.
+- e2e/issue-165-preview-image-base64.spec.ts seeds a dynamic
+  image field with a placeholder bitmap and asserts the JSON
+  Preview textarea contains `images.<key>` with a
+  `data:image/png;base64,…` prefix and `...<placeholder>` suffix.
+
+End-to-end verified in Chrome: JSON Preview shows the expected
+truncated base64 for the seeded image field. The previous
+'invalid data: expected Buffer / string, got object' error from
+Render is gone — the data URL flows cleanly into core.
+
+Closes #165.

--- a/packages/ui/e2e/issue-165-preview-image-base64.spec.ts
+++ b/packages/ui/e2e/issue-165-preview-image-base64.spec.ts
@@ -1,0 +1,101 @@
+/**
+ * #165 — Regression test for placeholder bitmap → truncated base64 in
+ * the JSON Preview.
+ *
+ * Seeds a dynamic image field with a placeholder bitmap stored in the
+ * UI store. After mount the right-panel JSON Preview textarea must
+ * contain the field's jsonKey under `images.<key>` with a value that
+ * starts with `data:image/` (i.e. the truncated base64 head, not the
+ * bare filename).
+ */
+import type { Page } from '@playwright/test'
+import { test, expect } from '@playwright/test'
+
+async function clearStorage(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    localStorage.removeItem('template-goblin-template')
+    localStorage.removeItem('template-goblin-ui')
+    try {
+      indexedDB.deleteDatabase('template-goblin')
+    } catch {
+      /* ignore */
+    }
+  })
+}
+
+async function onboardSolidColor(page: Page): Promise<void> {
+  await page.locator('[data-testid="onboarding-solid-color"]').click()
+  await page.getByRole('button', { name: /Next/i }).click()
+  await page.getByRole('button', { name: /Apply/i }).click()
+}
+
+// A 1×1 transparent PNG (8 bytes of pixel data) — enough to be a valid
+// PNG that buildImageDataUrlMap can convert.
+const ONE_PX_PNG_BYTES = new Uint8Array([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+  0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4,
+  0x89, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9c, 0x63, 0xfc, 0xcf, 0xc0, 0x50,
+  0x0f, 0x00, 0x05, 0x01, 0x01, 0x02, 0x97, 0xe9, 0xc4, 0xa7, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45,
+  0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
+])
+
+test('#165: JSON Preview shows truncated base64 for dynamic image with placeholder bitmap', async ({
+  page,
+}) => {
+  await clearStorage(page)
+  await page.goto('/')
+  await onboardSolidColor(page)
+  await expect(page.locator('canvas').first()).toBeVisible({ timeout: 5000 })
+
+  // Open the right panel + seed a dynamic image field with a
+  // placeholder bitmap in the store. Buffer + filename pair so
+  // `buildImageDataUrlMap` can render it as `data:image/png;base64,…`.
+  await page.evaluate((bytes) => {
+    type W = Window & {
+      __templateStore?: {
+        getState: () => {
+          addField: (f: unknown) => void
+          addPlaceholder: (filename: string, buffer: ArrayBuffer) => void
+        }
+      }
+      __uiStore?: { getState: () => { setShowRightPanel: (b: boolean) => void } }
+    }
+    const w = window as W
+    w.__uiStore?.getState().setShowRightPanel(true)
+
+    const buffer = new Uint8Array(bytes).buffer
+    w.__templateStore!.getState().addPlaceholder('placeholders/student_photo.png', buffer)
+    w.__templateStore!.getState().addField({
+      id: 'field-165-photo',
+      type: 'image',
+      x: 10,
+      y: 10,
+      width: 100,
+      height: 100,
+      zIndex: 0,
+      pageId: null,
+      groupId: null,
+      source: {
+        mode: 'dynamic',
+        jsonKey: 'student_photo',
+        required: false,
+        placeholder: { filename: 'placeholders/student_photo.png' },
+      },
+      style: { fit: 'contain' },
+    })
+  }, Array.from(ONE_PX_PNG_BYTES))
+
+  // The JSON Preview textarea should now contain
+  // images.student_photo with a value starting with data:image/ and
+  // ending in the placeholder sentinel '...<placeholder>'.
+  const textarea = page.locator('[data-testid="json-preview-textarea"]')
+  await expect(textarea).toBeVisible({ timeout: 5000 })
+  const text = await textarea.inputValue().catch(async () => {
+    // The empty-state branch renders a <div> not a <textarea>; this
+    // shouldn't fire because the field add forces the field-list branch.
+    return await textarea.innerText()
+  })
+  expect(text).toContain('"student_photo"')
+  expect(text).toMatch(/data:image\/png;base64,/)
+  expect(text).toContain('...<placeholder>')
+})

--- a/packages/ui/src/components/Preview/PreviewDialog.tsx
+++ b/packages/ui/src/components/Preview/PreviewDialog.tsx
@@ -198,14 +198,15 @@ export function PreviewDialog({ onClose }: { onClose: () => void }) {
         // the PDF byte stream.
         links: (parsed.links ?? {}) as Record<string, string>,
       }
-      // Seed every dynamic image field with its placeholder bitmap as
-      // a FULL data URL up front. Core accepts data URLs but not raw
-      // ArrayBuffers, so we keep the value as a string the whole way
-      // through and let the parsed.images overlay (or upload) cleanly
-      // replace it. Pre-#165 this branch wrote the raw ArrayBuffer
-      // and relied on parsed.images overwriting it with the bare
-      // filename string — fragile and broke on Render once the
-      // truncated-sentinel skip was added.
+      // Seed every dynamic image field with its placeholder as a
+      // FULL data URL. Core's resolveImageInput accepts data URLs
+      // directly (it does NOT consult template.placeholders for
+      // dynamic fields — preflightImages reads bytes only from
+      // data.images[jsonKey]), so a bare filename here would fail
+      // the format sniff with 'not a valid PNG / JPEG'. The data URL
+      // round-trips through Buffer.from(b64) cleanly when the
+      // underlying bitmap is real (any genuine PNG / JPEG bytes
+      // produced by the upload pipeline).
       for (const field of dynamicImageFields) {
         if (field.source.mode !== 'dynamic') continue
         const ph = field.source.placeholder
@@ -218,7 +219,7 @@ export function PreviewDialog({ onClose }: { onClose: () => void }) {
       // defaults; explicit uploads take precedence over both. Values
       // that came from the auto-generated example (truncated base64
       // ending in IMAGE_PLACEHOLDER_SENTINEL — see #165) are skipped
-      // so the full placeholder data URL set above wins when the user
+      // so the placeholder filename set above wins when the user
       // clicks Render without editing the JSON.
       const parsedImages = (parsed.images ?? {}) as Record<string, unknown>
       for (const [k, v] of Object.entries(parsedImages)) {

--- a/packages/ui/src/components/Preview/PreviewDialog.tsx
+++ b/packages/ui/src/components/Preview/PreviewDialog.tsx
@@ -16,7 +16,7 @@ import { useState, useMemo, useEffect } from 'react'
 import type { ImageField } from '@template-goblin/types'
 import { useTemplateStore } from '../../store/templateStore.js'
 import { useUiStore } from '../../store/uiStore.js'
-import { generateExampleJson } from '../../utils/jsonGenerator.js'
+import { generateExampleJson, isPlaceholderImageSentinel } from '../../utils/jsonGenerator.js'
 import { runCorePreview, openPdfInNewTab } from '../../utils/runCorePreview.js'
 import {
   parseInputJson,
@@ -46,17 +46,35 @@ export function PreviewDialog({ onClose }: { onClose: () => void }) {
   // a max snapshot directly into `previewJsonText` if the user wants it.
   // #61: include header/footer band fields so their dynamic jsonKeys seed
   // the editor too — the renderer reads them from the same flat buckets.
+  // Thumbnail data-URL map for the image-upload rows. Drawn from the user's
+  // already-loaded placeholder bitmaps + static images in the store; the
+  // PDF render path still gets bytes from the store via `templateToLoaded`.
+  const placeholderBuffers = useTemplateStore((s) => s.placeholderBuffers)
+  const staticImageDataUrls = useTemplateStore((s) => s.staticImageDataUrls)
+  const baseImageDataUrls = useMemo(
+    () => buildImageDataUrlMap(staticImageDataUrls, placeholderBuffers),
+    [staticImageDataUrls, placeholderBuffers],
+  )
+
   const defaultJsonText = useMemo(
     () =>
       JSON.stringify(
-        generateExampleJson(fields, 'default', repeatCount, {
-          header: headerFields,
-          footer: footerFields,
-        }),
+        generateExampleJson(
+          fields,
+          'default',
+          repeatCount,
+          {
+            header: headerFields,
+            footer: footerFields,
+          },
+          // #165: emit truncated base64 for each placeholder bitmap so
+          // the dialog opens with a JSON shape that reads as 'real' data.
+          baseImageDataUrls,
+        ),
         null,
         2,
       ),
-    [fields, headerFields, footerFields, repeatCount],
+    [fields, headerFields, footerFields, repeatCount, baseImageDataUrls],
   )
 
   // Initial editor content prefers the user's pinned text from the right
@@ -101,16 +119,6 @@ export function PreviewDialog({ onClose }: { onClose: () => void }) {
         (f): f is ImageField => f.type === 'image' && !!f.source && f.source.mode === 'dynamic',
       ),
     [fields],
-  )
-
-  // Thumbnail data-URL map for the image-upload rows. Drawn from the user's
-  // already-loaded placeholder bitmaps + static images in the store; the
-  // PDF render path still gets bytes from the store via `templateToLoaded`.
-  const placeholderBuffers = useTemplateStore((s) => s.placeholderBuffers)
-  const staticImageDataUrls = useTemplateStore((s) => s.staticImageDataUrls)
-  const baseImageDataUrls = useMemo(
-    () => buildImageDataUrlMap(staticImageDataUrls, placeholderBuffers),
-    [staticImageDataUrls, placeholderBuffers],
   )
 
   // ESC dismiss.
@@ -190,17 +198,33 @@ export function PreviewDialog({ onClose }: { onClose: () => void }) {
         // the PDF byte stream.
         links: (parsed.links ?? {}) as Record<string, string>,
       }
+      // Seed every dynamic image field with its placeholder bitmap as
+      // a FULL data URL up front. Core accepts data URLs but not raw
+      // ArrayBuffers, so we keep the value as a string the whole way
+      // through and let the parsed.images overlay (or upload) cleanly
+      // replace it. Pre-#165 this branch wrote the raw ArrayBuffer
+      // and relied on parsed.images overwriting it with the bare
+      // filename string — fragile and broke on Render once the
+      // truncated-sentinel skip was added.
       for (const field of dynamicImageFields) {
         if (field.source.mode !== 'dynamic') continue
         const ph = field.source.placeholder
         if (ph && typeof ph === 'object' && 'filename' in ph) {
-          const buf = state.placeholderBuffers.get(ph.filename as string)
-          if (buf) data.images[field.source.jsonKey] = buf
+          const fullDataUrl = baseImageDataUrls.get(ph.filename as string)
+          if (fullDataUrl) data.images[field.source.jsonKey] = fullDataUrl
         }
       }
       // User-edited JSON.images takes precedence over the placeholder
-      // defaults; explicit uploads take precedence over both.
-      Object.assign(data.images, (parsed.images ?? {}) as Record<string, string>)
+      // defaults; explicit uploads take precedence over both. Values
+      // that came from the auto-generated example (truncated base64
+      // ending in IMAGE_PLACEHOLDER_SENTINEL — see #165) are skipped
+      // so the full placeholder data URL set above wins when the user
+      // clicks Render without editing the JSON.
+      const parsedImages = (parsed.images ?? {}) as Record<string, unknown>
+      for (const [k, v] of Object.entries(parsedImages)) {
+        if (isPlaceholderImageSentinel(v)) continue
+        data.images[k] = v as string | ArrayBuffer
+      }
       for (const [jsonKey, upload] of imageOverrides) {
         data.images[jsonKey] = upload.dataUrl
       }

--- a/packages/ui/src/components/RightPanel/JsonPreview.tsx
+++ b/packages/ui/src/components/RightPanel/JsonPreview.tsx
@@ -2,6 +2,7 @@ import { useMemo, useCallback, useState, useEffect, useRef } from 'react'
 import { useTemplateStore } from '../../store/templateStore.js'
 import { useUiStore } from '../../store/uiStore.js'
 import { generateExampleJson } from '../../utils/jsonGenerator.js'
+import { buildImageDataUrlMap } from '../../utils/previewInputs.js'
 import { formatJsonString } from './formatJson.js'
 
 /**
@@ -25,17 +26,33 @@ export function JsonPreview() {
   const fields = useTemplateStore((s) => s.fields)
   const headerFields = useTemplateStore((s) => s.header?.fields)
   const footerFields = useTemplateStore((s) => s.footer?.fields)
+  const placeholderBuffers = useTemplateStore((s) => s.placeholderBuffers)
+  const staticImageDataUrls = useTemplateStore((s) => s.staticImageDataUrls)
   const maxModeRepeatCount = useUiStore((s) => s.maxModeRepeatCount)
   const previewJsonText = useUiStore((s) => s.previewJsonText)
   const setPreviewJsonText = useUiStore((s) => s.setPreviewJsonText)
 
+  // #165: resolve every image-field placeholder filename to a data URL so
+  // the JSON Preview's example output can show truncated base64 instead
+  // of just the bare filename.
+  const imageDataUrls = useMemo(
+    () => buildImageDataUrlMap(staticImageDataUrls, placeholderBuffers),
+    [staticImageDataUrls, placeholderBuffers],
+  )
+
   const generated = useMemo(
     () =>
-      generateExampleJson(fields, 'default', maxModeRepeatCount, {
-        header: headerFields,
-        footer: footerFields,
-      }),
-    [fields, headerFields, footerFields, maxModeRepeatCount],
+      generateExampleJson(
+        fields,
+        'default',
+        maxModeRepeatCount,
+        {
+          header: headerFields,
+          footer: footerFields,
+        },
+        imageDataUrls,
+      ),
+    [fields, headerFields, footerFields, maxModeRepeatCount, imageDataUrls],
   )
   const generatedText = useMemo(() => JSON.stringify(generated, null, 2), [generated])
 

--- a/packages/ui/src/utils/__tests__/jsonGenerator.test.ts
+++ b/packages/ui/src/utils/__tests__/jsonGenerator.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest'
-import { generateExampleJson } from '../jsonGenerator.js'
+import {
+  generateExampleJson,
+  IMAGE_PLACEHOLDER_SENTINEL,
+  isPlaceholderImageSentinel,
+} from '../jsonGenerator.js'
 import type {
   FieldDefinition,
   TextFieldStyle,
@@ -63,14 +67,23 @@ function textField(jsonKey: string, required = true): FieldDefinition {
   }
 }
 
-function imageField(jsonKey: string, required = true): FieldDefinition {
+function imageField(
+  jsonKey: string,
+  required = true,
+  placeholderFilename: string | null = null,
+): FieldDefinition {
   return {
     id: `f-${jsonKey}`,
     type: 'image',
     groupId: null,
     pageId: null,
     label: '',
-    source: { mode: 'dynamic', jsonKey, required, placeholder: null },
+    source: {
+      mode: 'dynamic',
+      jsonKey,
+      required,
+      placeholder: placeholderFilename ? { filename: placeholderFilename } : null,
+    },
     x: 0,
     y: 0,
     width: 100,
@@ -274,6 +287,66 @@ describe('generateExampleJson', () => {
       expect(maxResult.texts.school).toContain('It works in my machine')
       expect(maxResult.images.photo).toBe('<base64-image-data>')
       expect(maxResult.tables.marks).toHaveLength(3)
+    })
+  })
+
+  // #165 — dynamic image fields with placeholder bitmaps emit a
+  // truncated data URL ending in the placeholder sentinel so the
+  // JSON preview reads as 'real' data without flooding the editor
+  // with multi-KB base64 strings.
+  describe('placeholder image data URLs (#165)', () => {
+    const FAKE_DATA_URL =
+      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=='
+
+    it('emits truncated base64 ending in the sentinel when the placeholder is in the map', () => {
+      const field = imageField('photo', true, 'placeholders/photo.png')
+      const dataUrls = new Map([['placeholders/photo.png', FAKE_DATA_URL]])
+      const result = generateExampleJson([field], 'default', 5, {}, dataUrls)
+      const value = result.images.photo
+      expect(typeof value).toBe('string')
+      expect(value as string).toContain('data:image/png;base64,')
+      expect((value as string).endsWith(IMAGE_PLACEHOLDER_SENTINEL)).toBe(true)
+      // Truncated, not the full URL.
+      expect((value as string).length).toBeLessThan(FAKE_DATA_URL.length + 1)
+    })
+
+    it('falls back to the bare filename when the data-URL map is missing the entry', () => {
+      const field = imageField('photo', true, 'placeholders/photo.png')
+      const result = generateExampleJson([field], 'default', 5, {}, new Map())
+      expect(result.images.photo).toBe('placeholders/photo.png')
+    })
+
+    it('omits the imageDataUrls arg entirely → bare filename (pre-#165 behaviour)', () => {
+      const field = imageField('photo', true, 'placeholders/photo.png')
+      const result = generateExampleJson([field], 'default', 5)
+      expect(result.images.photo).toBe('placeholders/photo.png')
+    })
+
+    it('required image with no placeholder still emits the literal marker', () => {
+      const result = generateExampleJson([imageField('photo')], 'default', 5, {}, new Map())
+      expect(result.images.photo).toBe('<base64-image-data>')
+    })
+
+    it('non-required image with no placeholder → null', () => {
+      const result = generateExampleJson([imageField('photo', false)], 'default', 5, {}, new Map())
+      expect(result.images.photo).toBeNull()
+    })
+  })
+
+  describe('isPlaceholderImageSentinel', () => {
+    it('detects values ending with the sentinel', () => {
+      expect(
+        isPlaceholderImageSentinel('data:image/png;base64,iVBOR' + IMAGE_PLACEHOLDER_SENTINEL),
+      ).toBe(true)
+    })
+    it('returns false for ordinary data URLs', () => {
+      expect(isPlaceholderImageSentinel('data:image/png;base64,iVBORw0KGgo')).toBe(false)
+    })
+    it('returns false for non-string values', () => {
+      expect(isPlaceholderImageSentinel(123)).toBe(false)
+      expect(isPlaceholderImageSentinel(null)).toBe(false)
+      expect(isPlaceholderImageSentinel(undefined)).toBe(false)
+      expect(isPlaceholderImageSentinel({ filename: 'x' })).toBe(false)
     })
   })
 })

--- a/packages/ui/src/utils/jsonGenerator.ts
+++ b/packages/ui/src/utils/jsonGenerator.ts
@@ -40,11 +40,32 @@ interface GeneratedJson {
  * @param mode - `'default'` (panel display) or `'max'` (Max-Fill button)
  * @param repeatCount - How many times to repeat text in max mode
  */
+/**
+ * Sentinel suffix appended to placeholder image data URLs so the
+ * Preview-dialog merge code can detect 'this came from the auto-
+ * generated example, don't overlay it onto the real buffer'. See
+ * `PreviewDialog.handleRender` (#165).
+ */
+export const IMAGE_PLACEHOLDER_SENTINEL = '...<placeholder>'
+
+/** Max length of the visible base64 head before the sentinel suffix. */
+const IMAGE_PLACEHOLDER_HEAD = 80
+
 export function generateExampleJson(
   fields: FieldDefinition[],
   mode: JsonPreviewMode = 'default',
   repeatCount: number = 5,
   bandFields: { header?: FieldDefinition[]; footer?: FieldDefinition[] } = {},
+  /**
+   * Optional filename → data URL map for resolved placeholder bitmaps
+   * (passed in by the JSON Preview panel + the Preview dialog). When
+   * a dynamic image field's placeholder is in the map, the emitted
+   * JSON value is the data URL's first 80 chars + IMAGE_PLACEHOLDER_
+   * SENTINEL so the panel reads as real data without flooding the
+   * editor with multi-KB base64 blobs. The Preview dialog detects the
+   * sentinel and falls back to the full buffer when rendering.
+   */
+  imageDataUrls?: Map<string, string>,
 ): GeneratedJson {
   const result: GeneratedJson = {
     texts: {},
@@ -79,7 +100,7 @@ export function generateExampleJson(
             result.texts[name] = getTextValue(mode, required, repeatCount, placeholder)
             break
           case 'image':
-            result.images[name] = getImageValue(mode, required, placeholder)
+            result.images[name] = getImageValue(mode, required, placeholder, imageDataUrls)
             break
           case 'table':
             result.tables[name] = getTableValue(field, mode, required, repeatCount, placeholder)
@@ -135,16 +156,36 @@ function getImageValue(
   mode: JsonPreviewMode,
   required: boolean,
   placeholder: unknown,
+  imageDataUrls?: Map<string, string>,
 ): string | null {
   if (mode === 'max') {
     return '<base64-image-data>'
   }
-  // GH #25: surface the user's placeholder filename as the JSON value when set.
+  // #165: when the field's placeholder bitmap resolves to a stored
+  // data URL, emit the first chunk + a sentinel suffix so the JSON
+  // panel reads as 'real' data without printing the full base64.
   if (placeholder && typeof placeholder === 'object' && 'filename' in placeholder) {
     const filename = (placeholder as { filename: unknown }).filename
-    if (typeof filename === 'string' && filename.length > 0) return filename
+    if (typeof filename === 'string' && filename.length > 0) {
+      const dataUrl = imageDataUrls?.get(filename)
+      if (dataUrl) {
+        return dataUrl.slice(0, IMAGE_PLACEHOLDER_HEAD) + IMAGE_PLACEHOLDER_SENTINEL
+      }
+      // No bitmap in the map — fall back to the bare filename (pre-#165 behaviour).
+      return filename
+    }
   }
   return required ? '<base64-image-data>' : null
+}
+
+/**
+ * Detect a JSON-preview image value that came from
+ * `IMAGE_PLACEHOLDER_SENTINEL` — used by `PreviewDialog.handleRender`
+ * to skip overlaying the truncated string onto the placeholder
+ * buffer when the user clicks Render without editing the JSON.
+ */
+export function isPlaceholderImageSentinel(value: unknown): boolean {
+  return typeof value === 'string' && value.endsWith(IMAGE_PLACEHOLDER_SENTINEL)
 }
 
 function getTableValue(


### PR DESCRIPTION
## Summary

Closes #165. Two related fixes in one PR:

1. **JSON Preview** now shows truncated base64 (`data:image/png;base64,iVBOR…<placeholder>`) for every dynamic image field whose placeholder bitmap is stored — instead of the bare filename. Developers reading the panel for the schema now see what the runtime image bucket actually contains.
2. **Preview → Render** previously wrote the raw `ArrayBuffer` into `data.images[key]` and relied on `parsed.images` overlaying with a filename string. That hack broke the moment we kept the truncated sentinel in place. Render now seeds the FULL data URL from `baseImageDataUrls` up front and skips any parsed values ending in the sentinel suffix.

## New API

- `generateExampleJson(fields, mode, repeatCount, bandFields, imageDataUrls?)` — optional last arg.
- `IMAGE_PLACEHOLDER_SENTINEL` + `isPlaceholderImageSentinel(value)` exported from `jsonGenerator.ts`.

## Tests

- 8 new vitest cases (truncation, no-map fallback, required-no-placeholder, sentinel detector).
- New e2e `issue-165-preview-image-base64.spec.ts`.

## Live verification

Driven in Chrome via the MCP extension. JSON Preview textarea shows:

\`\`\`json
"images": {
  "student_photo": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nG...<placeholder>"
}
\`\`\`

PDFKit's previous "expected Buffer / string, got object" error is gone — Render now receives a valid data URL.

## Test plan

- [x] Type-check + UI + core test suites pass
- [x] e2e \`issue-165\` green
- [x] Browser-verified — JSON Preview shows the truncated base64 + sentinel