### PR TITLE
docs: drop construction banners; codify branch-first hard rule

### DIFF
--- a/.changeset/stable-docs.md
+++ b/.changeset/stable-docs.md
@@ -1,0 +1,9 @@
+---
+'@template-goblin/types': patch
+'template-goblin': patch
+'template-goblin-ui': patch
+---
+
+Docs: remove the "Under Construction" / "Pre-1.0" banners from the README of
+every published package — the packages are published and stable. The repo
+README gains an npm version badge in place of the construction notice.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,15 @@ developers use the npm library to generate PDFs at scale.
     supersedes Rule #15's "do exactly what is asked" for these
     specific phrases: the merge is the asked action and ALL of
     (a)-(g) are part of it.
-19. **Clarify before starting — both when filing an issue and when
+19. **Never work directly on `main` — branch first, always.** Before
+    writing ANY change (code, docs, examples, configs), create / switch
+    to a feature branch (`feature/<issue-or-topic>-<short-name>`). This
+    applies to documentation-only and examples-only changes too — there
+    are no "small enough" exceptions. If changes were accidentally
+    started on `main`, move them to a branch immediately (uncommitted
+    work carries over on `git switch -c <branch>`). `main` only ever
+    advances via PR merges.
+20. **Clarify before starting — both when filing an issue and when
     starting work on one.** If anything about the requested change
     is ambiguous (acceptance scope, edge cases, backward compat,
     cut-point / cap / default values, which surfaces are in scope,

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # TemplateGoblin
 
-> ## 🚧 Under Construction 🚧
->
-> **TemplateGoblin is in active early development.** APIs, the `.tgbl` file format, and the visual builder are all subject to breaking changes without notice. The packages are not yet published to npm, and the hosted UI is not stable. **Do not use in production.** Star the repo to follow progress — a stable `v1.0.0` release will be announced here.
+[![npm](https://img.shields.io/npm/v/template-goblin.svg)](https://www.npmjs.com/package/template-goblin)
 
 Open-source PDF template engine for generating PDFs at scale. Non-technical users design templates with a visual drag-and-drop builder, developers use the npm library to generate millions of PDFs from JSON data. Templates are saved as `.tgbl` files — portable ZIP archives containing the layout, fonts, and images needed for rendering.
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -41,5 +41,3 @@ Types live in [`@template-goblin/types`](https://www.npmjs.com/package/@template
 - 📖 **Full docs, examples, and the visual builder** — https://github.com/JaiminPatel345/template-goblin
 - 🐛 **Issues & feature requests** — https://github.com/JaiminPatel345/template-goblin/issues
 - 📄 **License** — MIT
-
-> 🚧 **Pre-1.0** — APIs and the `.tgbl` format may change between minor versions. See the repo for the current status.

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -31,5 +31,3 @@ If you're just rendering PDFs from a designed template, [`template-goblin`](http
 - 📖 **Repo, docs, and examples** — https://github.com/JaiminPatel345/template-goblin
 - 🐛 **Issues** — https://github.com/JaiminPatel345/template-goblin/issues
 - 📄 **License** — MIT
-
-> 🚧 **Pre-1.0** — schema fields may be added, renamed, or removed between minor versions.

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -39,5 +39,3 @@ await writeFile('out.pdf', pdf)
 - 📖 **Full docs and examples** — https://github.com/JaiminPatel345/template-goblin
 - 🐛 **Issues & feature requests** — https://github.com/JaiminPatel345/template-goblin/issues
 - 📄 **License** — MIT
-
-> 🚧 **Pre-1.0** — UI workflows and the `.tgbl` file format may change between minor versions.


### PR DESCRIPTION
Documentation-only changes:

- **Remove the "🚧 Under Construction 🚧" banner** from the repo README (replaced with an npm version badge) and the "🚧 Pre-1.0" notes from the `@template-goblin/types`, `template-goblin`, and `template-goblin-ui` package READMEs — the packages are published and stable.
- **CLAUDE.md: new Hard Rule #19** — never work directly on `main`; always create a feature branch before any change (docs included). The old #19 (clarify-before-starting) becomes #20.
- Changeset included (patch) since package READMEs ship inside the npm tarballs.