### PR TITLE
feat(canvas): rotate any element (#172)

### DIFF
--- a/.changeset/rotate-elements.md
+++ b/.changeset/rotate-elements.md
@@ -1,0 +1,42 @@
+---
+'@template-goblin/types': minor
+'template-goblin': minor
+'template-goblin-ui': minor
+---
+
+feat(canvas): rotate any element via sidebar Angle input + canvas handle (#172)
+
+Adds `rotation` to every field type and surfaces it through both an
+"Angle (°)" input in the LeftPanel properties editor and Fabric's
+selection rotation handle. The two are kept in two-way sync, both
+pivot around the field's unrotated centre, and the rotation
+round-trips through `.tgbl` save/load and the PDF render path.
+
+Schema (@template-goblin/types)
+
+- `FieldBase.rotation?: number | null` — degrees, around the rect
+  centre. `null` / `undefined` / `0` all render unrotated, so
+  pre-rotation templates continue to load.
+
+UI (template-goblin-ui)
+
+- LeftPanel "Angle (°)" input; canvas rotation handle exposed on
+  every field type (text, image, table).
+- Sidebar and canvas-handle inputs both pivot around the unrotated
+  centre — no visual translation when angle changes. Schema
+  invariant `(x, y) = unrotated top-left` survives every gesture.
+- Angles are normalised to `[0, 360)` at every consumer boundary so
+  huge inputs (e.g. accidental pastes) don't cause Fabric's
+  selection border to drift off the rendered content.
+- Bonus fix: clicking a solid-colour image field no longer paints
+  its bgRect with the selection emphasis fill — the user's chosen
+  colour is preserved, emphasis switches to stroke only.
+
+PDF renderer (template-goblin)
+
+- `renderField` wraps each draw block in `doc.save() / doc.rotate(angle,
+{ origin: [cx, cy] }) / doc.restore()` when rotation is non-zero.
+  Origin matches the UI's centre-pivot so canvas preview and
+  generated PDF agree pixel-for-pixel.
+
+Closes #172. Supersedes #33.

--- a/packages/core/src/render/field.ts
+++ b/packages/core/src/render/field.ts
@@ -57,6 +57,21 @@ export function renderField(
   // Skip if value is not provided (optional dynamic field or unresolved static)
   if (value === undefined || value === null) return
 
+  // #172 — rotation: wrap the field's draw block in a PDFKit graphics-state
+  // save / rotate / restore so every renderer (text, image, table) inherits
+  // the rotation without needing per-type plumbing. Rotation pivots around
+  // the unrotated rect's centre — same convention as Fabric's
+  // `centeredRotation`, so the canvas preview and the rendered PDF agree.
+  // Treats `null`, `undefined`, and `0` identically (no transform applied).
+  const rotation = field.rotation ?? 0
+  const rotated = rotation !== 0
+  if (rotated) {
+    doc.save()
+    doc.rotate(rotation, {
+      origin: [field.x + field.width / 2, field.y + field.height / 2],
+    })
+  }
+
   try {
     switch (field.type) {
       case 'text':
@@ -115,11 +130,18 @@ export function renderField(
     // rect matches the field's bounding box exactly; for tables, that
     // means the whole table is clickable as a single unit (per #87
     // resolution — no per-row variant in v1).
+    // #172 note: PDF link annotations are page-axis-aligned rectangles —
+    // the spec has no rotated-annotation primitive. When the field is
+    // rotated we draw the link rect at the field's unrotated rect so
+    // the clickable region stays predictable; v1 leaves the visual /
+    // hit-region mismatch as a known limitation (the field's content
+    // visually rotates, the click target does not).
     const url = resolveHyperlinkUrl(field, data)
     if (url !== null) {
       doc.link(field.x, field.y, field.width, field.height, url)
     }
   } catch (error) {
+    if (rotated) doc.restore()
     if (error instanceof TemplateGoblinError) throw error
     const detail = fieldErrorDetails(field, pageCtx)
     throw new TemplateGoblinError(
@@ -128,4 +150,6 @@ export function renderField(
       detail.details,
     )
   }
+
+  if (rotated) doc.restore()
 }

--- a/packages/core/src/render/field.ts
+++ b/packages/core/src/render/field.ts
@@ -63,7 +63,13 @@ export function renderField(
   // the unrotated rect's centre — same convention as Fabric's
   // `centeredRotation`, so the canvas preview and the rendered PDF agree.
   // Treats `null`, `undefined`, and `0` identically (no transform applied).
-  const rotation = field.rotation ?? 0
+  //
+  // Normalise to [0, 360) so huge stored values (legacy / corrupted
+  // templates, user typing nonsense into the sidebar) don't lose
+  // precision in `doc.rotate`'s internal trig — same fix as the UI
+  // side, see `packages/ui/.../rotationGeometry.ts#normaliseAngle`.
+  const rawRotation = field.rotation ?? 0
+  const rotation = Number.isFinite(rawRotation) ? ((rawRotation % 360) + 360) % 360 : 0
   const rotated = rotation !== 0
   if (rotated) {
     doc.save()

--- a/packages/core/tests/render/rotation.test.ts
+++ b/packages/core/tests/render/rotation.test.ts
@@ -112,7 +112,11 @@ describe('renderField — rotation transform (#172)', () => {
     expect(calls.indexOf('font')).toBeLessThan(calls.indexOf('link'))
   })
 
-  it('negative rotation passes through unchanged (unbounded angle)', () => {
+  it('negative rotation is normalised into [0, 360) before doc.rotate', () => {
+    // #172 follow-up: renderField normalises the angle so very large or
+    // negative inputs don't lose precision in PDFKit's internal trig
+    // (which would visibly desync the rotated content from where the UI
+    // canvas drew it). -90° -> 270° here.
     const field = {
       ...staticText('t1', 'hello', { x: 10, y: 20, width: 100, height: 50 }),
       rotation: -90,
@@ -121,7 +125,23 @@ describe('renderField — rotation transform (#172)', () => {
     const rotateSpy = jest.spyOn(doc, 'rotate')
     const template = loadedTemplate(makeManifest({ fields: [field] }))
     renderField(doc, field, emptyData(), new Map(), template, { pageIndex: 0 }, new Map())
-    expect(rotateSpy).toHaveBeenCalledWith(-90, { origin: [60, 45] })
+    expect(rotateSpy).toHaveBeenCalledWith(270, { origin: [60, 45] })
+    rotateSpy.mockRestore()
+  })
+
+  it('huge rotation is normalised into [0, 360) before doc.rotate', () => {
+    const field = {
+      ...staticText('t1', 'hello', { x: 10, y: 20, width: 100, height: 50 }),
+      rotation: 5612356213214654,
+    }
+    const doc = new PDFDocument({ size: [595, 842], margin: 0 })
+    const rotateSpy = jest.spyOn(doc, 'rotate')
+    const template = loadedTemplate(makeManifest({ fields: [field] }))
+    renderField(doc, field, emptyData(), new Map(), template, { pageIndex: 0 }, new Map())
+    expect(rotateSpy).toHaveBeenCalledTimes(1)
+    const [angle] = rotateSpy.mock.calls[0] ?? []
+    expect(angle).toBeGreaterThanOrEqual(0)
+    expect(angle).toBeLessThan(360)
     rotateSpy.mockRestore()
   })
 

--- a/packages/core/tests/render/rotation.test.ts
+++ b/packages/core/tests/render/rotation.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Render-side coverage for `field.rotation` (#172).
+ *
+ * Asserts that `renderField` wraps the field's draw block in
+ * `doc.save()` → `doc.rotate(angle, { origin: [cx, cy] })` → `doc.restore()`
+ * when rotation is non-zero, and is a no-op transform otherwise.
+ * Origin is the centre of the unrotated field rect so the canvas preview
+ * (Fabric `centeredRotation: true`) and the PDF match pixel-for-pixel.
+ */
+import PDFDocument from 'pdfkit'
+import type { InputJSON, LoadedTemplate, TemplateManifest } from '@template-goblin/types'
+import { renderField } from '../../src/render/field.js'
+import { makeManifest, staticText } from '../helpers/fixtures.js'
+
+function loadedTemplate(manifest: TemplateManifest): LoadedTemplate {
+  return {
+    manifest,
+    backgroundImage: null,
+    pageBackgrounds: new Map(),
+    fonts: new Map(),
+    placeholders: new Map(),
+    staticImages: new Map(),
+  }
+}
+
+function emptyData(): InputJSON {
+  return { texts: {}, images: {}, tables: {} }
+}
+
+describe('renderField — rotation transform (#172)', () => {
+  // We spy on `rotate` (not `save` / `restore`) because PDFKit itself
+  // calls save/restore internally during text rendering, which would
+  // make the spies noisy. `rotate` is only called by OUR code path, so
+  // its presence is a faithful proxy for the rotation envelope.
+  it('rotation = 0 does NOT invoke rotate', () => {
+    const field = staticText('t1', 'hello', { x: 100, y: 200, width: 80, height: 30 })
+    const doc = new PDFDocument({ size: [595, 842], margin: 0 })
+    const rotateSpy = jest.spyOn(doc, 'rotate')
+    const template = loadedTemplate(makeManifest({ fields: [field] }))
+    renderField(doc, field, emptyData(), new Map(), template, { pageIndex: 0 }, new Map())
+    expect(rotateSpy).not.toHaveBeenCalled()
+    rotateSpy.mockRestore()
+  })
+
+  it('rotation undefined (legacy field) is treated as no rotation', () => {
+    const field = staticText('t1', 'hello', { x: 100, y: 200, width: 80, height: 30 })
+    delete (field as { rotation?: number | null }).rotation
+    const doc = new PDFDocument({ size: [595, 842], margin: 0 })
+    const rotateSpy = jest.spyOn(doc, 'rotate')
+    const template = loadedTemplate(makeManifest({ fields: [field] }))
+    renderField(doc, field, emptyData(), new Map(), template, { pageIndex: 0 }, new Map())
+    expect(rotateSpy).not.toHaveBeenCalled()
+    rotateSpy.mockRestore()
+  })
+
+  it('rotation null is treated as no rotation', () => {
+    const field = { ...staticText('t1', 'hello'), rotation: null }
+    const doc = new PDFDocument({ size: [595, 842], margin: 0 })
+    const rotateSpy = jest.spyOn(doc, 'rotate')
+    const template = loadedTemplate(makeManifest({ fields: [field] }))
+    renderField(doc, field, emptyData(), new Map(), template, { pageIndex: 0 }, new Map())
+    expect(rotateSpy).not.toHaveBeenCalled()
+    rotateSpy.mockRestore()
+  })
+
+  it('non-zero rotation invokes rotate exactly once around the rect centre', () => {
+    const field = {
+      ...staticText('t1', 'hello', { x: 100, y: 200, width: 80, height: 30 }),
+      rotation: 45,
+    }
+    const doc = new PDFDocument({ size: [595, 842], margin: 0 })
+    const rotateSpy = jest.spyOn(doc, 'rotate')
+    const template = loadedTemplate(makeManifest({ fields: [field] }))
+    renderField(doc, field, emptyData(), new Map(), template, { pageIndex: 0 }, new Map())
+    expect(rotateSpy).toHaveBeenCalledTimes(1)
+    // Centre of rect (100,200,80,30) is (140, 215).
+    expect(rotateSpy).toHaveBeenCalledWith(45, { origin: [140, 215] })
+    rotateSpy.mockRestore()
+  })
+
+  it('rotate fires BEFORE the field-content font set, link rect fires AFTER restore', () => {
+    // Ordering test using the call sequence on a handful of spies. We
+    // can't reliably observe save/restore in isolation (PDFKit calls
+    // them internally), but `rotate` and `link` are unique to OUR
+    // wrapper so their relative order pins the structure: rotate must
+    // precede the field's font/draw, link must come after the field
+    // restored (so the link rect is at page-axis-aligned coords).
+    const field = {
+      ...staticText('t1', 'hello', { x: 0, y: 0, width: 100, height: 50 }),
+      rotation: 90,
+      hyperlink: { mode: 'static' as const, url: 'https://example.com' },
+    }
+    const doc = new PDFDocument({ size: [595, 842], margin: 0 })
+    const calls: string[] = []
+    jest.spyOn(doc, 'rotate').mockImplementation(() => {
+      calls.push('rotate')
+      return doc
+    })
+    jest.spyOn(doc, 'link').mockImplementation(() => {
+      calls.push('link')
+      return doc
+    })
+    const originalFont = doc.font.bind(doc)
+    jest.spyOn(doc, 'font').mockImplementation((arg: unknown) => {
+      calls.push('font')
+      return originalFont(arg as string)
+    })
+    const template = loadedTemplate(makeManifest({ fields: [field] }))
+    renderField(doc, field, emptyData(), new Map(), template, { pageIndex: 0 }, new Map())
+    expect(calls.indexOf('rotate')).toBeGreaterThanOrEqual(0)
+    expect(calls.indexOf('rotate')).toBeLessThan(calls.indexOf('font'))
+    expect(calls.indexOf('font')).toBeLessThan(calls.indexOf('link'))
+  })
+
+  it('negative rotation passes through unchanged (unbounded angle)', () => {
+    const field = {
+      ...staticText('t1', 'hello', { x: 10, y: 20, width: 100, height: 50 }),
+      rotation: -90,
+    }
+    const doc = new PDFDocument({ size: [595, 842], margin: 0 })
+    const rotateSpy = jest.spyOn(doc, 'rotate')
+    const template = loadedTemplate(makeManifest({ fields: [field] }))
+    renderField(doc, field, emptyData(), new Map(), template, { pageIndex: 0 }, new Map())
+    expect(rotateSpy).toHaveBeenCalledWith(-90, { origin: [60, 45] })
+    rotateSpy.mockRestore()
+  })
+
+  it('hyperlink rect is drawn at the UNROTATED field bounds (v1 limitation)', () => {
+    // PDF spec annotations are page-axis-aligned; the rect doesn't rotate
+    // with the visual content. This pins the v1 behaviour so future
+    // changes (e.g. rotated-AABB hit region) are deliberate.
+    const field = {
+      ...staticText('t1', 'hello', { x: 10, y: 20, width: 100, height: 50 }),
+      rotation: 45,
+      hyperlink: { mode: 'static' as const, url: 'https://example.com' },
+    }
+    const doc = new PDFDocument({ size: [595, 842], margin: 0 })
+    const linkSpy = jest.spyOn(doc, 'link')
+    const template = loadedTemplate(makeManifest({ fields: [field] }))
+    renderField(doc, field, emptyData(), new Map(), template, { pageIndex: 0 }, new Map())
+    expect(linkSpy).toHaveBeenCalledWith(10, 20, 100, 50, 'https://example.com')
+    linkSpy.mockRestore()
+  })
+})

--- a/packages/types/src/template.ts
+++ b/packages/types/src/template.ts
@@ -262,6 +262,15 @@ export interface FieldBase {
    * Allowed protocols: `https`, `http`, `mailto`, `tel`.
    */
   hyperlink?: Hyperlink
+  /**
+   * Optional rotation in degrees applied around the field's centre (#172).
+   * Positive values rotate clockwise. Unbounded (Fabric `angle` semantics
+   * — the sidebar UI normalises display to 0–359 but the schema accepts
+   * any number). `undefined`, `null`, and `0` are all rendered as
+   * "no rotation" — existing `.tgbl` bundles missing this field continue
+   * to load. Applies to every field type (text, image, table).
+   */
+  rotation?: number | null
 }
 
 /** A text field — static value is the literal rendered string. */

--- a/packages/ui/e2e/issue-172-rotation.spec.ts
+++ b/packages/ui/e2e/issue-172-rotation.spec.ts
@@ -1,0 +1,171 @@
+/**
+ * #172 — rotate any element via sidebar angle input + canvas rotation
+ * handle, two-way sync.
+ *
+ * Validates:
+ *   1. Selecting a field shows Fabric's rotation handle (no longer locked).
+ *   2. The PropertiesPanel "Angle (°)" input writes through to
+ *      `field.rotation` and the canvas group's angle updates live.
+ *   3. Programmatic rotation in the store mirrors onto the Fabric group's
+ *      `angle` property (store → canvas direction).
+ *   4. `null` rotation is rendered identically to `0` (legacy default).
+ *
+ * Sanity-checks the schema invariant: rotation is stored on the field,
+ * not the group, and the group's `lockRotation` is no longer forced.
+ */
+import type { Page } from '@playwright/test'
+import { test, expect } from '@playwright/test'
+
+async function clearStorage(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    localStorage.removeItem('template-goblin-template')
+    localStorage.removeItem('template-goblin-ui')
+    try {
+      indexedDB.deleteDatabase('template-goblin')
+    } catch {
+      /* ignore */
+    }
+  })
+}
+
+async function onboardSolidColor(page: Page): Promise<void> {
+  await page.locator('[data-testid="onboarding-solid-color"]').click()
+  await page.getByRole('button', { name: /Next/i }).click()
+  await page.getByRole('button', { name: /Apply/i }).click()
+}
+
+async function seedField(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    type W = Window & {
+      __templateStore?: {
+        getState: () => {
+          addField: (f: unknown) => void
+        }
+      }
+    }
+    const api = (window as W).__templateStore!.getState()
+    api.addField({
+      id: 'f-spin',
+      type: 'text',
+      x: 100,
+      y: 100,
+      width: 120,
+      height: 40,
+      zIndex: 0,
+      pageId: null,
+      groupId: null,
+      source: { mode: 'static', value: 'spin me' },
+      style: {},
+    })
+  })
+}
+
+test.describe('#172 — element rotation, sidebar ↔ canvas sync', () => {
+  test('Fabric group is no longer rotation-locked and reflects field.rotation on mount', async ({
+    page,
+  }) => {
+    await clearStorage(page)
+    await page.goto('/')
+    await onboardSolidColor(page)
+    await expect(page.locator('canvas').first()).toBeVisible({ timeout: 5000 })
+    await seedField(page)
+
+    // Apply rotation through the store (mirrors the sidebar Angle input
+    // commit path) and read back the Fabric group's `angle`.
+    const result = await page.evaluate(async () => {
+      type FabObj = { __fieldId?: string; angle?: number; lockRotation?: boolean }
+      type FabricCanvasLike = { getObjects: () => FabObj[] }
+      type W = Window & {
+        __fabricCanvas?: FabricCanvasLike
+        __templateStore?: {
+          getState: () => { updateField: (id: string, p: unknown) => void }
+        }
+      }
+      const w = window as W
+      const api = w.__templateStore!.getState()
+      api.updateField('f-spin', { rotation: 45 })
+      // Wait a tick for React → Fabric reconcile to apply the angle.
+      await new Promise((r) => setTimeout(r, 60))
+      const grp = w.__fabricCanvas!.getObjects().find((o) => o.__fieldId === 'f-spin')
+      return { angle: grp?.angle, lockRotation: grp?.lockRotation ?? false }
+    })
+
+    expect(result.lockRotation).toBe(false)
+    expect(result.angle).toBeCloseTo(45, 1)
+  })
+
+  test('setting rotation back to null normalises angle to 0', async ({ page }) => {
+    await clearStorage(page)
+    await page.goto('/')
+    await onboardSolidColor(page)
+    await expect(page.locator('canvas').first()).toBeVisible({ timeout: 5000 })
+    await seedField(page)
+
+    const finalAngle = await page.evaluate(async () => {
+      type FabObj = { __fieldId?: string; angle?: number }
+      type W = Window & {
+        __fabricCanvas?: { getObjects: () => FabObj[] }
+        __templateStore?: {
+          getState: () => { updateField: (id: string, p: unknown) => void }
+        }
+      }
+      const w = window as W
+      const api = w.__templateStore!.getState()
+      api.updateField('f-spin', { rotation: 120 })
+      await new Promise((r) => setTimeout(r, 60))
+      api.updateField('f-spin', { rotation: null })
+      await new Promise((r) => setTimeout(r, 60))
+      const grp = w.__fabricCanvas!.getObjects().find((o) => o.__fieldId === 'f-spin')
+      return grp?.angle ?? null
+    })
+    expect(finalAngle).toBe(0)
+  })
+
+  test('PropertiesPanel exposes Angle (°) input wired to field.rotation', async ({ page }) => {
+    await clearStorage(page)
+    await page.goto('/')
+    await onboardSolidColor(page)
+    await expect(page.locator('canvas').first()).toBeVisible({ timeout: 5000 })
+    await seedField(page)
+
+    // Select the seeded field through the store so the PropertiesPanel
+    // renders its angle input.
+    await page.evaluate(() => {
+      type W = Window & {
+        __uiStore?: { getState: () => { selectFields: (ids: string[]) => void } }
+      }
+      ;(window as W).__uiStore!.getState().selectFields(['f-spin'])
+    })
+
+    // The Angle label is unique to RotationSection.
+    const angleLabel = page.getByText(/^Angle \(°\)$/)
+    await expect(angleLabel).toBeVisible({ timeout: 3000 })
+
+    // Type a value into the corresponding number input. The label lives
+    // in the same `.tg-form-row` container as the NumberInput, so we
+    // scope through that ancestor.
+    const angleInput = angleLabel.locator('..').locator('input[type="number"]')
+    await angleInput.fill('72')
+    await angleInput.blur()
+
+    // Round-trip: the field's rotation should now read 72, and the
+    // Fabric group should be rotated to match.
+    const result = await page.evaluate(async () => {
+      type Field = { id: string; rotation?: number | null }
+      type FabObj = { __fieldId?: string; angle?: number }
+      type W = Window & {
+        __fabricCanvas?: { getObjects: () => FabObj[] }
+        __templateStore?: { getState: () => { fields: Field[] } }
+      }
+      await new Promise((r) => setTimeout(r, 60))
+      const fields = (window as W).__templateStore!.getState().fields
+      const grp = (window as W).__fabricCanvas!.getObjects().find((o) => o.__fieldId === 'f-spin')
+      return {
+        storedRotation: fields.find((f) => f.id === 'f-spin')?.rotation,
+        canvasAngle: grp?.angle,
+      }
+    })
+    expect(result.storedRotation).toBe(72)
+    expect(result.canvasAngle).toBeCloseTo(72, 1)
+  })
+})

--- a/packages/ui/e2e/solid-image-selection-fill.spec.ts
+++ b/packages/ui/e2e/solid-image-selection-fill.spec.ts
@@ -1,0 +1,161 @@
+/**
+ * Regression: clicking a solid-colour image field (#81) must NOT repaint
+ * its bgRect with the selection emphasis fill — the user's chosen colour
+ * IS the field's content, swapping it for the selection tint visually
+ * corrupts the document on every click.
+ *
+ * The fix tags the bgRect with `__userControlledFill = true` in
+ * `buildGroupChildren` whenever the image source carries a `{ color }`
+ * value; `applySelectionVisuals` then keeps the fill on select and
+ * emphasises through stroke only — same behaviour transparent-fill
+ * fields already enjoyed.
+ *
+ * Discovered during #172 (rotation) live testing; fixed in the same PR.
+ */
+import type { Page } from '@playwright/test'
+import { test, expect } from '@playwright/test'
+
+async function clearStorage(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    localStorage.removeItem('template-goblin-template')
+    localStorage.removeItem('template-goblin-ui')
+    try {
+      indexedDB.deleteDatabase('template-goblin')
+    } catch {
+      /* ignore */
+    }
+  })
+}
+
+async function onboardSolidColor(page: Page): Promise<void> {
+  await page.locator('[data-testid="onboarding-solid-color"]').click()
+  await page.getByRole('button', { name: /Next/i }).click()
+  await page.getByRole('button', { name: /Apply/i }).click()
+}
+
+async function seedSolidImage(page: Page, color: string): Promise<void> {
+  await page.evaluate((c) => {
+    type W = Window & {
+      __templateStore?: { getState: () => { addField: (f: unknown) => void } }
+    }
+    const api = (window as W).__templateStore!.getState()
+    api.addField({
+      id: 'f-solid',
+      type: 'image',
+      x: 60,
+      y: 60,
+      width: 120,
+      height: 120,
+      zIndex: 0,
+      pageId: null,
+      groupId: null,
+      source: { mode: 'static', value: { color: c } },
+      style: { fit: 'contain' },
+    })
+  }, color)
+}
+
+test.describe('solid-colour image field — fill stable across selection', () => {
+  test('selecting a solid-colour image keeps its bgRect fill (emphasis via stroke only)', async ({
+    page,
+  }) => {
+    await clearStorage(page)
+    await page.goto('/')
+    await onboardSolidColor(page)
+    await expect(page.locator('canvas').first()).toBeVisible({ timeout: 5000 })
+    await seedSolidImage(page, '#ff0066')
+
+    const phases = await page.evaluate(async () => {
+      type Bg = { fill?: string; stroke?: string; __defaultFill?: string }
+      type Grp = { __fieldId?: string; getObjects: () => Bg[] }
+      type W = Window & {
+        __fabricCanvas?: { getObjects: () => Grp[] }
+        __uiStore?: { getState: () => { selectFields: (ids: string[]) => void } }
+      }
+      const w = window as W
+      const wait = (ms: number) => new Promise<void>((r) => setTimeout(r, ms))
+      function snap(): { fill?: string; stroke?: string; defaultFill?: string } {
+        const grp = w.__fabricCanvas!.getObjects().find((o) => o.__fieldId === 'f-solid')
+        const bg = grp?.getObjects()[0]
+        return { fill: bg?.fill, stroke: bg?.stroke, defaultFill: bg?.__defaultFill }
+      }
+      await wait(60)
+      const initial = snap()
+      w.__uiStore!.getState().selectFields(['f-solid'])
+      await wait(120)
+      const selected = snap()
+      w.__uiStore!.getState().selectFields([])
+      await wait(120)
+      const deselected = snap()
+      return { initial, selected, deselected }
+    })
+
+    // BUG: pre-fix, `selected.fill` would be `rgba(74, 222, 128, 0.4)`
+    // (the image type's selectedFill token). Pins the regression.
+    expect(phases.initial.fill).toBe('#ff0066')
+    expect(phases.selected.fill).toBe('#ff0066')
+    expect(phases.deselected.fill).toBe('#ff0066')
+
+    // Stroke colour DOES change to convey selection — that's the
+    // emphasis vehicle for user-controlled-fill fields.
+    expect(phases.selected.stroke).not.toBe(phases.deselected.stroke)
+  })
+
+  test('regular text field still gets the selection-emphasis fill (no regression)', async ({
+    page,
+  }) => {
+    // Sanity check: the fix narrows to user-controlled-fill bgRects; it
+    // must NOT remove the emphasis fill for the normal text / image-
+    // without-color cases.
+    await clearStorage(page)
+    await page.goto('/')
+    await onboardSolidColor(page)
+    await expect(page.locator('canvas').first()).toBeVisible({ timeout: 5000 })
+    await page.evaluate(() => {
+      type W = Window & {
+        __templateStore?: { getState: () => { addField: (f: unknown) => void } }
+      }
+      ;(window as W).__templateStore!.getState().addField({
+        id: 'f-dyn',
+        type: 'text',
+        x: 60,
+        y: 60,
+        width: 120,
+        height: 40,
+        zIndex: 0,
+        pageId: null,
+        groupId: null,
+        source: { mode: 'dynamic', jsonKey: 'name', required: false, placeholder: null },
+        style: {},
+      })
+    })
+
+    const phases = await page.evaluate(async () => {
+      type Bg = { fill?: string }
+      type Grp = { __fieldId?: string; getObjects: () => Bg[] }
+      type W = Window & {
+        __fabricCanvas?: { getObjects: () => Grp[] }
+        __uiStore?: { getState: () => { selectFields: (ids: string[]) => void } }
+      }
+      const w = window as W
+      const wait = (ms: number) => new Promise<void>((r) => setTimeout(r, ms))
+      function fill(): string | undefined {
+        return w
+          .__fabricCanvas!.getObjects()
+          .find((o) => o.__fieldId === 'f-dyn')
+          ?.getObjects()[0]?.fill
+      }
+      await wait(60)
+      const initial = fill()
+      w.__uiStore!.getState().selectFields(['f-dyn'])
+      await wait(120)
+      const selected = fill()
+      return { initial, selected }
+    })
+
+    // Dynamic text gets its design-time tint as default fill, swapped
+    // for the selectedFill token on click. The fix MUST NOT have broken
+    // this — the two values must differ.
+    expect(phases.selected).not.toBe(phases.initial)
+  })
+})

--- a/packages/ui/src/components/Canvas/__tests__/rotationGeometry.test.ts
+++ b/packages/ui/src/components/Canvas/__tests__/rotationGeometry.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Unit tests for centre-pivoted rotation math (#172 follow-up).
+ *
+ * Property pinned: when the helper's `(left, top)` are applied to a
+ * Fabric Group with `originX: 'left', originY: 'top'` and the supplied
+ * angle, the visible centre lands EXACTLY at the unrotated centre.
+ * Round-trip via `recoverUnrotatedXY` returns the original `(x, y)`.
+ */
+import { describe, it, expect } from 'vitest'
+import { centerCompensatedLeftTop, recoverUnrotatedXY } from '../rotationGeometry'
+
+function visibleCenter(
+  left: number,
+  top: number,
+  width: number,
+  height: number,
+  angleDeg: number,
+): { cx: number; cy: number } {
+  // Rendering math under originX:'left', originY:'top' — the visible
+  // centre after rotating around `(left, top)` by angleDeg degrees.
+  const theta = (angleDeg * Math.PI) / 180
+  const cos = Math.cos(theta)
+  const sin = Math.sin(theta)
+  return {
+    cx: left + (width / 2) * cos - (height / 2) * sin,
+    cy: top + (width / 2) * sin + (height / 2) * cos,
+  }
+}
+
+describe('centerCompensatedLeftTop', () => {
+  it('returns (x, y) unchanged when rotation is 0', () => {
+    expect(
+      centerCompensatedLeftTop({ x: 100, y: 200, width: 80, height: 30, rotation: 0 }),
+    ).toEqual({ left: 100, top: 200 })
+  })
+
+  it('treats null rotation as 0', () => {
+    expect(
+      centerCompensatedLeftTop({ x: 100, y: 200, width: 80, height: 30, rotation: null }),
+    ).toEqual({ left: 100, top: 200 })
+  })
+
+  it('treats undefined rotation as 0', () => {
+    expect(centerCompensatedLeftTop({ x: 100, y: 200, width: 80, height: 30 })).toEqual({
+      left: 100,
+      top: 200,
+    })
+  })
+
+  it.each([15, 30, 45, 60, 90, 120, 180, -45, -90, 270, 359])(
+    'visible centre equals unrotated centre at rotation = %s°',
+    (rotation) => {
+      const rect = { x: 100, y: 200, width: 120, height: 40, rotation }
+      const { left, top } = centerCompensatedLeftTop(rect)
+      const { cx, cy } = visibleCenter(left, top, rect.width, rect.height, rotation)
+      // Unrotated centre = (x + w/2, y + h/2) = (160, 220) for this case.
+      expect(cx).toBeCloseTo(rect.x + rect.width / 2, 6)
+      expect(cy).toBeCloseTo(rect.y + rect.height / 2, 6)
+    },
+  )
+
+  it('positive rotation shifts compensated.left RIGHT for wide rects', () => {
+    // For a wide rect at angle 60°, compensation must push group.left
+    // right (so the visible centre stays on the unrotated centre).
+    const { left } = centerCompensatedLeftTop({
+      x: 100,
+      y: 100,
+      width: 120,
+      height: 40,
+      rotation: 60,
+    })
+    expect(left).toBeGreaterThan(100)
+  })
+})
+
+describe('recoverUnrotatedXY', () => {
+  it('returns (left, top) unchanged when angle is 0', () => {
+    expect(recoverUnrotatedXY(100, 200, 80, 30, 0)).toEqual({ x: 100, y: 200 })
+  })
+
+  it.each([15, 30, 45, 60, 90, 120, 180, -45, -90, 270, 359])(
+    'round-trips (x,y) → compensated → unrotated at rotation = %s°',
+    (rotation) => {
+      const original = { x: 137, y: 53, width: 120, height: 40 }
+      const { left, top } = centerCompensatedLeftTop({ ...original, rotation })
+      const back = recoverUnrotatedXY(left, top, original.width, original.height, rotation)
+      expect(back.x).toBeCloseTo(original.x, 6)
+      expect(back.y).toBeCloseTo(original.y, 6)
+    },
+  )
+
+  it('round-trips for very thin rects (height = 1)', () => {
+    const original = { x: 10, y: 10, width: 200, height: 1 }
+    const { left, top } = centerCompensatedLeftTop({ ...original, rotation: 17 })
+    const back = recoverUnrotatedXY(left, top, original.width, original.height, 17)
+    expect(back.x).toBeCloseTo(original.x, 6)
+    expect(back.y).toBeCloseTo(original.y, 6)
+  })
+
+  it('round-trips for square rects', () => {
+    const original = { x: 50, y: 50, width: 100, height: 100 }
+    const { left, top } = centerCompensatedLeftTop({ ...original, rotation: 33 })
+    const back = recoverUnrotatedXY(left, top, original.width, original.height, 33)
+    expect(back.x).toBeCloseTo(original.x, 6)
+    expect(back.y).toBeCloseTo(original.y, 6)
+  })
+})

--- a/packages/ui/src/components/Canvas/__tests__/rotationGeometry.test.ts
+++ b/packages/ui/src/components/Canvas/__tests__/rotationGeometry.test.ts
@@ -7,7 +7,7 @@
  * Round-trip via `recoverUnrotatedXY` returns the original `(x, y)`.
  */
 import { describe, it, expect } from 'vitest'
-import { centerCompensatedLeftTop, recoverUnrotatedXY } from '../rotationGeometry'
+import { centerCompensatedLeftTop, normaliseAngle, recoverUnrotatedXY } from '../rotationGeometry'
 
 function visibleCenter(
   left: number,
@@ -103,5 +103,69 @@ describe('recoverUnrotatedXY', () => {
     const back = recoverUnrotatedXY(left, top, original.width, original.height, 33)
     expect(back.x).toBeCloseTo(original.x, 6)
     expect(back.y).toBeCloseTo(original.y, 6)
+  })
+})
+
+describe('normaliseAngle', () => {
+  it.each([
+    [0, 0],
+    [360, 0],
+    [-360, 0],
+    [720, 0],
+    [45, 45],
+    [-45, 315],
+    [180, 180],
+    [-180, 180],
+    [359.999, 359.999],
+    [400, 40],
+    [-400, 320],
+  ])('normalises %s -> %s', (input, expected) => {
+    expect(normaliseAngle(input)).toBeCloseTo(expected, 6)
+  })
+
+  it.each([null, undefined, NaN, Infinity, -Infinity])('non-finite %s collapses to 0', (input) => {
+    expect(normaliseAngle(input as number | null | undefined)).toBe(0)
+  })
+
+  it('huge values stay in [0, 360)', () => {
+    const huge = 5612356213214654
+    const result = normaliseAngle(huge)
+    expect(result).toBeGreaterThanOrEqual(0)
+    expect(result).toBeLessThan(360)
+  })
+
+  it('huge value pair that maps to the same equivalence class yields the same normalised angle', () => {
+    // Property: x and x + 360 should normalise to the same value at
+    // small magnitudes. At large magnitudes the float ULP exceeds
+    // 360, so we just require the result to be in range — not bit-
+    // identical to a small-magnitude representative.
+    const a = normaliseAngle(720 + 45)
+    const b = normaliseAngle(45)
+    expect(a).toBeCloseTo(b, 6)
+  })
+})
+
+describe('centerCompensatedLeftTop — huge-angle precision (#172 follow-up)', () => {
+  it('rotation = N and rotation = (N mod 360) produce the same compensated (left, top) for small N', () => {
+    // For small N (well within float precision), normalising the
+    // rotation MUST be a no-op for the visible position.
+    const rect = { x: 100, y: 100, width: 160, height: 160 }
+    const a = centerCompensatedLeftTop({ ...rect, rotation: 720 + 45 })
+    const b = centerCompensatedLeftTop({ ...rect, rotation: 45 })
+    expect(a.left).toBeCloseTo(b.left, 6)
+    expect(a.top).toBeCloseTo(b.top, 6)
+  })
+
+  it('huge rotation returns a finite, in-range visible position (no NaN/Infinity)', () => {
+    const huge = 5612356213214654
+    const result = centerCompensatedLeftTop({
+      x: 100,
+      y: 100,
+      width: 160,
+      height: 160,
+      rotation: huge,
+    })
+    expect(Number.isFinite(result.left)).toBe(true)
+    expect(Number.isFinite(result.top)).toBe(true)
   })
 })

--- a/packages/ui/src/components/Canvas/buildGroupChildren.ts
+++ b/packages/ui/src/components/Canvas/buildGroupChildren.ts
@@ -118,6 +118,10 @@ export function buildGroupChildren(
   bgRect.__defaultFill = defaultFill
   bgRect.__defaultStroke = defaultStroke
   bgRect.__defaultStrokeWidth = defaultStrokeWidth
+  // Solid-colour image (#81): the bgRect's fill IS the user's chosen
+  // colour, not a design-time tint. Mark it so `applySelectionVisuals`
+  // doesn't paint over it with the selection emphasis fill.
+  bgRect.__userControlledFill = imageColor !== null
 
   const children: FabricObject[] = [bgRect]
 

--- a/packages/ui/src/components/Canvas/fabric.d.ts
+++ b/packages/ui/src/components/Canvas/fabric.d.ts
@@ -35,6 +35,14 @@ declare module 'fabric' {
     __defaultStroke?: string
     /** Default (un-selected) strokeWidth saved on the field's background Rect. */
     __defaultStrokeWidth?: number
+    /**
+     * Marks a bgRect whose fill is user-controlled (e.g. solid-colour image
+     * field, #81). Selection emphasis must NOT paint over this fill — the
+     * user's chosen colour is the field's content, swapping it for the
+     * selection tint visually corrupts the document. `applySelectionVisuals`
+     * uses this flag to keep the fill and emphasise via stroke only.
+     */
+    __userControlledFill?: boolean
     /** Source-of-truth width of the field rect, written by `applyFieldToGroup`.
      *  Fabric's Group#width getter includes child bounding-box overhang, so it
      *  cannot be trusted as the intended rect width during drag/resize commit. */

--- a/packages/ui/src/components/Canvas/fabricUtils.ts
+++ b/packages/ui/src/components/Canvas/fabricUtils.ts
@@ -40,6 +40,7 @@ import type { FabricObject, FabricImage, Rect } from 'fabric'
 import type { FieldDefinition, InputJSON } from '@template-goblin/types'
 import { FIELD_COLORS, SELECTED_STROKE_WIDTH } from '../../theme/fieldColors.js'
 import { buildGroupChildren, type ImageResolver } from './buildGroupChildren.js'
+import { centerCompensatedLeftTop, recoverUnrotatedXY } from './rotationGeometry.js'
 
 // Re-export the moved utilities so existing importers keep working without
 // having to update their import paths.
@@ -159,9 +160,17 @@ export function createFieldGroup(
     data,
   )
 
+  // #172 — pivot rotation around the unrotated centre. With Fabric's
+  // `originX: 'left', originY: 'top'`, `group.angle` rotates around
+  // `(group.left, group.top)` (the top-left corner). To make Fabric's
+  // pivot match the schema's "rotate around the rect centre" intent,
+  // we offset `(left, top)` by exactly the amount Fabric's own
+  // `centeredRotation: true` compensates during a handle drag — see
+  // `rotationGeometry.ts` for the math.
+  const { left: groupLeft, top: groupTop } = centerCompensatedLeftTop(field)
   createdGroup = new Group(children, {
-    left: field.x,
-    top: field.y,
+    left: groupLeft,
+    top: groupTop,
     width: field.width,
     height: field.height,
     angle: field.rotation ?? 0,
@@ -276,9 +285,11 @@ export function applyFieldToGroup(
   // visible as a "white flash" on mouseup of every drag).
   const newHash = fieldRenderHash(field, resolveImage, data)
   if (group.__fieldHash === newHash && group.getObjects().length > 0) {
+    // #172 — see `centerCompensatedLeftTop` for the rationale.
+    const { left: gLeft, top: gTop } = centerCompensatedLeftTop(field)
     group.set({
-      left: field.x,
-      top: field.y,
+      left: gLeft,
+      top: gTop,
       angle: field.rotation ?? 0,
       scaleX: 1,
       scaleY: 1,
@@ -334,9 +345,12 @@ export function applyFieldToGroup(
   }
 
   // Restore the group to its real position now that children are in place.
+  // #172 — `centerCompensatedLeftTop` makes `group.angle` pivot around
+  // the field's unrotated centre.
+  const { left: finalLeft, top: finalTop } = centerCompensatedLeftTop(field)
   group.set({
-    left: field.x,
-    top: field.y,
+    left: finalLeft,
+    top: finalTop,
     angle: field.rotation ?? 0,
     width: field.width,
     height: field.height,
@@ -465,8 +479,8 @@ export function groupToFieldPatch(
   gridSize: number,
   snapToGrid: boolean,
 ): Pick<FieldDefinition, 'x' | 'y' | 'width' | 'height' | 'rotation'> {
-  const rawX = group.left ?? 0
-  const rawY = group.top ?? 0
+  const rawLeft = group.left ?? 0
+  const rawTop = group.top ?? 0
   const sx = group.scaleX ?? 1
   const sy = group.scaleY ?? 1
   // On a pure drag (no resize handle interaction) `scaleX/Y` stays at 1 and
@@ -481,16 +495,19 @@ export function groupToFieldPatch(
   const baseH = group.__fieldHeight ?? group.height ?? 0
   const rawW = baseW * sx
   const rawH = baseH * sy
-
-  const x = snap(rawX, gridSize, snapToGrid)
-  const y = snap(rawY, gridSize, snapToGrid)
+  const rotation = group.angle ?? 0
+  // #172 — recover the UNROTATED top-left from Fabric's compensated
+  // `(left, top)`. With `centeredRotation: true`, the rotation-handle
+  // drag updates `group.left/top` so the visible centre stays put;
+  // the recovery formula undoes that offset so the schema invariant
+  // (x/y describe the UNROTATED rect's top-left) holds. Snap-to-grid
+  // is applied AFTER recovery so the user's snap targets are the
+  // unrotated rect's edges, not the rotated AABB's.
+  const { x: unrotX, y: unrotY } = recoverUnrotatedXY(rawLeft, rawTop, rawW, rawH, rotation)
+  const x = snap(unrotX, gridSize, snapToGrid)
+  const y = snap(unrotY, gridSize, snapToGrid)
   const width = Math.max(20, snap(rawW, gridSize, snapToGrid))
   const height = Math.max(20, snap(rawH, gridSize, snapToGrid))
-  // #172 — read group.angle. Fabric's rotation handle leaves x/y at the
-  // group's pre-rotation position because we set `centeredRotation: true`
-  // in `createFieldGroup`, so the schema invariant (x/y/width/height
-  // describe the UNROTATED rect) holds without any extra correction.
-  const rotation = group.angle ?? 0
 
   // Update the group's logical position only. Deliberately DO NOT reset
   // scaleX/Y here even on a resize — the children were rendered stretched
@@ -500,7 +517,18 @@ export function groupToFieldPatch(
   // flash" on mouseup). Letting the scale linger means the in-between
   // frame keeps showing the stretched children that filled the group;
   // `applyFieldToGroup` will reset scale + rebuild atomically next tick.
-  group.set({ left: x, top: y })
+  //
+  // #172 — re-apply the centre-compensation when writing the snapped
+  // (x, y) back to the group so the visible position stays consistent
+  // with the snapped unrotated rect.
+  const { left: gLeft, top: gTop } = centerCompensatedLeftTop({
+    x,
+    y,
+    width,
+    height,
+    rotation,
+  })
+  group.set({ left: gLeft, top: gTop })
   group.__fieldWidth = width
   group.__fieldHeight = height
   group.setCoords()

--- a/packages/ui/src/components/Canvas/fabricUtils.ts
+++ b/packages/ui/src/components/Canvas/fabricUtils.ts
@@ -40,7 +40,7 @@ import type { FabricObject, FabricImage, Rect } from 'fabric'
 import type { FieldDefinition, InputJSON } from '@template-goblin/types'
 import { FIELD_COLORS, SELECTED_STROKE_WIDTH } from '../../theme/fieldColors.js'
 import { buildGroupChildren, type ImageResolver } from './buildGroupChildren.js'
-import { centerCompensatedLeftTop, recoverUnrotatedXY } from './rotationGeometry.js'
+import { centerCompensatedLeftTop, normaliseAngle, recoverUnrotatedXY } from './rotationGeometry.js'
 
 // Re-export the moved utilities so existing importers keep working without
 // having to update their import paths.
@@ -173,7 +173,12 @@ export function createFieldGroup(
     top: groupTop,
     width: field.width,
     height: field.height,
-    angle: field.rotation ?? 0,
+    // Normalised to [0, 360) so all consumers (Fabric content render,
+    // Fabric selection border render, our compensation math) use the
+    // same effective angle. Without this, huge inputs lose precision
+    // unevenly across code paths and the border drifts off the
+    // content — see `normaliseAngle` for the failure mode.
+    angle: normaliseAngle(field.rotation),
     originX: 'left',
     originY: 'top',
     centeredRotation: true,
@@ -290,7 +295,7 @@ export function applyFieldToGroup(
     group.set({
       left: gLeft,
       top: gTop,
-      angle: field.rotation ?? 0,
+      angle: normaliseAngle(field.rotation),
       scaleX: 1,
       scaleY: 1,
     })
@@ -351,7 +356,7 @@ export function applyFieldToGroup(
   group.set({
     left: finalLeft,
     top: finalTop,
-    angle: field.rotation ?? 0,
+    angle: normaliseAngle(field.rotation),
     width: field.width,
     height: field.height,
     scaleX: 1,
@@ -495,7 +500,7 @@ export function groupToFieldPatch(
   const baseH = group.__fieldHeight ?? group.height ?? 0
   const rawW = baseW * sx
   const rawH = baseH * sy
-  const rotation = group.angle ?? 0
+  const rotation = normaliseAngle(group.angle)
   // #172 — recover the UNROTATED top-left from Fabric's compensated
   // `(left, top)`. With `centeredRotation: true`, the rotation-handle
   // drag updates `group.left/top` so the visible centre stays put;

--- a/packages/ui/src/components/Canvas/fabricUtils.ts
+++ b/packages/ui/src/components/Canvas/fabricUtils.ts
@@ -126,7 +126,10 @@ function swapPlaceholderForImage(
  *
  * Group config (REQ-048):
  *  - `originX: 'left', originY: 'top'` so `left`/`top` = field `x`/`y`.
- *  - `lockRotation: true` (v1 constraint, REQ-013).
+ *  - Rotation handle is exposed (#172); the rotation handle uses Fabric's
+ *    `centeredRotation` default — rotates around the field's centre. The
+ *    stored value lives on `field.rotation` (degrees, null/0/undefined =
+ *    no rotation).
  *  - `lockScalingFlip: true` (REQ-011).
  *  - `selectable: true`, `hasControls: true`, `hasBorders: true`.
  *  - `subTargetCheck: false` (children must not receive individual events —
@@ -161,9 +164,10 @@ export function createFieldGroup(
     top: field.y,
     width: field.width,
     height: field.height,
+    angle: field.rotation ?? 0,
     originX: 'left',
     originY: 'top',
-    lockRotation: true,
+    centeredRotation: true,
     lockScalingFlip: true,
     selectable: true,
     hasControls: true,
@@ -275,6 +279,7 @@ export function applyFieldToGroup(
     group.set({
       left: field.x,
       top: field.y,
+      angle: field.rotation ?? 0,
       scaleX: 1,
       scaleY: 1,
     })
@@ -297,9 +302,13 @@ export function applyFieldToGroup(
   // identity) BEFORE re-adding children — the auto-translate becomes a
   // no-op and children land where their (left, top) say they should.
   // After the rebuild we restore the group to its real position.
+  // Also zero the angle during the rebuild so child enterGroup translation
+  // happens against an identity transform; the real angle is restored
+  // below once the children are in place.
   group.set({
     left: 0,
     top: 0,
+    angle: 0,
     width: field.width,
     height: field.height,
     scaleX: 1,
@@ -328,6 +337,7 @@ export function applyFieldToGroup(
   group.set({
     left: field.x,
     top: field.y,
+    angle: field.rotation ?? 0,
     width: field.width,
     height: field.height,
     scaleX: 1,
@@ -439,14 +449,18 @@ export function syncSelectionEmphasis(canvas: {
  * We multiply to get the true dimensions, reset scale to 1, and call
  * `setCoords()` so Fabric's bounding-box math stays in sync (REQ-051).
  *
+ * #172 — also captures `group.angle` so canvas rotation flows back into
+ * `field.rotation`. Returns `0` when the group isn't rotated so the
+ * sidebar input always sees a concrete number to display.
+ *
  * @param group - The Group that fired `object:modified`.
- * @returns Partial<FieldDefinition> with x, y, width, height.
+ * @returns Partial<FieldDefinition> with x, y, width, height, rotation.
  */
 export function groupToFieldPatch(
   group: Group,
   gridSize: number,
   snapToGrid: boolean,
-): Pick<FieldDefinition, 'x' | 'y' | 'width' | 'height'> {
+): Pick<FieldDefinition, 'x' | 'y' | 'width' | 'height' | 'rotation'> {
   const rawX = group.left ?? 0
   const rawY = group.top ?? 0
   const sx = group.scaleX ?? 1
@@ -468,6 +482,11 @@ export function groupToFieldPatch(
   const y = snap(rawY, gridSize, snapToGrid)
   const width = Math.max(20, snap(rawW, gridSize, snapToGrid))
   const height = Math.max(20, snap(rawH, gridSize, snapToGrid))
+  // #172 — read group.angle. Fabric's rotation handle leaves x/y at the
+  // group's pre-rotation position because we set `centeredRotation: true`
+  // in `createFieldGroup`, so the schema invariant (x/y/width/height
+  // describe the UNROTATED rect) holds without any extra correction.
+  const rotation = group.angle ?? 0
 
   // Update the group's logical position only. Deliberately DO NOT reset
   // scaleX/Y here even on a resize — the children were rendered stretched
@@ -482,7 +501,7 @@ export function groupToFieldPatch(
   group.__fieldHeight = height
   group.setCoords()
 
-  return { x, y, width, height }
+  return { x, y, width, height, rotation }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/packages/ui/src/components/Canvas/fabricUtils.ts
+++ b/packages/ui/src/components/Canvas/fabricUtils.ts
@@ -394,7 +394,11 @@ export function applySelectionVisuals(group: Group, selected: boolean): void {
   if (selected) {
     // Transparent-default fields keep a transparent fill on selection so a
     // rendered image / placeholder isn't painted over — stroke alone signals.
-    const nextFill = defaultFill === 'transparent' ? 'transparent' : tokens.selectedFill
+    // Solid-colour image fields (#81) carry the user's chosen colour as
+    // their bgRect fill; we tag those with `__userControlledFill` so the
+    // emphasis colour doesn't paint over the user's content either.
+    const keepFill = defaultFill === 'transparent' || bgRect.__userControlledFill === true
+    const nextFill = keepFill ? defaultFill : tokens.selectedFill
     bgRect.set({
       fill: nextFill,
       stroke: tokens.selectedStroke,

--- a/packages/ui/src/components/Canvas/rotationGeometry.ts
+++ b/packages/ui/src/components/Canvas/rotationGeometry.ts
@@ -1,0 +1,78 @@
+/**
+ * #172 follow-up: centre-pivoted rotation math.
+ *
+ * Schema invariant — `field.x / field.y / field.width / field.height`
+ * describe the UNROTATED rect. `field.rotation` is the visible rotation
+ * (degrees, clockwise positive) around the rect's CENTRE.
+ *
+ * Fabric's Group uses `originX: 'left', originY: 'top'`, so `group.angle`
+ * pivots around the group's top-left corner — NOT around the field's
+ * unrotated centre. To make Fabric's render agree with the schema
+ * (`group.angle = field.rotation`, visible centre = `(field.x + w/2,
+ * field.y + h/2)`), `group.left / group.top` must be offset by the same
+ * amount Fabric's own `centeredRotation: true` compensates during a
+ * rotation-handle drag. Without this offset, sidebar-driven rotation
+ * pivots around the top-left and visibly TRANSLATES the rect — the bug
+ * reported during #172 manual testing.
+ *
+ * The geometry helpers below convert in both directions so the
+ * schema's "unrotated top-left" semantics survive every input surface
+ * (sidebar, canvas handle, drag, store hydrate).
+ */
+export interface RectGeom {
+  x: number
+  y: number
+  width: number
+  height: number
+  rotation?: number | null
+}
+
+/**
+ * Given the field's unrotated rect + rotation, return the
+ * `(left, top)` Fabric needs on the Group so its `angle` pivot
+ * pivots around the unrotated centre — i.e. so the visible centre
+ * lands at `(x + width/2, y + height/2)` regardless of rotation.
+ *
+ * When rotation is 0 / null / undefined, returns `(x, y)` unchanged
+ * (the no-rotation fast path).
+ */
+export function centerCompensatedLeftTop(field: RectGeom): { left: number; top: number } {
+  const rotation = field.rotation ?? 0
+  if (rotation === 0) return { left: field.x, top: field.y }
+  const theta = (rotation * Math.PI) / 180
+  const cos = Math.cos(theta)
+  const sin = Math.sin(theta)
+  const halfW = field.width / 2
+  const halfH = field.height / 2
+  return {
+    left: field.x + halfW * (1 - cos) + halfH * sin,
+    top: field.y + halfH * (1 - cos) - halfW * sin,
+  }
+}
+
+/**
+ * Inverse of {@link centerCompensatedLeftTop}: given Fabric's compensated
+ * `(left, top)` for a rotated rect, return the unrotated rect's
+ * top-left so the schema invariant holds when reading group state back
+ * after a drag / rotate gesture.
+ *
+ * When `angle` is 0, returns `(left, top)` unchanged.
+ */
+export function recoverUnrotatedXY(
+  left: number,
+  top: number,
+  width: number,
+  height: number,
+  angle: number,
+): { x: number; y: number } {
+  if (angle === 0) return { x: left, y: top }
+  const theta = (angle * Math.PI) / 180
+  const cos = Math.cos(theta)
+  const sin = Math.sin(theta)
+  const halfW = width / 2
+  const halfH = height / 2
+  return {
+    x: left - halfW * (1 - cos) - halfH * sin,
+    y: top - halfH * (1 - cos) + halfW * sin,
+  }
+}

--- a/packages/ui/src/components/Canvas/rotationGeometry.ts
+++ b/packages/ui/src/components/Canvas/rotationGeometry.ts
@@ -28,6 +28,27 @@ export interface RectGeom {
 }
 
 /**
+ * Reduce any angle (in degrees) to the canonical `[0, 360)` range.
+ *
+ * `null` / `undefined` / non-finite values collapse to `0`. Beyond
+ * making the schema's "any number" rotation behave sanely, this is
+ * load-bearing for huge inputs: at e.g. `5.6e15` degrees, the
+ * `deg * π / 180` multiplication loses enough precision that
+ * `Math.cos / Math.sin` evaluated in two different code paths can
+ * diverge by ~0.7% — the visible content and Fabric's selection
+ * border end up rotated to slightly different effective angles.
+ * Normalising first turns the multiplication into a precise one
+ * (value is under 360, so the result fits well within IEEE 754
+ * mantissa precision) and the divergence disappears.
+ */
+export function normaliseAngle(deg: number | null | undefined): number {
+  const d = deg ?? 0
+  if (!Number.isFinite(d)) return 0
+  const m = d % 360
+  return m < 0 ? m + 360 : m
+}
+
+/**
  * Given the field's unrotated rect + rotation, return the
  * `(left, top)` Fabric needs on the Group so its `angle` pivot
  * pivots around the unrotated centre — i.e. so the visible centre
@@ -37,7 +58,7 @@ export interface RectGeom {
  * (the no-rotation fast path).
  */
 export function centerCompensatedLeftTop(field: RectGeom): { left: number; top: number } {
-  const rotation = field.rotation ?? 0
+  const rotation = normaliseAngle(field.rotation)
   if (rotation === 0) return { left: field.x, top: field.y }
   const theta = (rotation * Math.PI) / 180
   const cos = Math.cos(theta)
@@ -65,8 +86,9 @@ export function recoverUnrotatedXY(
   height: number,
   angle: number,
 ): { x: number; y: number } {
-  if (angle === 0) return { x: left, y: top }
-  const theta = (angle * Math.PI) / 180
+  const rotation = normaliseAngle(angle)
+  if (rotation === 0) return { x: left, y: top }
+  const theta = (rotation * Math.PI) / 180
   const cos = Math.cos(theta)
   const sin = Math.sin(theta)
   const halfW = width / 2

--- a/packages/ui/src/components/Canvas/wireDragResizeEvents.ts
+++ b/packages/ui/src/components/Canvas/wireDragResizeEvents.ts
@@ -42,12 +42,19 @@ export function wireDragResizeEvents(fc: FabricCanvas) {
         y: localY,
         width: patch.width,
         height: patch.height,
+        rotation: patch.rotation,
       })
       return
     }
 
     store.moveField(g.__fieldId, patch.x, patch.y)
     store.resizeField(g.__fieldId, patch.width, patch.height)
+    // #172 — rotation goes through updateField (no dedicated rotateField
+    // action; updateField handles the partial cleanly). Fires once per
+    // object:modified — Fabric only emits this at the end of a gesture,
+    // so calling it on every drag/resize event still produces a single
+    // commit per user action.
+    store.updateField(g.__fieldId, { rotation: patch.rotation })
   })
 
   fc.on('object:moving', (opt) => {

--- a/packages/ui/src/components/Canvas/wireDragResizeEvents.ts
+++ b/packages/ui/src/components/Canvas/wireDragResizeEvents.ts
@@ -66,7 +66,10 @@ export function wireDragResizeEvents(fc: FabricCanvas) {
     // visible edge — disable the snap-while-moving for rotated fields
     // and let the commit-time snap in `groupToFieldPatch` (which works
     // off the recovered unrotated rect) handle it instead.
-    if ((obj.angle ?? 0) !== 0) return
+    // Normalised so a 0 / 360 / -720 angle (visually identical to 0)
+    // doesn't skip the snap.
+    const normAngle = (((obj.angle ?? 0) % 360) + 360) % 360
+    if (normAngle !== 0) return
     const { showGrid: sg, gridSize: gs } = useUiStore.getState()
     obj.set({
       left: snap(obj.left ?? 0, gs, sg),

--- a/packages/ui/src/components/Canvas/wireDragResizeEvents.ts
+++ b/packages/ui/src/components/Canvas/wireDragResizeEvents.ts
@@ -60,6 +60,13 @@ export function wireDragResizeEvents(fc: FabricCanvas) {
   fc.on('object:moving', (opt) => {
     const obj = opt.target
     if (!obj) return
+    // #172 — `obj.left/top` on a rotated group is the centre-compensated
+    // value (so `group.angle` pivots around the unrotated centre). Grid
+    // snap on that value would snap an offset point, NOT the rect's
+    // visible edge — disable the snap-while-moving for rotated fields
+    // and let the commit-time snap in `groupToFieldPatch` (which works
+    // off the recovered unrotated rect) handle it instead.
+    if ((obj.angle ?? 0) !== 0) return
     const { showGrid: sg, gridSize: gs } = useUiStore.getState()
     obj.set({
       left: snap(obj.left ?? 0, gs, sg),

--- a/packages/ui/src/components/LeftPanel/PropertiesPanel.tsx
+++ b/packages/ui/src/components/LeftPanel/PropertiesPanel.tsx
@@ -3,6 +3,7 @@ import { useUiStore } from '../../store/uiStore.js'
 import { TextFieldProps } from '../RightPanel/TextFieldProps.js'
 import { ImageFieldProps } from '../RightPanel/ImageFieldProps.js'
 import { LoopFieldProps } from '../RightPanel/LoopFieldProps.js'
+import { RotationSection } from './RotationSection.js'
 
 /**
  * Left-panel content under the new layout (GH #19): the styling / properties
@@ -55,6 +56,10 @@ export function PropertiesPanel() {
       {selectedField.type === 'text' && <TextFieldProps field={selectedField} />}
       {selectedField.type === 'image' && <ImageFieldProps field={selectedField} />}
       {selectedField.type === 'table' && <LoopFieldProps field={selectedField} />}
+      {/* #172 — field-type-agnostic rotation control. Lives in PropertiesPanel
+          rather than each *FieldProps.tsx so a single section serves all three
+          field types without bloating any one file past the 300-LOC cap. */}
+      <RotationSection field={selectedField} />
     </>
   )
 }

--- a/packages/ui/src/components/LeftPanel/RotationSection.tsx
+++ b/packages/ui/src/components/LeftPanel/RotationSection.tsx
@@ -1,0 +1,45 @@
+/**
+ * Per-field rotation control (#172).
+ *
+ * Renders a single "Angle" row in the field properties panel: a numeric
+ * input whose value mirrors the field's `rotation` (degrees, around the
+ * field centre). Two-way sync with the canvas rotation handle —
+ * `wireDragResizeEvents` commits `group.angle` back through
+ * `updateField`, so dragging the handle live-updates this input.
+ *
+ * Schema invariants:
+ *  - `null` / `undefined` / `0` all mean "no rotation".
+ *  - Writes from this control normalise to `null` when the user types 0
+ *    so blank/zero states converge to the sparse representation (avoids
+ *    `.tgbl` bloat for fields that never rotated).
+ *  - Any number is accepted (Fabric `angle` is unbounded); the input
+ *    does not clamp to 0–359.
+ */
+import type { FieldDefinition } from '@template-goblin/types'
+import { NumberInput } from '../NumberInput.js'
+import { useTemplateStore } from '../../store/templateStore.js'
+
+interface Props {
+  field: FieldDefinition
+}
+
+export function RotationSection({ field }: Props) {
+  const updateField = useTemplateStore((s) => s.updateField)
+  const value = field.rotation ?? 0
+
+  function onChange(next: number) {
+    // Persist `null` for the zero case so we don't bloat templates with
+    // `rotation: 0` on every field that never moved off the default.
+    updateField(field.id, { rotation: next === 0 ? null : next })
+  }
+
+  return (
+    <div className="tg-panel-section">
+      <div className="tg-panel-section-title">Transform</div>
+      <div className="tg-form-row">
+        <label>Angle (°)</label>
+        <NumberInput value={value} step={1} defaultValue={0} onChange={onChange} />
+      </div>
+    </div>
+  )
+}

--- a/packages/ui/src/components/LeftPanel/RotationSection.tsx
+++ b/packages/ui/src/components/LeftPanel/RotationSection.tsx
@@ -18,6 +18,7 @@
 import type { FieldDefinition } from '@template-goblin/types'
 import { NumberInput } from '../NumberInput.js'
 import { useTemplateStore } from '../../store/templateStore.js'
+import { normaliseAngle } from '../Canvas/rotationGeometry.js'
 
 interface Props {
   field: FieldDefinition
@@ -28,9 +29,15 @@ export function RotationSection({ field }: Props) {
   const value = field.rotation ?? 0
 
   function onChange(next: number) {
+    // Reduce to [0, 360) on commit so the input value, the canvas
+    // angle, Fabric's selection border, and the PDF rotation ALL
+    // agree on the same effective angle. Huge inputs (e.g. accidental
+    // pastes) lose precision unevenly in different code paths
+    // otherwise — see rotationGeometry.ts#normaliseAngle.
+    const norm = normaliseAngle(next)
     // Persist `null` for the zero case so we don't bloat templates with
     // `rotation: 0` on every field that never moved off the default.
-    updateField(field.id, { rotation: next === 0 ? null : next })
+    updateField(field.id, { rotation: norm === 0 ? null : norm })
   }
 
   return (

--- a/packages/ui/src/store/__tests__/rotation.test.ts
+++ b/packages/ui/src/store/__tests__/rotation.test.ts
@@ -1,0 +1,99 @@
+/**
+ * #172 — store-level coverage for `field.rotation`.
+ *
+ * The schema accepts `number | null | undefined`; this pins:
+ *   - updateField persists a non-zero rotation
+ *   - updateField with null clears the rotation back to the sparse default
+ *   - omitting rotation entirely (legacy field shape) does not crash any
+ *     selector and reads back as undefined
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { TextField, TextFieldStyle } from '@template-goblin/types'
+
+const storage = new Map<string, string>()
+vi.stubGlobal('localStorage', {
+  getItem: (key: string) => storage.get(key) ?? null,
+  setItem: (key: string, value: string) => storage.set(key, value),
+  removeItem: (key: string) => storage.delete(key),
+  clear: () => storage.clear(),
+})
+
+import { useTemplateStore } from '../templateStore'
+
+function makeTextStyle(): TextFieldStyle {
+  return {
+    fontId: null,
+    fontFamily: 'Helvetica',
+    fontSize: 12,
+    fontSizeMin: 11,
+    lineHeight: 1.2,
+    fontWeight: 'normal',
+    fontStyle: 'normal',
+    textDecoration: 'none',
+    color: '#000',
+    align: 'left',
+    verticalAlign: 'top',
+    maxRows: 1,
+    overflowMode: 'truncate',
+    snapToGrid: true,
+  }
+}
+
+function makeField(overrides: Partial<TextField> = {}): TextField {
+  return {
+    id: 'f-1',
+    type: 'text',
+    groupId: null,
+    pageId: null,
+    label: '',
+    source: { mode: 'static', value: 'hi' },
+    x: 10,
+    y: 20,
+    width: 100,
+    height: 30,
+    zIndex: 0,
+    style: makeTextStyle(),
+    ...overrides,
+  }
+}
+
+describe('templateStore — field.rotation (#172)', () => {
+  beforeEach(() => {
+    storage.clear()
+    useTemplateStore.getState().reset()
+  })
+
+  it('updateField writes a non-zero rotation', () => {
+    const s = useTemplateStore.getState()
+    s.addField(makeField())
+    s.updateField('f-1', { rotation: 45 })
+    expect(useTemplateStore.getState().fields[0]?.rotation).toBe(45)
+  })
+
+  it('updateField with null clears rotation to the sparse default', () => {
+    const s = useTemplateStore.getState()
+    s.addField(makeField({ rotation: 90 }))
+    s.updateField('f-1', { rotation: null })
+    expect(useTemplateStore.getState().fields[0]?.rotation).toBeNull()
+  })
+
+  it('newly added field with no rotation reads as undefined (sparse default)', () => {
+    const s = useTemplateStore.getState()
+    s.addField(makeField())
+    expect(useTemplateStore.getState().fields[0]?.rotation).toBeUndefined()
+  })
+
+  it('negative rotation passes through (Fabric angle is unbounded)', () => {
+    const s = useTemplateStore.getState()
+    s.addField(makeField())
+    s.updateField('f-1', { rotation: -135 })
+    expect(useTemplateStore.getState().fields[0]?.rotation).toBe(-135)
+  })
+
+  it('rotation > 360 passes through unchanged (no clamp on write)', () => {
+    const s = useTemplateStore.getState()
+    s.addField(makeField())
+    s.updateField('f-1', { rotation: 720 })
+    expect(useTemplateStore.getState().fields[0]?.rotation).toBe(720)
+  })
+})


### PR DESCRIPTION
## Summary

Closes #172. Supersedes #33.

Adds `rotation` to every field type and surfaces it through both an "Angle (°)" input in the LeftPanel properties editor and Fabric's selection rotation handle. The two are kept in two-way sync, both pivot around the field's unrotated centre, and the rotation round-trips through `.tgbl` save/load and the PDF render path.

### Schema (`@template-goblin/types`)
- `FieldBase.rotation?: number | null` — degrees, around the rect centre. `null` / `undefined` / `0` all render unrotated, so pre-rotation templates load unchanged.

### UI (`template-goblin-ui`)
- LeftPanel "Angle (°)" input; canvas rotation handle exposed on every field type (text, image, table).
- Sidebar and canvas-handle inputs both pivot around the unrotated centre — no visual translation when angle changes. Schema invariant `(x, y) = unrotated top-left` survives every gesture.
- Angles are normalised to `[0, 360)` at every consumer boundary so huge inputs (e.g. accidental pastes like `5612356213214654`) don't cause Fabric's selection border to drift off the rendered content.
- Bonus fix: clicking a **solid-colour image field** (`{ color }`) no longer overrides its bgRect with the selection emphasis fill — the user's chosen colour is preserved, emphasis switches to stroke only.

### PDF renderer (`template-goblin`)
- `renderField` wraps each draw block in `doc.save() / doc.rotate(angle, { origin: [cx, cy] }) / doc.restore()` when rotation is non-zero. Origin matches the UI's centre-pivot so canvas preview and generated PDF agree pixel-for-pixel.
- Rotation is normalised before `doc.rotate` so legacy / malformed values can't desync the PDF from the UI.

## Test plan
- [x] Core Jest: 467 / 467 (+8 new rotation render cases)
- [x] UI Vitest: 582 / 582 (+49 new rotation geometry + normalisation cases, +5 store-level cases)
- [x] Playwright e2e: 134 passed, 0 failed (+3 rotation specs, +2 solid-image specs)
- [x] Live browser verification: sidebar rotation pivots around centre; canvas handle pivots around centre; both produce identical visible result. Solid-colour image keeps its fill on selection. Huge angle (`5612356213214654`) normalises to `254` with content+border coincident. PDF preview generates valid `%PDF-1.3` bytes for rotated fields.