### PR TITLE
fix: master-QA sweep — phantom pages, band-field data loss, batch hangs, undo coverage, WYSIWYG parity

### DIFF
--- a/.changeset/master-qa-sweep.md
+++ b/.changeset/master-qa-sweep.md
@@ -1,0 +1,24 @@
+---
+'@template-goblin/types': minor
+'template-goblin': minor
+'template-goblin-ui': patch
+---
+
+Master-QA sweep: phantom pages, band-field data loss, batch hangs, undo coverage, and WYSIWYG parity fixes.
+
+**template-goblin**
+
+- `addPage` now carries `margin: 0` — pages after the first silently got PDFKit's 72pt default margins, spilling bottom-strip content onto phantom pages and corrupting the clip state.
+- Header/footer band fields are now visible to `validateData`, preflight, `loadTemplate`, and font-subset code-point extraction — required band fields validate, band images load and render, and load→save round-trips no longer drop band assets.
+- Per-page backgrounds are written under `page.backgroundFilename` so they survive a save→load round-trip.
+- `generateBatchPDF` settles with a failure result instead of hanging forever when a worker process dies without replying; bare `Error` throws replaced with `TemplateGoblinError` (new `INVALID_ARGUMENT` code).
+- Fields rendered after a multiPage table land on their own page instead of the table's last continuation page.
+- `validateManifest` tolerates legacy manifests without a `pages` array; `loadTemplate` accepts directory-prefixed asset filenames; table header labels truncate to their cell box.
+
+**template-goblin-ui**
+
+- Band fields are first-class everywhere: `openTemplate` loads their image assets, undo/redo snapshots include bands (hiding a band then Ctrl+Z no longer loses its fields permanently), and keyboard Delete / mode toggle / duplicate work on band fields.
+- Multi-select drag/resize gestures commit to the store (previously dropped entirely — fields snapped back).
+- Canvas text wrapping mirrors the PDF renderer exactly: newlines split paragraphs and over-wide words break mid-word.
+- Properties-panel editors re-mount per field, fixing hyperlink drafts leaking across selections (which could silently overwrite or delete a field's link).
+- Footer drag/draw math uses the viewed page's own height; bands with "not on first page" no longer swallow fields drawn on page 1; File→Open resets the page view; the first action after a reload is undoable; image/font uploads are validated up front; JSON-panel table edits no longer stamp fallback strings into sparse placeholders.

--- a/packages/core/src/assetRefs.ts
+++ b/packages/core/src/assetRefs.ts
@@ -1,4 +1,5 @@
-import type { PageBand, TemplateManifest } from '@template-goblin/types'
+import type { TemplateManifest } from '@template-goblin/types'
+import { allManifestFields } from './utils/manifestFields.js'
 
 /**
  * Referenced-image-asset collection — the mark phase of the .tgbl
@@ -48,19 +49,12 @@ export function collectReferencedImageAssets(
 ): ReferencedImageAssets {
   const refs: ReferencedImageAssets = { placeholders: new Set(), staticImages: new Set() }
 
-  const pools: Array<Pick<PageBand, 'fields'> | undefined> = [
-    { fields: manifest.fields },
-    manifest.header,
-    manifest.footer,
-  ]
-  for (const pool of pools) {
-    for (const field of pool?.fields ?? []) {
-      if (field.type !== 'image' || !field.source) continue
-      if (field.source.mode === 'dynamic') {
-        addRef(refs.placeholders, filenameOf(field.source.placeholder), PLACEHOLDERS_PREFIX)
-      } else {
-        addRef(refs.staticImages, filenameOf(field.source.value), IMAGES_PREFIX)
-      }
+  for (const field of allManifestFields(manifest)) {
+    if (field.type !== 'image' || !field.source) continue
+    if (field.source.mode === 'dynamic') {
+      addRef(refs.placeholders, filenameOf(field.source.placeholder), PLACEHOLDERS_PREFIX)
+    } else {
+      addRef(refs.staticImages, filenameOf(field.source.value), IMAGES_PREFIX)
     }
   }
   return refs

--- a/packages/core/src/batch.ts
+++ b/packages/core/src/batch.ts
@@ -1,5 +1,6 @@
 import { fork } from 'node:child_process'
 import { cpus } from 'node:os'
+import { TemplateGoblinError } from '@template-goblin/types'
 import type { LoadedTemplate, InputJSON } from '@template-goblin/types'
 import { generatePDF } from './generate.js'
 
@@ -90,7 +91,10 @@ export async function generateBatchPDF(
   const { concurrency = cpus().length, parallel = true, onProgress, workerPath } = options
 
   if (dataArray.length > MAX_BATCH_SIZE) {
-    throw new Error(`Batch size ${dataArray.length} exceeds maximum of ${MAX_BATCH_SIZE}`)
+    throw new TemplateGoblinError(
+      'INVALID_ARGUMENT',
+      `Batch size ${dataArray.length} exceeds maximum of ${MAX_BATCH_SIZE}`,
+    )
   }
 
   if (!parallel || dataArray.length <= 1) {
@@ -103,7 +107,10 @@ export async function generateBatchPDF(
   let completed = 0
 
   if (!workerPath) {
-    throw new Error('workerPath is required when parallel=true. Pass the path to batch-worker.js.')
+    throw new TemplateGoblinError(
+      'INVALID_ARGUMENT',
+      'workerPath is required when parallel=true. Pass the path to batch-worker.js.',
+    )
   }
   const resolvedWorkerPath: string = workerPath
 
@@ -118,34 +125,50 @@ export async function generateBatchPDF(
 
       const child = fork(resolvedWorkerPath, [], { serialization: 'json' })
 
+      // Exactly ONE settlement per worker slot — `message`, `error`, and
+      // `exit` can all fire for the same child, and a child killed by the
+      // OS (OOM, segfault) fires ONLY `exit`. Without the exit handler a
+      // dead worker left `completed` short forever and the batch promise
+      // never resolved.
+      let settled = false
+      function settle(result: BatchResult) {
+        if (settled) return
+        settled = true
+        results[index] = result
+        completed++
+        onProgress?.(completed, dataArray.length)
+
+        if (completed === dataArray.length) {
+          resolve(results)
+        } else {
+          spawnNext()
+        }
+      }
+
       child.on('message', (msg: { success: boolean; pdf?: string; error?: string }) => {
-        results[index] = {
+        settle({
           index,
           success: msg.success,
           pdf: msg.pdf ? Buffer.from(msg.pdf, 'base64') : undefined,
           error: msg.error,
-        }
-
-        completed++
-        onProgress?.(completed, dataArray.length)
-
-        if (completed === dataArray.length) {
-          resolve(results)
-        } else {
-          spawnNext()
-        }
+        })
       })
 
       child.on('error', (err) => {
-        results[index] = { index, success: false, error: err.message }
-        completed++
-        onProgress?.(completed, dataArray.length)
+        settle({ index, success: false, error: err.message })
+      })
 
-        if (completed === dataArray.length) {
-          resolve(results)
-        } else {
-          spawnNext()
-        }
+      child.on('exit', (code, signal) => {
+        // A healthy worker sends its result and exits immediately — give an
+        // already-delivered `message` event one tick of priority so a clean
+        // exit can't race its own reply into a false failure.
+        setImmediate(() =>
+          settle({
+            index,
+            success: false,
+            error: `Worker exited before replying (code ${code ?? 'null'}, signal ${signal ?? 'null'})`,
+          }),
+        )
       })
 
       child.send({ template: serialized, data })

--- a/packages/core/src/file/write.ts
+++ b/packages/core/src/file/write.ts
@@ -56,7 +56,12 @@ export async function saveTemplate(
       for (const page of sortedPages) {
         const bgBuffer = assets.pageBackgrounds.get(page.id)
         if (bgBuffer) {
-          const filename = `${BACKGROUNDS_DIR}page-${page.index}.png`
+          // The loader resolves backgrounds via `page.backgroundFilename`
+          // — writing under a synthetic index-based name orphaned every
+          // per-page background on the very next load. Honour the
+          // manifest's filename; the index name remains only as the
+          // legacy fallback for pages that never set one.
+          const filename = page.backgroundFilename ?? `${BACKGROUNDS_DIR}page-${page.index}.png`
           zip.addFile(filename, bgBuffer)
         }
       }

--- a/packages/core/src/generate.ts
+++ b/packages/core/src/generate.ts
@@ -121,7 +121,12 @@ export async function generatePDF(
         const page = sortedPages[i] as PageDefinition
 
         if (i > 0) {
-          doc.addPage({ size: [meta.width, meta.height] })
+          // `addPage(options)` REPLACES the constructor options — without an
+          // explicit margin PDFKit applies its 72pt default to every page
+          // after the first, shrinking the writable area: content in the
+          // bottom 72pt triggered auto-pagination (phantom pages) and split
+          // clip save/restore pairs across pages (corrupt q/Q nesting).
+          doc.addPage({ size: [meta.width, meta.height], margin: 0 })
         }
 
         const pageCtx: PageContext = { pageId: page.id, pageIndex: page.index }
@@ -152,8 +157,18 @@ export async function generatePDF(
         // Sort by zIndex (lowest first), stable with id tiebreaker
         pageFields.sort((a, b) => a.zIndex - b.zIndex || a.id.localeCompare(b.id))
 
+        // A multiPage table appends continuation pages and leaves the doc
+        // pointed at the LAST of them — without switching back, every
+        // later field of this template page rendered onto the table's
+        // final overflow page instead of its own. Pin this page's buffer
+        // index (it IS the last page right after addPage) and return to
+        // it whenever a field grew the document.
+        const thisPageIndex = doc.bufferedPageRange().count - 1
         for (const field of pageFields) {
           renderField(doc, field, data, fontMap, template, pageCtx, resolvedImages)
+          if (doc.bufferedPageRange().count - 1 !== thisPageIndex) {
+            doc.switchToPage(thisPageIndex)
+          }
         }
       }
     }

--- a/packages/core/src/load.ts
+++ b/packages/core/src/load.ts
@@ -2,6 +2,7 @@ import AdmZip from 'adm-zip'
 import type { LoadedTemplate } from '@template-goblin/types'
 import { TemplateGoblinError } from '@template-goblin/types'
 import { readTgblBuffer, parseManifestFromZip } from './file/read.js'
+import { allManifestFields } from './utils/manifestFields.js'
 import {
   BACKGROUND_FILENAME,
   BACKGROUNDS_DIR,
@@ -88,14 +89,19 @@ export async function loadTemplate(path: string): Promise<LoadedTemplate> {
   // the archive entry and stores the bare filename as the Map key.
   const placeholders = new Map<string, Buffer>()
   const staticImages = new Map<string, Buffer>()
-  for (const field of manifest.fields) {
+  // #61 — band image fields' assets live in the same archive folders.
+  for (const field of allManifestFields(manifest)) {
     if (field.type !== 'image') continue
     if (field.source.mode === 'static') {
       // GH #81 — solid-colour static fields carry no asset to load.
       if ('color' in field.source.value) continue
       const filename = field.source.value.filename
       if (!staticImages.has(filename)) {
-        const entry = zip.getEntry(`${IMAGES_DIR}${filename}`)
+        // References may already carry the folder prefix (the writers
+        // accept both spellings — see assetRefs.ts); don't double it.
+        const entry = zip.getEntry(
+          filename.startsWith(IMAGES_DIR) ? filename : `${IMAGES_DIR}${filename}`,
+        )
         if (!entry) {
           throw new TemplateGoblinError(
             'MISSING_STATIC_IMAGE_FILE',
@@ -109,7 +115,9 @@ export async function loadTemplate(path: string): Promise<LoadedTemplate> {
       if ('color' in field.source.placeholder) continue
       const filename = field.source.placeholder.filename
       if (!placeholders.has(filename)) {
-        const entry = zip.getEntry(`${PLACEHOLDERS_DIR}${filename}`)
+        const entry = zip.getEntry(
+          filename.startsWith(PLACEHOLDERS_DIR) ? filename : `${PLACEHOLDERS_DIR}${filename}`,
+        )
         if (!entry) {
           throw new TemplateGoblinError(
             'MISSING_PLACEHOLDER_IMAGE_FILE',

--- a/packages/core/src/preflight.ts
+++ b/packages/core/src/preflight.ts
@@ -4,6 +4,7 @@ import { sniffImageFormat } from './utils/imageFormat.js'
 import { pageContextFor, pageLabel, type PageContext } from './utils/errorContext.js'
 import { resolveImageInputs, type ResolveContext, type ResolveOptions } from './utils/imageInput.js'
 import { isImageColorMarker } from './utils/imageColorMarker.js'
+import { allManifestFields } from './utils/manifestFields.js'
 
 /** Per-call options for {@link preflightImages}. */
 export interface PreflightOptions {
@@ -49,7 +50,9 @@ export async function preflightImages(
   // synchronous.
   const dynamicWork: Array<{ input: ImageInput; ctx: ResolveContext; field: FieldDefinition }> = []
 
-  for (const field of manifest.fields) {
+  // #61 — band image fields resolve from the same pools; skipping them
+  // meant required band images silently rendered blank.
+  for (const field of allManifestFields(manifest)) {
     if (field.type !== 'image') continue
     const pageContext = pageContextFor(template, field.pageId)
 

--- a/packages/core/src/render/loop.ts
+++ b/packages/core/src/render/loop.ts
@@ -74,7 +74,8 @@ export function renderLoop(
       // so each page's table chunk has all four edges (#65).
       drawTablePerimeter(doc, x, y, width, field.height, style)
 
-      doc.addPage({ size: [meta.width, meta.height] })
+      // margin: 0 — addPage REPLACES constructor options (see generate.ts).
+      doc.addPage({ size: [meta.width, meta.height], margin: 0 })
       renderBackground(doc, backgroundImage, meta)
 
       currentY = y
@@ -193,7 +194,13 @@ function renderHeaderRow(
     )
     const textWidth = colWidth - hs.paddingLeft - hs.paddingRight
 
-    const headerLabel = col.label || col.key
+    // Truncate to the cell box exactly like data cells do — a long
+    // column label painted past the column edge (Hard Rule #10).
+    const rawLabel = col.label || col.key
+    const measured = measureText(doc, rawLabel, hs.fontSize, textWidth, 1)
+    const headerLabel = measured.fits
+      ? rawLabel
+      : (truncateLines(doc, measured.lines, 1, textWidth)[0] ?? '')
     doc.text(headerLabel, textX, textY, {
       width: textWidth,
       align: hs.align,

--- a/packages/core/src/storage.ts
+++ b/packages/core/src/storage.ts
@@ -1,4 +1,5 @@
 import type { LoadedTemplate, InputJSON } from '@template-goblin/types'
+import { TemplateGoblinError } from '@template-goblin/types'
 import { generatePDF } from './generate.js'
 
 /**
@@ -63,7 +64,10 @@ export async function generateAndStore(
 
   // Sanitize storage key — prevent path traversal
   if (rawKey.includes('..') || rawKey.startsWith('/') || /[<>:"|?*]/.test(rawKey)) {
-    throw new Error('Invalid storage key: contains unsafe characters')
+    throw new TemplateGoblinError(
+      'INVALID_ARGUMENT',
+      'Invalid storage key: contains unsafe characters',
+    )
   }
   const fullKey = rawKey
 

--- a/packages/core/src/utils/fontSubset.ts
+++ b/packages/core/src/utils/fontSubset.ts
@@ -1,4 +1,5 @@
 import type { TemplateManifest } from '@template-goblin/types'
+import { allManifestFields } from './manifestFields.js'
 
 /**
  * Common characters to always include in subsetted fonts.
@@ -29,7 +30,19 @@ for (const ch of EXTENDED) {
 export function extractUsedCodePoints(manifest: TemplateManifest): Set<number> {
   const codePoints = new Set(COMMON_CHARS)
 
-  for (const field of manifest.fields) {
+  // #61 — band fields render text too; pageNumber stamps digits, roman
+  // numerals, and the user's prefix/suffix. Subsetting only body fields
+  // would render band/page-number glyphs as tofu once real subsetting
+  // is wired in.
+  if (manifest.pageNumber) {
+    addStringCodePoints(codePoints, '0123456789ivxlcdmIVXLCDM/ ')
+    const pn = manifest.pageNumber as { format?: string; prefix?: string; suffix?: string }
+    if (typeof pn.format === 'string') addStringCodePoints(codePoints, pn.format)
+    if (typeof pn.prefix === 'string') addStringCodePoints(codePoints, pn.prefix)
+    if (typeof pn.suffix === 'string') addStringCodePoints(codePoints, pn.suffix)
+  }
+
+  for (const field of allManifestFields(manifest)) {
     // Collect text from source (static value for text; placeholder string for dynamic text)
     if (field.type === 'text') {
       if (field.source.mode === 'static') {

--- a/packages/core/src/utils/manifestFields.ts
+++ b/packages/core/src/utils/manifestFields.ts
@@ -1,0 +1,23 @@
+import type { FieldDefinition, TemplateManifest } from '@template-goblin/types'
+
+/**
+ * Body + header/footer band fields, flattened.
+ *
+ * Band fields (#61) render through the same `renderField` and read the
+ * same `data.texts` / `data.images` / `data.tables` buckets as body
+ * fields — so EVERY pass that walks the manifest's fields (preflight,
+ * `validateData`, archive asset loading, font subsetting, referenced-
+ * asset collection) must walk all three pools. Walking only
+ * `manifest.fields` silently skips band content: required band fields
+ * go unvalidated, band image assets never load, band glyphs go
+ * unsubsetted.
+ */
+export function allManifestFields(
+  manifest: Pick<TemplateManifest, 'fields' | 'header' | 'footer'>,
+): FieldDefinition[] {
+  return [
+    ...manifest.fields,
+    ...(manifest.header?.fields ?? []),
+    ...(manifest.footer?.fields ?? []),
+  ]
+}

--- a/packages/core/src/validate.ts
+++ b/packages/core/src/validate.ts
@@ -8,6 +8,7 @@ import type {
   ValidationResult,
 } from '@template-goblin/types'
 import { isValidHyperlinkUrl } from '@template-goblin/types'
+import { allManifestFields } from './utils/manifestFields.js'
 
 /** Maximum allowed text length to prevent memory exhaustion */
 const MAX_TEXT_LENGTH = 100_000
@@ -224,7 +225,9 @@ export function validateData(template: LoadedTemplate, data: InputJSON): Validat
 
   const errors: ValidationError[] = []
 
-  for (const field of template.manifest.fields) {
+  // #61 — band fields read the same data buckets; a required header
+  // field must fail validation exactly like a required body field.
+  for (const field of allManifestFields(template.manifest)) {
     errors.push(...validateField(field, data))
     errors.push(...validateHyperlink(field, data))
   }

--- a/packages/core/src/validateManifest.ts
+++ b/packages/core/src/validateManifest.ts
@@ -268,7 +268,9 @@ function validatePageDimensions(manifest: TemplateManifest): void {
   }
   checkDim(manifest.meta.width, 'meta.width')
   checkDim(manifest.meta.height, 'meta.height')
-  for (const page of manifest.pages) {
+  // `pages` is optional for legacy single-page templates (see
+  // file/read.ts + generate.ts's no-pages branch) — don't crash on it.
+  for (const page of manifest.pages ?? []) {
     // Per-page width / height are optional; when present they must be valid.
     if (page.width !== undefined) checkDim(page.width, `pages[${page.id}].width`)
     if (page.height !== undefined) checkDim(page.height, `pages[${page.id}].height`)

--- a/packages/core/tests/qaRegressions.test.ts
+++ b/packages/core/tests/qaRegressions.test.ts
@@ -47,7 +47,10 @@ const BAND_STYLE = {
   paddingRight: 8,
 }
 
-function loadedFrom(manifest: TemplateManifest, assets: Partial<LoadedTemplate> = {}): LoadedTemplate {
+function loadedFrom(
+  manifest: TemplateManifest,
+  assets: Partial<LoadedTemplate> = {},
+): LoadedTemplate {
   return {
     manifest,
     backgroundImage: null,

--- a/packages/core/tests/qaRegressions.test.ts
+++ b/packages/core/tests/qaRegressions.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Master-QA regression suite — pins the fixes from the 2026-06 QA sweep:
+ *
+ *  1. `doc.addPage({ size })` must carry `margin: 0` — PDFKit's `addPage`
+ *     REPLACES the constructor options, so pages after the first got 72pt
+ *     default margins: content in the bottom strip triggered phantom
+ *     auto-pagination and split clip q/Q pairs across pages.
+ *  2. Band fields (#61) must be visible to validateData / preflight /
+ *     loadTemplate — they render through the same `renderField` and data
+ *     buckets as body fields.
+ *  3. Per-page backgrounds must round-trip save → load (the writer used a
+ *     synthetic `page-<index>.png` name while the loader resolves via
+ *     `page.backgroundFilename`).
+ *  4. `generateBatchPDF` must settle even when a worker dies without
+ *     replying (only `exit` fires for an OS-killed child).
+ *  5. Fields rendered after a multiPage table must land on their own page,
+ *     not the table's last continuation page.
+ *  6. `validateManifest` must tolerate legacy manifests without `pages`.
+ */
+import { mkdirSync, rmSync, existsSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { randomUUID } from 'node:crypto'
+import type { LoadedTemplate, TemplateAssets, TemplateManifest } from '@template-goblin/types'
+import { generatePDF } from '../src/generate.js'
+import { generateBatchPDF } from '../src/batch.js'
+import { validateData } from '../src/validate.js'
+import { validateManifest } from '../src/validateManifest.js'
+import { saveTemplate } from '../src/file/write.js'
+import { loadTemplate } from '../src/load.js'
+import { parsePdfGeometry, pageText } from './helpers/pdfGeometry.js'
+import { dynText, dynTable, makeManifest, staticImage } from './helpers/fixtures.js'
+
+// 1×1 red PNG — a real decodable image for static-asset checks.
+const TINY_PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+  'base64',
+)
+
+const BAND_STYLE = {
+  height: 50,
+  backgroundColor: null,
+  divider: null,
+  paddingTop: 4,
+  paddingBottom: 4,
+  paddingLeft: 8,
+  paddingRight: 8,
+}
+
+function loadedFrom(manifest: TemplateManifest, assets: Partial<LoadedTemplate> = {}): LoadedTemplate {
+  return {
+    manifest,
+    backgroundImage: null,
+    pageBackgrounds: new Map(),
+    fonts: new Map(),
+    placeholders: new Map(),
+    staticImages: new Map(),
+    ...assets,
+  }
+}
+
+function twoPages() {
+  return [
+    {
+      id: 'p0',
+      index: 0,
+      backgroundType: 'none' as const,
+      backgroundColor: null,
+      backgroundFilename: null,
+    },
+    {
+      id: 'p1',
+      index: 1,
+      backgroundType: 'none' as const,
+      backgroundColor: null,
+      backgroundFilename: null,
+    },
+  ]
+}
+
+let tmpDir: string
+beforeAll(() => {
+  tmpDir = join(tmpdir(), `tgbl-qa-${randomUUID()}`)
+  mkdirSync(tmpDir, { recursive: true })
+})
+afterAll(() => {
+  if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true, force: true })
+})
+
+describe('addPage margins (phantom-page regression)', () => {
+  it('content in the bottom 72pt of page 2 stays on page 2', async () => {
+    const manifest = makeManifest({
+      pages: twoPages(),
+      fields: [
+        { ...dynText('t0', 'a', false), pageId: 'p0', y: 10 },
+        // Inside the bottom 72pt of an 842pt page — pre-fix this
+        // auto-paginated onto a phantom page 3.
+        { ...dynText('t1', 'b', false), pageId: 'p1', y: 800, height: 30 },
+      ],
+    })
+    const pdf = await generatePDF(loadedFrom(manifest), {
+      texts: { a: 'top text', b: 'bottom text' },
+      images: {},
+      tables: {},
+    })
+    const pages = await parsePdfGeometry(pdf)
+    expect(pages).toHaveLength(2)
+    expect(pageText(pages[1]!)).toContain('bottom text')
+  })
+
+  it('a multiPage table paginates by full page height (no 72pt dead strip)', async () => {
+    const table = dynTable('tbl1', 'items', true)
+    table.style.multiPage = true
+    table.style.maxRows = 100
+    table.pageId = 'p0'
+    table.y = 700
+    table.height = 120
+    const manifest = makeManifest({
+      pages: [twoPages()[0]!],
+      fields: [table],
+    })
+    const rows = Array.from({ length: 20 }, (_, i) => ({ col: `row-${i}` }))
+    const pdf = await generatePDF(loadedFrom(manifest), {
+      texts: {},
+      images: {},
+      tables: { items: rows },
+    })
+    const pages = await parsePdfGeometry(pdf)
+    // Every row present exactly once, regardless of page distribution.
+    const all = pages.map((p) => pageText(p)).join('\n')
+    for (let i = 0; i < 20; i++) {
+      expect(all).toContain(`row-${i}`)
+    }
+    // And the continuation pages really were used (the table overflowed).
+    expect(pages.length).toBeGreaterThan(1)
+  })
+})
+
+describe('band fields are first-class in validate / preflight / load (#61)', () => {
+  function manifestWithHeaderField(field: TemplateManifest['fields'][number]): TemplateManifest {
+    // Body field placed BELOW the band zone — validateManifest enforces
+    // body-outside-band.
+    const manifest = makeManifest({ fields: [{ ...dynText('body', 'body_key', false), y: 100 }] })
+    manifest.header = { enabled: true, style: BAND_STYLE, fields: [field] }
+    return manifest
+  }
+
+  it('a required header text field missing from the data fails validateData', () => {
+    const manifest = manifestWithHeaderField(dynText('h1', 'title', true))
+    const result = validateData(loadedFrom(manifest), { texts: {}, images: {}, tables: {} })
+    expect(result.valid).toBe(false)
+    expect(result.errors.some((e) => e.field === 'title')).toBe(true)
+  })
+
+  it('a static image in the header band loads from the archive and renders', async () => {
+    const manifest = manifestWithHeaderField(staticImage('h-logo', 'logo.png'))
+    const assets: TemplateAssets = {
+      backgroundImage: null,
+      pageBackgrounds: new Map(),
+      fonts: new Map(),
+      placeholders: new Map(),
+      staticImages: new Map([['logo.png', TINY_PNG]]),
+    }
+    const path = join(tmpDir, 'band-logo.tgbl')
+    await saveTemplate(manifest, assets, path)
+
+    const loaded = await loadTemplate(path)
+    // Pre-fix: loadTemplate skipped band fields → staticImages stayed empty
+    // and the header logo rendered blank (or a re-save dropped the bytes).
+    expect(loaded.staticImages.get('logo.png')).toEqual(TINY_PNG)
+
+    // And the full render passes preflight + draws without throwing.
+    const pdf = await generatePDF(loaded, { texts: {}, images: {}, tables: {} })
+    expect(pdf.length).toBeGreaterThan(0)
+  })
+})
+
+describe('per-page background filename round-trip', () => {
+  it('writes backgrounds under page.backgroundFilename so loadTemplate finds them', async () => {
+    const manifest = makeManifest({
+      pages: [
+        {
+          id: 'page-abc',
+          index: 0,
+          backgroundType: 'image' as const,
+          backgroundColor: null,
+          backgroundFilename: 'backgrounds/page-abc.png',
+        },
+      ],
+      fields: [],
+    })
+    const assets: TemplateAssets = {
+      backgroundImage: null,
+      pageBackgrounds: new Map([['page-abc', TINY_PNG]]),
+      fonts: new Map(),
+      placeholders: new Map(),
+      staticImages: new Map(),
+    }
+    const path = join(tmpDir, 'bg-roundtrip.tgbl')
+    await saveTemplate(manifest, assets, path)
+
+    const loaded = await loadTemplate(path)
+    expect(loaded.pageBackgrounds.get('page-abc')).toEqual(TINY_PNG)
+  })
+})
+
+describe('generateBatchPDF worker death', () => {
+  it('settles with a failure result instead of hanging when the worker exits silently', async () => {
+    const deadWorker = join(tmpDir, 'dead-worker.cjs')
+    writeFileSync(deadWorker, 'process.exit(3)\n')
+
+    const manifest = makeManifest({ fields: [dynText('t', 'a', false)] })
+    const input = { texts: {}, images: {}, tables: {} }
+    const results = await Promise.race([
+      generateBatchPDF(loadedFrom(manifest), [input, input], {
+        workerPath: deadWorker,
+        concurrency: 2,
+      }),
+      new Promise<'timeout'>((r) => setTimeout(() => r('timeout'), 15_000)),
+    ])
+
+    expect(results).not.toBe('timeout')
+    const batch = results as Awaited<ReturnType<typeof generateBatchPDF>>
+    expect(batch).toHaveLength(2)
+    for (const r of batch) {
+      expect(r.success).toBe(false)
+      expect(r.error).toContain('exited before replying')
+    }
+  }, 20_000)
+})
+
+describe('fields after a multiPage table render on their own page', () => {
+  it('a text field on page 1 stays there while the table overflows', async () => {
+    const table = dynTable('tbl1', 'items', true)
+    table.style.multiPage = true
+    table.style.maxRows = 100
+    table.pageId = 'p0'
+    table.y = 600
+    table.height = 200
+    table.zIndex = 0
+    const marker = { ...dynText('after', 'marker', false), pageId: 'p0', y: 40, zIndex: 5 }
+    const manifest = makeManifest({ pages: twoPages(), fields: [table, marker] })
+
+    const rows = Array.from({ length: 30 }, (_, i) => ({ col: `r${i}` }))
+    const pdf = await generatePDF(loadedFrom(manifest), {
+      texts: { marker: 'MARKER-TEXT' },
+      images: {},
+      tables: { items: rows },
+    })
+    const pages = await parsePdfGeometry(pdf)
+    expect(pages.length).toBeGreaterThan(2) // the table really overflowed
+    // Pre-fix the marker rendered on the table's LAST continuation page.
+    expect(pageText(pages[0]!)).toContain('MARKER-TEXT')
+    expect(pageText(pages[pages.length - 1]!)).not.toContain('MARKER-TEXT')
+  })
+})
+
+describe('legacy manifests without pages', () => {
+  it('validateManifest does not crash on a manifest with no pages array', () => {
+    const manifest = makeManifest({ fields: [dynText('t', 'a', false)] })
+    delete (manifest as Partial<TemplateManifest>).pages
+    expect(() => validateManifest(manifest)).not.toThrow(TypeError)
+  })
+})

--- a/packages/types/src/errors.ts
+++ b/packages/types/src/errors.ts
@@ -20,6 +20,7 @@ export type ErrorCode =
   | 'INVALID_TABLE_ROW'
   | 'FIELD_OVERLAPS_BAND'
   | 'PAGE_NUMBER_PLACEMENT_INVALID'
+  | 'INVALID_ARGUMENT'
 
 /** Base error class for all TemplateGoblin errors */
 export class TemplateGoblinError extends Error {

--- a/packages/ui/src/components/Canvas/__tests__/textWrapParity.test.ts
+++ b/packages/ui/src/components/Canvas/__tests__/textWrapParity.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Canvas ⇄ PDF text-wrap parity (#91).
+ *
+ * `wrapToLines` must mirror `core/src/utils/measure.ts#wrapText`
+ * line-for-line: paragraphs split on `\n` first, over-wide words break
+ * mid-word. These cases are the exact divergences the QA sweep found —
+ * the old canvas wrapper collapsed `\n` into spaces and admitted
+ * over-wide words whole.
+ *
+ * The fake context measures 10px per character, making expected line
+ * splits exact and font-independent (the algorithm under test is pure
+ * given a measurer).
+ */
+import { describe, it, expect } from 'vitest'
+import { wrapToLines } from '../textMeasure.js'
+
+const ctx = {
+  measureText: (s: string) => ({ width: s.length * 10 }) as TextMetrics,
+}
+
+describe('wrapToLines mirrors core wrapText', () => {
+  it('splits paragraphs on \\n before word-wrapping', () => {
+    // 200px = 20 chars per line; both paragraphs fit on one line each.
+    expect(wrapToLines(ctx, 'Line one\nLine two', 200)).toEqual(['Line one', 'Line two'])
+  })
+
+  it('preserves empty lines from consecutive newlines', () => {
+    expect(wrapToLines(ctx, 'a\n\nb', 200)).toEqual(['a', '', 'b'])
+  })
+
+  it('breaks a single over-wide word mid-word (URLs)', () => {
+    // 50px = 5 chars per fragment.
+    expect(wrapToLines(ctx, 'abcdefghij', 50)).toEqual(['abcde', 'fghij'])
+  })
+
+  it('breaks an over-wide word that follows normal words', () => {
+    // 50px = 5 chars: "ab cd" fits one line, then the long word fragments.
+    expect(wrapToLines(ctx, 'ab cd abcdefghij', 50)).toEqual(['ab cd', 'abcde', 'fghij'])
+  })
+
+  it('wraps ordinary text on word boundaries', () => {
+    // 70px = 7 chars.
+    expect(wrapToLines(ctx, 'one two three', 70)).toEqual(['one two', 'three'])
+  })
+
+  it('empty text yields a single empty line', () => {
+    expect(wrapToLines(ctx, '', 100)).toEqual([''])
+  })
+})

--- a/packages/ui/src/components/Canvas/bandGeometry.ts
+++ b/packages/ui/src/components/Canvas/bandGeometry.ts
@@ -1,0 +1,49 @@
+import { getPageSize } from '@template-goblin/types'
+import type { PageBand } from '@template-goblin/types'
+import { useTemplateStore } from '../../store/templateStore.js'
+import { useUiStore } from '../../store/uiStore.js'
+
+/**
+ * Band geometry for the page the user is VIEWING — the one truth the
+ * three gesture-time call sites (drag/resize commit, draw-to-create zone
+ * detection, smart-guides clamp) must share with the render side
+ * (`deriveCanvasFields` / `useBandVisuals`).
+ *
+ * Two render-side rules these call sites used to ignore:
+ *  1. Pages can carry their OWN width/height (`getPageSize`); using
+ *     `meta.height` put the footer's top edge ~`meta.height - pageHeight`
+ *     points off on custom-height pages, so footer fields jumped on
+ *     every drop and bottom-of-page draws mis-routed.
+ *  2. A band with `applyToFirstPage: false` does not render on page
+ *     index 0 — its zone there is ordinary body space.
+ */
+export interface CurrentPageBandContext {
+  /** The viewed page's height in pt (per-page override or meta fallback). */
+  pageHeight: number
+  /** The header band — `undefined` when absent, disabled, or not rendered
+   *  on this page (`applyToFirstPage` rule). */
+  header: PageBand | undefined
+  /** Same for the footer. */
+  footer: PageBand | undefined
+}
+
+/**
+ * Imperative read of both stores — for Fabric event handlers that run
+ * outside React's render cycle.
+ */
+export function currentPageBandContext(): CurrentPageBandContext {
+  const store = useTemplateStore.getState()
+  const pageId = useUiStore.getState().currentPageId
+  const page = store.pages.find((p) => p.id === pageId) ?? store.pages.find((p) => p.index === 0)
+  const pageHeight = getPageSize(page ?? null, store.meta).height
+  const pageIndex = page?.index ?? 0
+
+  const rendersHere = (band: PageBand | undefined): band is PageBand =>
+    !!band && band.enabled && !(pageIndex === 0 && band.applyToFirstPage === false)
+
+  return {
+    pageHeight,
+    header: rendersHere(store.header) ? store.header : undefined,
+    footer: rendersHere(store.footer) ? store.footer : undefined,
+  }
+}

--- a/packages/ui/src/components/Canvas/smartGuides/wireSmartGuides.ts
+++ b/packages/ui/src/components/Canvas/smartGuides/wireSmartGuides.ts
@@ -27,6 +27,7 @@ import type { Canvas as FabricCanvas, FabricObject } from 'fabric'
 import { getPageSize } from '@template-goblin/types'
 import { useTemplateStore } from '../../../store/templateStore.js'
 import { useUiStore } from '../../../store/uiStore.js'
+import { currentPageBandContext } from '../bandGeometry.js'
 import { clampToPage } from '../usePageBoundsEnforcement.js'
 import { buildCandidates, type Rect } from './candidates.js'
 import { computeSnap } from './snap.js'
@@ -47,12 +48,15 @@ function readPageMeta(): PageMeta {
   return getPageSize(page, store.meta)
 }
 
-/** Read the current header/footer band heights from the store (#61). */
+/** Read the band heights that apply on the VIEWED page (#61). A band
+ *  with applyToFirstPage=false reserves no space on page 0 — clamping by
+ *  its height there shoved body fields out of a strip where no band
+ *  renders. */
 function readBandHeights(): { header: number; footer: number } {
-  const s = useTemplateStore.getState()
+  const ctx = currentPageBandContext()
   return {
-    header: s.header?.enabled ? s.header.style.height : 0,
-    footer: s.footer?.enabled ? s.footer.style.height : 0,
+    header: ctx.header?.style.height ?? 0,
+    footer: ctx.footer?.style.height ?? 0,
   }
 }
 

--- a/packages/ui/src/components/Canvas/textMeasure.ts
+++ b/packages/ui/src/components/Canvas/textMeasure.ts
@@ -131,21 +131,69 @@ function getMeasureCtx(): CanvasRenderingContext2D | null {
   return _measureCtx
 }
 
-function wrapToLines(ctx: CanvasRenderingContext2D, text: string, maxWidth: number): string[] {
+/**
+ * Word-wrap mirroring `core/src/utils/measure.ts#wrapText` exactly
+ * (#91 WYSIWYG): paragraphs split on `\n` FIRST (the old version
+ * collapsed newlines into spaces, so `"a\nb"` previewed as one wrapped
+ * paragraph but printed as two lines), and a single word wider than the
+ * box breaks mid-word instead of being admitted whole and char-truncated.
+ */
+export function wrapToLines(
+  ctx: Pick<CanvasRenderingContext2D, 'measureText'>,
+  text: string,
+  maxWidth: number,
+): string[] {
   if (maxWidth <= 0) return [text]
-  const words = text.split(/\s+/).filter(Boolean)
-  if (words.length === 0) return ['']
+  if (!text) return ['']
   const lines: string[] = []
+  for (const paragraph of text.split('\n')) {
+    if (paragraph === '') {
+      lines.push('')
+      continue
+    }
+    const words = paragraph.split(/\s+/).filter(Boolean)
+    let current = ''
+    for (const word of words) {
+      const test = current ? `${current} ${word}` : word
+      if (ctx.measureText(test).width <= maxWidth) {
+        current = test
+      } else if (!current) {
+        const broken = breakWord(ctx, word, maxWidth)
+        lines.push(...broken.slice(0, -1))
+        current = broken[broken.length - 1] ?? ''
+      } else {
+        lines.push(current)
+        if (ctx.measureText(word).width <= maxWidth) {
+          current = word
+        } else {
+          const broken = breakWord(ctx, word, maxWidth)
+          lines.push(...broken.slice(0, -1))
+          current = broken[broken.length - 1] ?? ''
+        }
+      }
+    }
+    if (current) lines.push(current)
+  }
+  return lines.length > 0 ? lines : ['']
+}
+
+/** Mirror of `core/src/utils/measure.ts#breakWord` — split an over-wide
+ *  word into fragments that each fit `maxWidth`. */
+function breakWord(
+  ctx: Pick<CanvasRenderingContext2D, 'measureText'>,
+  word: string,
+  maxWidth: number,
+): string[] {
+  const parts: string[] = []
   let current = ''
-  for (const w of words) {
-    const test = current ? `${current} ${w}` : w
-    if (ctx.measureText(test).width <= maxWidth || current === '') {
-      current = test
+  for (const char of word) {
+    if (ctx.measureText(current + char).width > maxWidth && current) {
+      parts.push(current)
+      current = char
     } else {
-      lines.push(current)
-      current = w
+      current += char
     }
   }
-  if (current) lines.push(current)
-  return lines
+  if (current) parts.push(current)
+  return parts
 }

--- a/packages/ui/src/components/Canvas/useFieldCreationPopup.ts
+++ b/packages/ui/src/components/Canvas/useFieldCreationPopup.ts
@@ -8,6 +8,7 @@ import { useTemplateStore } from '../../store/templateStore.js'
 import { useUiStore } from '../../store/uiStore.js'
 import { createDefaultField } from '../../utils/defaults.js'
 import { autoShrinkStaticField } from '../../utils/autoShrinkDispatch.js'
+import { currentPageBandContext } from './bandGeometry.js'
 import type { FieldDefinition, PageBand } from '@template-goblin/types'
 import type { FieldCreationDraft, SourceInputs } from './FieldCreationPopup.js'
 
@@ -93,19 +94,24 @@ export function useFieldCreationPopup() {
       // path. Band fields' x/y are stored band-local so the renderer can
       // re-add the band offset on every paint.
       const store = useTemplateStore.getState()
+      // Zone-detect against the VIEWED page: per-page heights shift the
+      // footer zone, and a band with applyToFirstPage=false doesn't render
+      // on page 0 — drawing in its strip there must create a BODY field
+      // (it previously vanished into a band that never renders here).
+      const pageCtx = currentPageBandContext()
       const zone = detectDrawZone(
         pendingDraft.y,
         pendingDraft.height,
-        store.header,
-        store.footer,
-        store.meta.height,
+        pageCtx.header,
+        pageCtx.footer,
+        pageCtx.pageHeight,
       )
 
       if (zone !== 'body') {
-        const band = zone === 'header' ? store.header : store.footer
+        const band = zone === 'header' ? pageCtx.header : pageCtx.footer
         // `band` is non-null here because `zone !== 'body'` only returns
         // when the corresponding band exists with height > 0.
-        const bandTop = zone === 'header' ? 0 : store.meta.height - (band?.style.height ?? 0)
+        const bandTop = zone === 'header' ? 0 : pageCtx.pageHeight - (band?.style.height ?? 0)
         const bandLocalX = pendingDraft.x - (band?.style.paddingLeft ?? 0)
         const bandLocalY = pendingDraft.y - bandTop - (band?.style.paddingTop ?? 0)
         const bandField: FieldDefinition = {

--- a/packages/ui/src/components/Canvas/wireDragResizeEvents.ts
+++ b/packages/ui/src/components/Canvas/wireDragResizeEvents.ts
@@ -11,53 +11,97 @@
  * authored `fontSize` and overflow is handled by the field's
  * `overflowMode` (truncate / dynamic_font), not by mutating `fontSize`.
  */
-import type { Canvas as FabricCanvas, Group as FabricGroup } from 'fabric'
+import type { Canvas as FabricCanvas, FabricObject, Group as FabricGroup } from 'fabric'
+import { util as fabricUtil } from 'fabric'
 import { useTemplateStore } from '../../store/templateStore.js'
 import { useUiStore } from '../../store/uiStore.js'
 import { groupToFieldPatch, snap } from './fabricUtils.js'
+import { currentPageBandContext } from './bandGeometry.js'
+import { normaliseAngle } from './rotationGeometry.js'
+
+type FieldPatch = { x: number; y: number; width: number; height: number; rotation: number }
+
+/** Commit one field group's geometry to the store, routing band fields
+ *  back to band-local coordinates. */
+function commitFieldPatch(g: FabricObject, patch: FieldPatch): void {
+  if (!g.__fieldId) return
+  const store = useTemplateStore.getState()
+
+  // #61 — band fields commit to the band's own `fields` array, with
+  // coordinates translated back to band-local before storing. The
+  // `useBandVisuals` renderer adds bandTop + paddingTop on every paint,
+  // so we subtract them here to keep the round-trip lossless.
+  if (g.__isBandField && g.__bandKind) {
+    const kind = g.__bandKind
+    const band = kind === 'header' ? store.header : store.footer
+    if (!band) return
+    // The footer's top edge depends on the VIEWED page's height (pages
+    // can override meta dims) — `meta.height` shifted footer fields by
+    // the difference on every drop on custom-height pages.
+    const { pageHeight } = currentPageBandContext()
+    const bandTop = kind === 'header' ? 0 : pageHeight - band.style.height
+    const updater = kind === 'header' ? store.updateHeaderField : store.updateFooterField
+    updater(g.__fieldId, {
+      ...patch,
+      x: patch.x - band.style.paddingLeft,
+      y: patch.y - bandTop - band.style.paddingTop,
+    })
+    return
+  }
+
+  // ONE updateField call per gesture — this used to be moveField +
+  // resizeField + updateField(rotation), i.e. three history snapshots,
+  // so a single Ctrl+Z only un-rotated and the user had to press undo
+  // three times to fully revert one drag.
+  store.updateField(g.__fieldId, patch)
+}
+
+/**
+ * Absolute (scene-space) geometry of a member INSIDE an ActiveSelection.
+ * Members carry selection-relative left/top, so we decompose the full
+ * object→scene transform instead: its translation is the member's
+ * CENTRE, which matches the schema's centre-pivot rotation model — the
+ * unrotated top-left is just centre minus half the (scaled) size.
+ */
+function memberPatch(member: FabricObject): FieldPatch {
+  const dec = fabricUtil.qrDecompose(member.calcTransformMatrix())
+  const baseW = member.__fieldWidth ?? member.width ?? 0
+  const baseH = member.__fieldHeight ?? member.height ?? 0
+  const width = Math.max(20, baseW * dec.scaleX)
+  const height = Math.max(20, baseH * dec.scaleY)
+  return {
+    x: dec.translateX - width / 2,
+    y: dec.translateY - height / 2,
+    width,
+    height,
+    rotation: normaliseAngle(dec.angle),
+  }
+}
 
 /** Wire drag/resize commit + grid-snap on the given Fabric canvas. */
 export function wireDragResizeEvents(fc: FabricCanvas) {
   fc.on('object:modified', (opt) => {
     const g = opt.target
-    if (!g?.__fieldId) return
-    const { showGrid: sg, gridSize: gs } = useUiStore.getState()
-    const patch = groupToFieldPatch(g as FabricGroup, gs, sg)
-    const store = useTemplateStore.getState()
+    if (!g) return
 
-    // #61 — band fields commit to the band's own `fields` array, with
-    // coordinates translated back to band-local before storing. The
-    // `useBandVisuals` renderer adds bandTop + paddingTop on every paint,
-    // so we subtract them here to keep the round-trip lossless.
-    if (g.__isBandField && g.__bandKind) {
-      const kind = g.__bandKind
-      const band = kind === 'header' ? store.header : store.footer
-      if (!band) return
-      const bandTop = kind === 'header' ? 0 : store.meta.height - band.style.height
-      const localX = patch.x - band.style.paddingLeft
-      const localY = patch.y - bandTop - band.style.paddingTop
-      const updater = kind === 'header' ? store.updateHeaderField : store.updateFooterField
-      updater(g.__fieldId, {
-        x: localX,
-        y: localY,
-        width: patch.width,
-        height: patch.height,
-        rotation: patch.rotation,
-      })
+    // Multi-selection: Fabric fires ONE `object:modified` whose target is
+    // the ActiveSelection (no `__fieldId`); the members never fire their
+    // own. Pre-fix the whole gesture was silently dropped — the canvas
+    // showed the move, the store kept the old positions, and the fields
+    // snapped back on the next reconcile.
+    if (!g.__fieldId) {
+      const members = (g as FabricGroup).getObjects?.()
+      if (!members?.length) return
+      for (const member of members) {
+        if (!member.__fieldId) continue
+        commitFieldPatch(member, memberPatch(member))
+      }
       return
     }
 
-    // ONE updateField call per gesture — this used to be moveField +
-    // resizeField + updateField(rotation), i.e. three history snapshots,
-    // so a single Ctrl+Z only un-rotated and the user had to press undo
-    // three times to fully revert one drag.
-    store.updateField(g.__fieldId, {
-      x: patch.x,
-      y: patch.y,
-      width: patch.width,
-      height: patch.height,
-      rotation: patch.rotation,
-    })
+    const { showGrid: sg, gridSize: gs } = useUiStore.getState()
+    const patch = groupToFieldPatch(g as FabricGroup, gs, sg)
+    commitFieldPatch(g, { ...patch, rotation: normaliseAngle(patch.rotation) })
   })
 
   fc.on('object:moving', (opt) => {

--- a/packages/ui/src/components/LeftPanel/PropertiesPanel.tsx
+++ b/packages/ui/src/components/LeftPanel/PropertiesPanel.tsx
@@ -53,9 +53,20 @@ export function PropertiesPanel() {
 
   return (
     <>
-      {selectedField.type === 'text' && <TextFieldProps field={selectedField} />}
-      {selectedField.type === 'image' && <ImageFieldProps field={selectedField} />}
-      {selectedField.type === 'table' && <LoopFieldProps field={selectedField} />}
+      {/* key={id} — the props components hold per-field draft state (e.g.
+          HyperlinkSection's URL/key inputs, seeded once per mount). Without
+          remounting on selection change, switching between two same-type
+          fields showed (and on blur, COMMITTED) field A's drafts onto
+          field B — including silently deleting B's link when A had none. */}
+      {selectedField.type === 'text' && (
+        <TextFieldProps key={selectedField.id} field={selectedField} />
+      )}
+      {selectedField.type === 'image' && (
+        <ImageFieldProps key={selectedField.id} field={selectedField} />
+      )}
+      {selectedField.type === 'table' && (
+        <LoopFieldProps key={selectedField.id} field={selectedField} />
+      )}
       {/* #172 — field-type-agnostic rotation control. Lives in PropertiesPanel
           rather than each *FieldProps.tsx so a single section serves all three
           field types without bloating any one file past the 300-LOC cap. */}

--- a/packages/ui/src/components/Preview/PreviewImageUploadRow.tsx
+++ b/packages/ui/src/components/Preview/PreviewImageUploadRow.tsx
@@ -87,7 +87,7 @@ export function PreviewImageUploadRow({
       <input
         ref={inputRef}
         type="file"
-        accept="image/png,image/jpeg,image/webp"
+        accept="image/png,image/jpeg"
         hidden
         data-testid={`preview-upload-input-${jsonKey}`}
         onChange={(e) => {

--- a/packages/ui/src/components/Preview/__tests__/previewDialogHelpers.test.ts
+++ b/packages/ui/src/components/Preview/__tests__/previewDialogHelpers.test.ts
@@ -131,7 +131,9 @@ describe('validateUpload', () => {
   })
 
   it('accepts WEBP under the cap', () => {
-    expect(validateUpload(fakeFile('image/webp', 1024))).toBeNull()
+    // WEBP is NOT accepted — the PDF engine renders only PNG/JPEG, so
+    // inviting it here just deferred the failure to Render.
+    expect(validateUpload(fakeFile('image/webp', 1024))).not.toBeNull()
   })
 
   it('rejects GIF (not in the allow-list per the issue spec)', () => {

--- a/packages/ui/src/components/Preview/previewDialogHelpers.ts
+++ b/packages/ui/src/components/Preview/previewDialogHelpers.ts
@@ -9,7 +9,9 @@ import type { FieldSource, ImageSourceValue } from '@template-goblin/types'
 export const MAX_UPLOAD_BYTES = 10 * 1024 * 1024
 
 /** MIME types accepted by the image upload picker. */
-export const ALLOWED_UPLOAD_MIME = new Set(['image/png', 'image/jpeg', 'image/webp'])
+// PNG + JPEG only — the PDF engine's format sniff rejects everything
+// else, so inviting WEBP here just deferred the failure to Render.
+export const ALLOWED_UPLOAD_MIME = new Set(['image/png', 'image/jpeg'])
 
 interface ParseOk {
   ok: true

--- a/packages/ui/src/components/RightPanel/ImageFieldProps.tsx
+++ b/packages/ui/src/components/RightPanel/ImageFieldProps.tsx
@@ -3,7 +3,8 @@ import type { FieldDefinition, ImageField, ImageFieldStyle } from '@template-gob
 import { isSafeKey } from '@template-goblin/types'
 import { useTemplateStore } from '../../store/templateStore.js'
 import { autoShrinkStaticField } from '../../utils/autoShrinkDispatch.js'
-import { bufferToDataUrl } from '../../utils/previewInputs.js'
+import { bufferToDataUrl, sniffImageMime } from '../../utils/previewInputs.js'
+import { useDialogs } from '../Dialogs/index.js'
 import { SourceModeToggle } from './SourceModeToggle.js'
 import { HyperlinkSection } from './HyperlinkSection.js'
 import { ColorPickerPopover } from '../ColorPickerPopover.js'
@@ -17,6 +18,31 @@ export function ImageFieldProps({ field }: Props) {
   const updateFieldStyle = useTemplateStore((s) => s.updateFieldStyle)
   const addPlaceholder = useTemplateStore((s) => s.addPlaceholder)
   const addStaticImage = useTemplateStore((s) => s.addStaticImage)
+  const { alert: showAlert } = useDialogs()
+
+  /** PNG/JPEG + 10MB gate shared by both upload paths — anything else
+   *  sailed through here and failed later at Render/Save with a format
+   *  error far from the action that caused it. */
+  async function validateImageFile(buffer: ArrayBuffer, filename: string): Promise<boolean> {
+    if (buffer.byteLength > 10 * 1024 * 1024) {
+      await showAlert({
+        title: 'Image too large',
+        message: `${filename} is over 10 MB. Compress or resize it and upload again.`,
+        variant: 'danger',
+      })
+      return false
+    }
+    const mime = sniffImageMime(new Uint8Array(buffer))
+    if (mime !== 'image/png' && mime !== 'image/jpeg') {
+      await showAlert({
+        title: 'Unsupported image format',
+        message: `${filename} is not a PNG or JPEG. PDFs support only PNG and JPEG — convert it and upload again.`,
+        variant: 'danger',
+      })
+      return false
+    }
+    return true
+  }
   const groups = useTemplateStore((s) => s.groups)
   // Separate file inputs per mode so the static and dynamic buttons don't
   // share a hidden <input ref>.
@@ -82,8 +108,9 @@ export function ImageFieldProps({ field }: Props) {
     const file = e.target.files?.[0]
     if (!file) return
     const reader = new FileReader()
-    reader.onload = () => {
+    reader.onload = async () => {
       const buffer = reader.result as ArrayBuffer
+      if (!(await validateImageFile(buffer, file.name))) return
       const filename = `static-${field.id}-${file.name}`
       // The bytes MUST land in the static-image pool — the PDF renderer's
       // preflight resolves static fields strictly from `staticImages`
@@ -123,8 +150,9 @@ export function ImageFieldProps({ field }: Props) {
     if (!dynamicSource) return
 
     const reader = new FileReader()
-    reader.onload = () => {
+    reader.onload = async () => {
       const buffer = reader.result as ArrayBuffer
+      if (!(await validateImageFile(buffer, file.name))) return
       const filename = `placeholder-${field.id}-${file.name}`
       addPlaceholder(filename, buffer)
       updateField(field.id, {

--- a/packages/ui/src/components/Toolbar/FontManager.tsx
+++ b/packages/ui/src/components/Toolbar/FontManager.tsx
@@ -30,6 +30,26 @@ export function FontManager() {
           message: `Invalid font file: ${r.filename}. Please select a valid .ttf file.`,
           variant: 'danger',
         })
+      } else if (r.reason === 'duplicate') {
+        // Previously SILENT — re-uploading a same-named font did nothing
+        // and gave no hint why.
+        await showAlert({
+          title: 'Font already added',
+          message: `A font named ${r.filename} is already in this template. Remove it first to replace it.`,
+          variant: 'danger',
+        })
+      } else if (r.reason === 'extension') {
+        await showAlert({
+          title: 'Unsupported file type',
+          message: `${r.filename} is not a .ttf file. Only TrueType fonts (.ttf) are supported.`,
+          variant: 'danger',
+        })
+      } else {
+        await showAlert({
+          title: 'Could not read font',
+          message: `${r.filename} could not be read. Try the file again or re-export it.`,
+          variant: 'danger',
+        })
       }
     }
     e.target.value = ''

--- a/packages/ui/src/components/Toolbar/fontUpload.ts
+++ b/packages/ui/src/components/Toolbar/fontUpload.ts
@@ -96,7 +96,14 @@ export async function processFontFiles(files: File[] | FileList): Promise<FontUp
       continue
     }
 
-    if (buffer.byteLength >= 4) {
+    // Too short to even carry the magic bytes — definitely not a font.
+    // (Previously a 0–3-byte file SKIPPED the magic check and was added,
+    // then every render using it failed with FONT_LOAD_FAILED.)
+    if (buffer.byteLength < 4) {
+      results.push({ filename: file.name, ok: false, reason: 'magic' })
+      continue
+    }
+    {
       const view = new DataView(buffer)
       const magic = view.getUint32(0)
       if (!TTF_MAGIC_BYTES.has(magic)) {

--- a/packages/ui/src/store/__tests__/bandHistoryRouting.test.ts
+++ b/packages/ui/src/store/__tests__/bandHistoryRouting.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Band fields are first-class in every store mutation + undo/redo.
+ *
+ * The band pools (#61) were retrofitted onto only SOME field mutations:
+ * `removeFields` (the keyboard Delete path), `setFieldMode`, and
+ * `duplicateField` still assumed a single body pool, and history
+ * snapshots carried fields+groups only — so undo was blind to band
+ * edits, and hiding a band (which migrates its fields into the body)
+ * followed by Ctrl+Z permanently lost the fields from BOTH pools.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { FieldDefinition, ImageField, TextField } from '@template-goblin/types'
+
+const storage = new Map<string, string>()
+vi.stubGlobal('localStorage', {
+  getItem: (k: string) => storage.get(k) ?? null,
+  setItem: (k: string, v: string) => storage.set(k, v),
+  removeItem: (k: string) => storage.delete(k),
+  clear: () => storage.clear(),
+})
+vi.mock('../idbStorage', () => ({
+  idbGet: async (k: string) => storage.get(k),
+  idbSet: async (k: string, v: string) => {
+    storage.set(k, v)
+  },
+  idbDelete: async (k: string) => {
+    storage.delete(k)
+  },
+  migrateFromLocalStorage: async () => {},
+}))
+
+import { useTemplateStore } from '../templateStore'
+import { createDefaultField } from '../../utils/defaults'
+
+function makeText(id: string, jsonKey: string): FieldDefinition {
+  const field = createDefaultField('text', {
+    id,
+    pageId: null,
+    x: 10,
+    y: 10,
+    width: 100,
+    height: 30,
+    zIndex: 0,
+  })
+  ;(field as TextField).source = { mode: 'dynamic', jsonKey, required: true, placeholder: null }
+  return field
+}
+
+const PNG_BYTES = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]).buffer
+
+function store() {
+  return useTemplateStore.getState()
+}
+
+beforeEach(() => {
+  storage.clear()
+  store().reset()
+})
+
+describe('band routing parity', () => {
+  it('removeFields (keyboard Delete) actually removes a band field', () => {
+    store().setHeaderEnabled(true)
+    store().addHeaderField(makeText('h1', 'title'))
+    expect(store().header?.fields).toHaveLength(1)
+
+    store().removeFields(['h1'])
+    expect(store().header?.fields).toHaveLength(0)
+  })
+
+  it('removeFields removes a mixed body+band selection atomically', () => {
+    store().addField(makeText('b1', 'body_one'))
+    store().setHeaderEnabled(true)
+    store().addHeaderField(makeText('h1', 'title'))
+
+    store().removeFields(['b1', 'h1'])
+    expect(store().fields).toHaveLength(0)
+    expect(store().header?.fields).toHaveLength(0)
+  })
+
+  it('setFieldMode flips a band field (the toggle previously no-opd)', () => {
+    store().setHeaderEnabled(true)
+    store().addHeaderField(makeText('h1', 'title'))
+
+    store().setFieldMode('h1', 'static')
+    const flipped = store().header?.fields.find((f) => f.id === 'h1')
+    expect(flipped?.source.mode).toBe('static')
+
+    store().setFieldMode('h1', 'dynamic')
+    const back = store().header?.fields.find((f) => f.id === 'h1')
+    expect(back?.source.mode).toBe('dynamic')
+    // QA BUG-06 memo applies to band fields too — the jsonKey round-trips.
+    expect(back?.source.mode === 'dynamic' && back.source.jsonKey).toBe('title')
+  })
+
+  it('setFieldMode migrates image bytes for band image fields', () => {
+    store().setHeaderEnabled(true)
+    const img = createDefaultField('image', {
+      id: 'h-img',
+      pageId: null,
+      x: 0,
+      y: 0,
+      width: 50,
+      height: 30,
+      zIndex: 0,
+    }) as ImageField
+    img.source = {
+      mode: 'dynamic',
+      jsonKey: 'logo',
+      required: true,
+      placeholder: { filename: 'logo.png' },
+    }
+    store().addHeaderField(img)
+    store().addPlaceholder('logo.png', PNG_BYTES)
+
+    store().setFieldMode('h-img', 'static')
+    expect(store().staticImageBuffers.has('logo.png')).toBe(true)
+  })
+
+  it('duplicateField duplicates a band field into its own pool', () => {
+    store().setHeaderEnabled(true)
+    store().addHeaderField(makeText('h1', 'title'))
+
+    const copy = store().duplicateField('h1')
+    expect(copy).not.toBeNull()
+    expect(store().header?.fields).toHaveLength(2)
+    expect(store().fields).toHaveLength(0)
+  })
+})
+
+describe('band-aware undo/redo', () => {
+  it('hiding a band then Ctrl+Z restores the band fields (the data-loss case)', () => {
+    store().setHeaderEnabled(true)
+    store().addHeaderField(makeText('h1', 'title'))
+    expect(store().header?.fields).toHaveLength(1)
+
+    // Hide migrates h1 into the body pool and clears the band.
+    store().setHeaderEnabled(false)
+    expect(store().header?.fields).toHaveLength(0)
+    expect(store().fields.some((f) => f.id === 'h1')).toBe(true)
+
+    // Pre-fix: undo restored a pre-migration BODY array while the band was
+    // already empty — h1 vanished from both pools, unrecoverable.
+    store().undo()
+    expect(store().header?.fields.some((f) => f.id === 'h1')).toBe(true)
+    expect(store().fields.some((f) => f.id === 'h1')).toBe(false)
+
+    // And redo replays the hide-migration.
+    store().redo()
+    expect(store().header?.fields).toHaveLength(0)
+    expect(store().fields.some((f) => f.id === 'h1')).toBe(true)
+  })
+
+  it('undoing a band-field edit reverts the band, not the last body change', () => {
+    store().addField(makeText('b1', 'body_one'))
+    store().setHeaderEnabled(true)
+    store().addHeaderField(makeText('h1', 'title'))
+
+    store().updateField('h1', { label: 'renamed' })
+    expect(store().header?.fields[0]?.label).toBe('renamed')
+
+    store().undo()
+    expect(store().header?.fields[0]?.label).toBe('')
+    // The body field is untouched by that undo step.
+    expect(store().fields.some((f) => f.id === 'b1')).toBe(true)
+  })
+
+  it('deleting a band field is one undoable step', () => {
+    store().setHeaderEnabled(true)
+    store().addHeaderField(makeText('h1', 'title'))
+    store().removeField('h1')
+    expect(store().header?.fields).toHaveLength(0)
+
+    store().undo()
+    expect(store().header?.fields.some((f) => f.id === 'h1')).toBe(true)
+  })
+})

--- a/packages/ui/src/store/history.ts
+++ b/packages/ui/src/store/history.ts
@@ -1,0 +1,103 @@
+import type { FieldDefinition, GroupDefinition, PageBand } from '@template-goblin/types'
+
+/**
+ * Undo/redo history for the template store — extracted from
+ * `templateStore.ts` (Hard Rule #11) and extended to cover band fields.
+ *
+ * A snapshot is the full undoable document state: body fields, groups,
+ * AND the header/footer bands (#61). Pre-fix snapshots carried only
+ * fields+groups, which made undo blind to band edits — worse, hiding a
+ * band (which migrates its fields into the body pool) followed by
+ * Ctrl+Z restored a body array from BEFORE the migration while the band
+ * was already empty: the fields vanished from both pools with no
+ * recovery.
+ */
+export interface HistorySnapshot {
+  fields: FieldDefinition[]
+  groups: GroupDefinition[]
+  header: PageBand | undefined
+  footer: PageBand | undefined
+}
+
+/** The slice of the template store the history engine reads and writes. */
+export interface HistoryState {
+  fields: FieldDefinition[]
+  groups: GroupDefinition[]
+  header?: PageBand
+  footer?: PageBand
+  history: HistorySnapshot[]
+  historyIndex: number
+  maxHistory: number
+  canUndo: boolean
+  canRedo: boolean
+}
+
+type DocumentState = Pick<HistoryState, 'fields' | 'groups' | 'header' | 'footer'>
+
+export function createSnapshot(state: DocumentState): HistorySnapshot {
+  return {
+    fields: structuredClone(state.fields),
+    groups: structuredClone(state.groups),
+    header: state.header ? structuredClone(state.header) : undefined,
+    footer: state.footer ? structuredClone(state.footer) : undefined,
+  }
+}
+
+/**
+ * Append a snapshot of the (post-mutation) state. Callers spread the
+ * result into their `set()` return: `{ fields, ...pushHistory({ ...state, fields }) }`.
+ */
+export function pushHistory(state: HistoryState): Partial<HistoryState> {
+  const snapshot = createSnapshot(state)
+  const newHistory = state.history.slice(0, state.historyIndex + 1)
+  newHistory.push(snapshot)
+
+  // Trim to max history
+  if (newHistory.length > state.maxHistory) {
+    newHistory.shift()
+  }
+
+  const historyIndex = newHistory.length - 1
+  return {
+    history: newHistory,
+    historyIndex,
+    // #160 — reactive flags kept in sync with the index/length on
+    // every history mutation so component subscribers re-render.
+    canUndo: historyIndex > 0,
+    canRedo: false,
+  }
+}
+
+/** Restore one step back. Returns `null` when there's nothing to undo. */
+export function applyUndo(state: HistoryState): Partial<HistoryState> | null {
+  if (state.historyIndex <= 0) return null
+  const newIndex = state.historyIndex - 1
+  const snapshot = state.history[newIndex]
+  if (!snapshot) return null
+  return restoreSnapshot(snapshot, newIndex, state.history.length)
+}
+
+/** Restore one step forward. Returns `null` when there's nothing to redo. */
+export function applyRedo(state: HistoryState): Partial<HistoryState> | null {
+  if (state.historyIndex >= state.history.length - 1) return null
+  const newIndex = state.historyIndex + 1
+  const snapshot = state.history[newIndex]
+  if (!snapshot) return null
+  return restoreSnapshot(snapshot, newIndex, state.history.length)
+}
+
+function restoreSnapshot(
+  snapshot: HistorySnapshot,
+  newIndex: number,
+  historyLength: number,
+): Partial<HistoryState> {
+  return {
+    fields: structuredClone(snapshot.fields),
+    groups: structuredClone(snapshot.groups),
+    header: snapshot.header ? structuredClone(snapshot.header) : undefined,
+    footer: snapshot.footer ? structuredClone(snapshot.footer) : undefined,
+    historyIndex: newIndex,
+    canUndo: newIndex > 0,
+    canRedo: newIndex < historyLength - 1,
+  }
+}

--- a/packages/ui/src/store/templateStore.ts
+++ b/packages/ui/src/store/templateStore.ts
@@ -2,6 +2,13 @@ import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 import { idbGet, idbSet, idbDelete, migrateFromLocalStorage } from './idbStorage.js'
 import { migrateImageAssetOnModeFlip, type ImageAssetPools } from './imageAssetMigration.js'
+import {
+  createSnapshot,
+  pushHistory,
+  applyUndo,
+  applyRedo,
+  type HistorySnapshot,
+} from './history.js'
 import type {
   FieldDefinition,
   TemplateMeta,
@@ -18,10 +25,6 @@ import type {
 } from '@template-goblin/types'
 
 /** Snapshot of the template state for undo/redo */
-interface HistorySnapshot {
-  fields: FieldDefinition[]
-  groups: GroupDefinition[]
-}
 
 export interface TemplateState {
   /** Template metadata */
@@ -335,37 +338,6 @@ const defaultMeta: TemplateMeta = {
   updatedAt: new Date().toISOString(),
 }
 
-function createSnapshot(state: {
-  fields: FieldDefinition[]
-  groups: GroupDefinition[]
-}): HistorySnapshot {
-  return {
-    fields: structuredClone(state.fields),
-    groups: structuredClone(state.groups),
-  }
-}
-
-function pushHistory(state: TemplateState): Partial<TemplateState> {
-  const snapshot = createSnapshot(state)
-  const newHistory = state.history.slice(0, state.historyIndex + 1)
-  newHistory.push(snapshot)
-
-  // Trim to max history
-  if (newHistory.length > state.maxHistory) {
-    newHistory.shift()
-  }
-
-  const historyIndex = newHistory.length - 1
-  return {
-    history: newHistory,
-    historyIndex,
-    // #160 — reactive flags kept in sync with the index/length on
-    // every history mutation so component subscribers re-render.
-    canUndo: historyIndex > 0,
-    canRedo: false,
-  }
-}
-
 let fieldCounter = 0
 
 /**
@@ -641,12 +613,13 @@ export const useTemplateStore = create<TemplateState>()(
           // First-time enable on a never-configured store: lay down a sensible
           // default band. First-time disable: nothing to remember; no-op.
           if (!state.header) {
-            return enabled
-              ? {
-                  header: defaultBand('header'),
-                  meta: { ...state.meta, updatedAt: new Date().toISOString() },
-                }
-              : state
+            if (!enabled) return state
+            const header = defaultBand('header')
+            return {
+              header,
+              meta: { ...state.meta, updatedAt: new Date().toISOString() },
+              ...pushHistory({ ...state, header }),
+            }
           }
           if (state.header.enabled === enabled) return state
           if (enabled) {
@@ -667,14 +640,16 @@ export const useTemplateStore = create<TemplateState>()(
             const restored = reclaim.map(
               (f) => ({ ...f, x: f.x - padX, y: f.y - padY }) as FieldDefinition,
             )
+            const header = {
+              ...state.header,
+              enabled: true,
+              fields: [...state.header.fields, ...restored],
+            }
             return {
               fields: remaining,
-              header: {
-                ...state.header,
-                enabled: true,
-                fields: [...state.header.fields, ...restored],
-              },
+              header,
               meta: { ...state.meta, updatedAt: new Date().toISOString() },
+              ...pushHistory({ ...state, fields: remaining, header }),
             }
           }
           // Hide — migrate band fields to body with page-absolute coords so
@@ -686,10 +661,15 @@ export const useTemplateStore = create<TemplateState>()(
           const migrated = state.header.fields.map(
             (f) => ({ ...f, x: f.x + padX, y: f.y + bandTop + padY }) as FieldDefinition,
           )
+          const fields = [...state.fields, ...migrated]
+          const header = { ...state.header, enabled: false, fields: [] }
           return {
-            fields: [...state.fields, ...migrated],
-            header: { ...state.header, enabled: false, fields: [] },
+            fields,
+            header,
             meta: { ...state.meta, updatedAt: new Date().toISOString() },
+            // The hide-migration is exactly the mutation that, without a
+            // snapshot, let Ctrl+Z lose the migrated fields from BOTH pools.
+            ...pushHistory({ ...state, fields, header }),
           }
         }),
 
@@ -704,42 +684,45 @@ export const useTemplateStore = create<TemplateState>()(
         ),
 
       addHeaderField: (field) =>
-        set((state) =>
-          state.header
-            ? {
-                header: { ...state.header, fields: [...state.header.fields, field] },
-                meta: { ...state.meta, updatedAt: new Date().toISOString() },
-              }
-            : state,
-        ),
+        set((state) => {
+          if (!state.header) return state
+          const header = { ...state.header, fields: [...state.header.fields, field] }
+          return {
+            header,
+            meta: { ...state.meta, updatedAt: new Date().toISOString() },
+            ...pushHistory({ ...state, header }),
+          }
+        }),
 
       updateHeaderField: (id, updates) =>
-        set((state) =>
-          state.header
-            ? {
-                header: {
-                  ...state.header,
-                  fields: state.header.fields.map((f) =>
-                    f.id === id ? ({ ...f, ...updates } as FieldDefinition) : f,
-                  ),
-                },
-                meta: { ...state.meta, updatedAt: new Date().toISOString() },
-              }
-            : state,
-        ),
+        set((state) => {
+          if (!state.header) return state
+          const header = {
+            ...state.header,
+            fields: state.header.fields.map((f) =>
+              f.id === id ? ({ ...f, ...updates } as FieldDefinition) : f,
+            ),
+          }
+          return {
+            header,
+            meta: { ...state.meta, updatedAt: new Date().toISOString() },
+            ...pushHistory({ ...state, header }),
+          }
+        }),
 
       removeHeaderField: (id) =>
-        set((state) =>
-          state.header
-            ? {
-                header: {
-                  ...state.header,
-                  fields: state.header.fields.filter((f) => f.id !== id),
-                },
-                meta: { ...state.meta, updatedAt: new Date().toISOString() },
-              }
-            : state,
-        ),
+        set((state) => {
+          if (!state.header) return state
+          const header = {
+            ...state.header,
+            fields: state.header.fields.filter((f) => f.id !== id),
+          }
+          return {
+            header,
+            meta: { ...state.meta, updatedAt: new Date().toISOString() },
+            ...pushHistory({ ...state, header }),
+          }
+        }),
 
       setFooter: (footer) =>
         set((state) => ({
@@ -750,12 +733,13 @@ export const useTemplateStore = create<TemplateState>()(
       setFooterEnabled: (enabled) =>
         set((state) => {
           if (!state.footer) {
-            return enabled
-              ? {
-                  footer: defaultBand('footer'),
-                  meta: { ...state.meta, updatedAt: new Date().toISOString() },
-                }
-              : state
+            if (!enabled) return state
+            const footer = defaultBand('footer')
+            return {
+              footer,
+              meta: { ...state.meta, updatedAt: new Date().toISOString() },
+              ...pushHistory({ ...state, footer }),
+            }
           }
           if (state.footer.enabled === enabled) return state
           if (enabled) {
@@ -769,14 +753,16 @@ export const useTemplateStore = create<TemplateState>()(
             const restored = reclaim.map(
               (f) => ({ ...f, x: f.x - padX, y: f.y - bandTop - padY }) as FieldDefinition,
             )
+            const footer = {
+              ...state.footer,
+              enabled: true,
+              fields: [...state.footer.fields, ...restored],
+            }
             return {
               fields: remaining,
-              footer: {
-                ...state.footer,
-                enabled: true,
-                fields: [...state.footer.fields, ...restored],
-              },
+              footer,
               meta: { ...state.meta, updatedAt: new Date().toISOString() },
+              ...pushHistory({ ...state, fields: remaining, footer }),
             }
           }
           const bandTop = state.meta.height - state.footer.style.height
@@ -785,10 +771,13 @@ export const useTemplateStore = create<TemplateState>()(
           const migrated = state.footer.fields.map(
             (f) => ({ ...f, x: f.x + padX, y: f.y + bandTop + padY }) as FieldDefinition,
           )
+          const fields = [...state.fields, ...migrated]
+          const footer = { ...state.footer, enabled: false, fields: [] }
           return {
-            fields: [...state.fields, ...migrated],
-            footer: { ...state.footer, enabled: false, fields: [] },
+            fields,
+            footer,
             meta: { ...state.meta, updatedAt: new Date().toISOString() },
+            ...pushHistory({ ...state, fields, footer }),
           }
         }),
 
@@ -803,42 +792,45 @@ export const useTemplateStore = create<TemplateState>()(
         ),
 
       addFooterField: (field) =>
-        set((state) =>
-          state.footer
-            ? {
-                footer: { ...state.footer, fields: [...state.footer.fields, field] },
-                meta: { ...state.meta, updatedAt: new Date().toISOString() },
-              }
-            : state,
-        ),
+        set((state) => {
+          if (!state.footer) return state
+          const footer = { ...state.footer, fields: [...state.footer.fields, field] }
+          return {
+            footer,
+            meta: { ...state.meta, updatedAt: new Date().toISOString() },
+            ...pushHistory({ ...state, footer }),
+          }
+        }),
 
       updateFooterField: (id, updates) =>
-        set((state) =>
-          state.footer
-            ? {
-                footer: {
-                  ...state.footer,
-                  fields: state.footer.fields.map((f) =>
-                    f.id === id ? ({ ...f, ...updates } as FieldDefinition) : f,
-                  ),
-                },
-                meta: { ...state.meta, updatedAt: new Date().toISOString() },
-              }
-            : state,
-        ),
+        set((state) => {
+          if (!state.footer) return state
+          const footer = {
+            ...state.footer,
+            fields: state.footer.fields.map((f) =>
+              f.id === id ? ({ ...f, ...updates } as FieldDefinition) : f,
+            ),
+          }
+          return {
+            footer,
+            meta: { ...state.meta, updatedAt: new Date().toISOString() },
+            ...pushHistory({ ...state, footer }),
+          }
+        }),
 
       removeFooterField: (id) =>
-        set((state) =>
-          state.footer
-            ? {
-                footer: {
-                  ...state.footer,
-                  fields: state.footer.fields.filter((f) => f.id !== id),
-                },
-                meta: { ...state.meta, updatedAt: new Date().toISOString() },
-              }
-            : state,
-        ),
+        set((state) => {
+          if (!state.footer) return state
+          const footer = {
+            ...state.footer,
+            fields: state.footer.fields.filter((f) => f.id !== id),
+          }
+          return {
+            footer,
+            meta: { ...state.meta, updatedAt: new Date().toISOString() },
+            ...pushHistory({ ...state, footer }),
+          }
+        }),
 
       setPageNumber: (config) =>
         set((state) => {
@@ -885,24 +877,22 @@ export const useTemplateStore = create<TemplateState>()(
           // making the router transparent means they keep working for band fields
           // without per-callsite knowledge of which pool the field lives in.
           if (state.header?.fields.some((f) => f.id === id)) {
-            return {
-              header: {
-                ...state.header,
-                fields: state.header.fields.map((f) =>
-                  f.id === id ? ({ ...f, ...updates } as FieldDefinition) : f,
-                ),
-              },
+            const header = {
+              ...state.header,
+              fields: state.header.fields.map((f) =>
+                f.id === id ? ({ ...f, ...updates } as FieldDefinition) : f,
+              ),
             }
+            return { header, ...pushHistory({ ...state, header }) }
           }
           if (state.footer?.fields.some((f) => f.id === id)) {
-            return {
-              footer: {
-                ...state.footer,
-                fields: state.footer.fields.map((f) =>
-                  f.id === id ? ({ ...f, ...updates } as FieldDefinition) : f,
-                ),
-              },
+            const footer = {
+              ...state.footer,
+              fields: state.footer.fields.map((f) =>
+                f.id === id ? ({ ...f, ...updates } as FieldDefinition) : f,
+              ),
             }
+            return { footer, ...pushHistory({ ...state, footer }) }
           }
           // `{ ...f, ...updates }` widens the discriminated union — cast back to
           // `FieldDefinition` once the shape is known to match (`type` stays put,
@@ -922,28 +912,22 @@ export const useTemplateStore = create<TemplateState>()(
         set((state) => {
           // #61 — route through the band pool when the field lives there.
           if (state.header?.fields.some((f) => f.id === id)) {
-            return {
-              header: {
-                ...state.header,
-                fields: state.header.fields.map((f) =>
-                  f.id === id
-                    ? ({ ...f, style: { ...f.style, ...updates } } as FieldDefinition)
-                    : f,
-                ),
-              },
+            const header = {
+              ...state.header,
+              fields: state.header.fields.map((f) =>
+                f.id === id ? ({ ...f, style: { ...f.style, ...updates } } as FieldDefinition) : f,
+              ),
             }
+            return { header, ...pushHistory({ ...state, header }) }
           }
           if (state.footer?.fields.some((f) => f.id === id)) {
-            return {
-              footer: {
-                ...state.footer,
-                fields: state.footer.fields.map((f) =>
-                  f.id === id
-                    ? ({ ...f, style: { ...f.style, ...updates } } as FieldDefinition)
-                    : f,
-                ),
-              },
+            const footer = {
+              ...state.footer,
+              fields: state.footer.fields.map((f) =>
+                f.id === id ? ({ ...f, style: { ...f.style, ...updates } } as FieldDefinition) : f,
+              ),
             }
+            return { footer, ...pushHistory({ ...state, footer }) }
           }
           const fields = state.fields.map((f) =>
             f.id === id ? ({ ...f, style: { ...f.style, ...updates } } as FieldDefinition) : f,
@@ -962,14 +946,21 @@ export const useTemplateStore = create<TemplateState>()(
           // value) — the BYTES must follow it or the renderer's preflight
           // fails with MISSING_ASSET. Computed from the pre-flip field.
           let assetPatch: Partial<ImageAssetPools> | null = null
-          const fields = state.fields.map((f) => {
+          // jsonKey uniqueness is checked across ALL pools so a band flip
+          // can't collide with a body field's key.
+          const everyField = [
+            ...state.fields,
+            ...(state.header?.fields ?? []),
+            ...(state.footer?.fields ?? []),
+          ]
+          const flip = (f: FieldDefinition): FieldDefinition => {
             if (f.id !== id) return f
             if (!f.source || f.source.mode === mode) return f
             assetPatch = migrateImageAssetOnModeFlip(f, mode, state)
             if (f.source.mode === 'static' && mode === 'dynamic') {
               const placeholder = f.source.value as unknown
               const restored = dynMemo.get(id)
-              const jsonKey = restored?.jsonKey ?? generateDefaultJsonKey(f.type, state.fields, id)
+              const jsonKey = restored?.jsonKey ?? generateDefaultJsonKey(f.type, everyField, id)
               const required = restored?.required ?? false
               return {
                 ...f,
@@ -992,7 +983,21 @@ export const useTemplateStore = create<TemplateState>()(
               } as FieldDefinition
             }
             return f
-          })
+          }
+          // #61 — route to whichever pool owns the id (parity with
+          // updateField); the Static/Dynamic toggle previously no-op'd on
+          // band fields.
+          if (state.header?.fields.some((f) => f.id === id)) {
+            const header = { ...state.header, fields: state.header.fields.map(flip) }
+            fieldDynamicMemo = dynMemo
+            return { header, ...(assetPatch ?? {}), ...pushHistory({ ...state, header }) }
+          }
+          if (state.footer?.fields.some((f) => f.id === id)) {
+            const footer = { ...state.footer, fields: state.footer.fields.map(flip) }
+            fieldDynamicMemo = dynMemo
+            return { footer, ...(assetPatch ?? {}), ...pushHistory({ ...state, footer }) }
+          }
+          const fields = state.fields.map(flip)
           fieldDynamicMemo = dynMemo
           return {
             fields,
@@ -1005,20 +1010,18 @@ export const useTemplateStore = create<TemplateState>()(
         set((state) => {
           // #61 — band-aware removal.
           if (state.header?.fields.some((f) => f.id === id)) {
-            return {
-              header: {
-                ...state.header,
-                fields: state.header.fields.filter((f) => f.id !== id),
-              },
+            const header = {
+              ...state.header,
+              fields: state.header.fields.filter((f) => f.id !== id),
             }
+            return { header, ...pushHistory({ ...state, header }) }
           }
           if (state.footer?.fields.some((f) => f.id === id)) {
-            return {
-              footer: {
-                ...state.footer,
-                fields: state.footer.fields.filter((f) => f.id !== id),
-              },
+            const footer = {
+              ...state.footer,
+              fields: state.footer.fields.filter((f) => f.id !== id),
             }
+            return { footer, ...pushHistory({ ...state, footer }) }
           }
           const fields = state.fields.filter((f) => f.id !== id)
           return { fields, ...pushHistory({ ...state, fields, groups: state.groups }) }
@@ -1027,13 +1030,27 @@ export const useTemplateStore = create<TemplateState>()(
       removeFields: (ids) =>
         set((state) => {
           const idSet = new Set(ids)
+          // #61 — the keyboard Delete path uses the plural form; a selected
+          // band field previously survived (the cleared selection just made
+          // it LOOK deleted). Route across all three pools atomically.
           const fields = state.fields.filter((f) => !idSet.has(f.id))
-          return { fields, ...pushHistory({ ...state, fields, groups: state.groups }) }
+          const header = state.header
+            ? { ...state.header, fields: state.header.fields.filter((f) => !idSet.has(f.id)) }
+            : state.header
+          const footer = state.footer
+            ? { ...state.footer, fields: state.footer.fields.filter((f) => !idSet.has(f.id)) }
+            : state.footer
+          return { fields, header, footer, ...pushHistory({ ...state, fields, header, footer }) }
         }),
 
       duplicateField: (id) => {
         const state = get()
-        const field = state.fields.find((f) => f.id === id)
+        // #61 — find the source in whichever pool owns it and duplicate
+        // INTO that pool (previously a band-field duplicate silently
+        // returned null).
+        const inHeader = state.header?.fields.find((f) => f.id === id)
+        const inFooter = state.footer?.fields.find((f) => f.id === id)
+        const field = state.fields.find((f) => f.id === id) ?? inHeader ?? inFooter
         if (!field) return null
         const newField: FieldDefinition = {
           ...structuredClone(field),
@@ -1042,6 +1059,14 @@ export const useTemplateStore = create<TemplateState>()(
           y: field.y + 20,
         }
         set((s) => {
+          if (inHeader && s.header) {
+            const header = { ...s.header, fields: [...s.header.fields, newField] }
+            return { header, ...pushHistory({ ...s, header }) }
+          }
+          if (inFooter && s.footer) {
+            const footer = { ...s.footer, fields: [...s.footer.fields, newField] }
+            return { footer, ...pushHistory({ ...s, footer }) }
+          }
           const fields = [...s.fields, newField]
           return { fields, ...pushHistory({ ...s, fields, groups: s.groups }) }
         })
@@ -1290,35 +1315,9 @@ export const useTemplateStore = create<TemplateState>()(
           }
         }),
 
-      undo: () =>
-        set((state) => {
-          if (state.historyIndex <= 0) return state
-          const newIndex = state.historyIndex - 1
-          const snapshot = state.history[newIndex]
-          if (!snapshot) return state
-          return {
-            fields: structuredClone(snapshot.fields),
-            groups: structuredClone(snapshot.groups),
-            historyIndex: newIndex,
-            canUndo: newIndex > 0,
-            canRedo: newIndex < state.history.length - 1,
-          }
-        }),
+      undo: () => set((state) => applyUndo(state) ?? state),
 
-      redo: () =>
-        set((state) => {
-          if (state.historyIndex >= state.history.length - 1) return state
-          const newIndex = state.historyIndex + 1
-          const snapshot = state.history[newIndex]
-          if (!snapshot) return state
-          return {
-            fields: structuredClone(snapshot.fields),
-            groups: structuredClone(snapshot.groups),
-            historyIndex: newIndex,
-            canUndo: newIndex > 0,
-            canRedo: newIndex < state.history.length - 1,
-          }
-        }),
+      redo: () => set((state) => applyRedo(state) ?? state),
 
       // canUndo / canRedo are reactive state fields above — kept in
       // sync by pushHistory / undo / redo / reset (#160).
@@ -1394,7 +1393,7 @@ export const useTemplateStore = create<TemplateState>()(
           header,
           footer,
           pageNumber,
-          history: [createSnapshot({ fields, groups })],
+          history: [createSnapshot({ fields, groups, header, footer })],
           historyIndex: 0,
           // #160 — keep the reactive undo/redo flags in lockstep with the
           // history index. After loadFromManifest the index is 0 (single
@@ -1406,6 +1405,22 @@ export const useTemplateStore = create<TemplateState>()(
     {
       name: 'template-goblin-template',
       version: PERSIST_VERSION,
+      // History isn't persisted, so a fresh page load starts with an EMPTY
+      // stack — the first mutation then pushes only the post-change
+      // snapshot and the pre-change state is unrecoverable (delete a field
+      // right after reload → Ctrl+Z dead). Seed a baseline snapshot of the
+      // rehydrated document so the first action is always undoable.
+      onRehydrateStorage: () => () => {
+        const s = useTemplateStore.getState()
+        if (s.history.length === 0) {
+          useTemplateStore.setState({
+            history: [createSnapshot(s)],
+            historyIndex: 0,
+            canUndo: false,
+            canRedo: false,
+          })
+        }
+      },
       // Only persist essential data, skip history and transient state
       partialize: (state) => ({
         meta: state.meta,

--- a/packages/ui/src/utils/__tests__/jsonApply.test.ts
+++ b/packages/ui/src/utils/__tests__/jsonApply.test.ts
@@ -311,3 +311,26 @@ describe('diffJsonEdit — structure', () => {
     expect(result.patches).toEqual([{ fieldId: 'h1', placeholder: 'New title' }])
   })
 })
+
+describe('diffJsonEdit — sparse table placeholders are not polluted by fallbacks', () => {
+  it('editing one cell does not stamp the projected column-key fallback into untouched cells', () => {
+    // Placeholder row has only `name`; the projection fills `grade` with
+    // the column-key fallback "grade". Editing just `name` must NOT write
+    // that literal fallback into the placeholder.
+    const fields = [tableField('f4', 'marks', [{ name: 'Widget' }])]
+    const result = diffJsonEdit(editedText(fields, 'tables', 'marks', [
+      { name: 'Gadget', grade: 'grade' },
+    ]), fields)
+    expect(result.patches).toEqual([{ fieldId: 'f4', placeholder: [{ name: 'Gadget' }] }])
+  })
+
+  it('an actually-edited fallback cell IS written', () => {
+    const fields = [tableField('f4', 'marks', [{ name: 'Widget' }])]
+    const result = diffJsonEdit(editedText(fields, 'tables', 'marks', [
+      { name: 'Widget', grade: 'A+' },
+    ]), fields)
+    expect(result.patches).toEqual([
+      { fieldId: 'f4', placeholder: [{ name: 'Widget', grade: 'A+' }] },
+    ])
+  })
+})

--- a/packages/ui/src/utils/__tests__/saveOpen.bandAssets.test.ts
+++ b/packages/ui/src/utils/__tests__/saveOpen.bandAssets.test.ts
@@ -1,0 +1,132 @@
+/**
+ * openTemplate must load image assets referenced by header/footer band
+ * fields (#61). Pre-fix the two asset-loading loops walked
+ * `manifest.fields` only — a saved header/footer logo rendered blank
+ * after open, PDF preview failed preflight with MISSING_ASSET, and the
+ * next save's orphan sweep dropped the bytes from the archive for good.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import JSZip from 'jszip'
+
+const storage = new Map<string, string>()
+vi.stubGlobal('localStorage', {
+  getItem: (k: string) => storage.get(k) ?? null,
+  setItem: (k: string, v: string) => storage.set(k, v),
+  removeItem: (k: string) => storage.delete(k),
+  clear: () => storage.clear(),
+})
+vi.stubGlobal(
+  'Blob',
+  class BlobStub {
+    constructor(
+      public parts: unknown[],
+      public opts: { type?: string } = {},
+    ) {}
+    get type() {
+      return this.opts.type ?? ''
+    }
+  },
+)
+// Node has no FileReader — openTemplate only uses it to build data-URL
+// MIRRORS of the binary buffers; the buffers themselves are what we assert.
+vi.stubGlobal(
+  'FileReader',
+  class FileReaderStub {
+    result: string | null = null
+    onload: (() => void) | null = null
+    onerror: (() => void) | null = null
+    readAsDataURL(_blob: unknown) {
+      this.result = 'data:image/png;base64,c3R1Yg=='
+      queueMicrotask(() => this.onload?.())
+    }
+  },
+)
+
+import { openTemplate } from '../saveOpen.js'
+import { useTemplateStore } from '../../store/templateStore.js'
+
+const PNG_BYTES = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+
+const BAND_STYLE = {
+  height: 40,
+  backgroundColor: null,
+  divider: null,
+  paddingTop: 4,
+  paddingBottom: 4,
+  paddingLeft: 12,
+  paddingRight: 12,
+}
+
+function bandImageField(id: string, source: object) {
+  return {
+    id,
+    type: 'image',
+    groupId: null,
+    pageId: null,
+    label: id,
+    x: 0,
+    y: 0,
+    width: 20,
+    height: 20,
+    zIndex: 1,
+    style: { fit: 'contain' },
+    source,
+  }
+}
+
+function buildManifest() {
+  return {
+    version: '1.0',
+    meta: {
+      name: 'BandAssets',
+      width: 595,
+      height: 842,
+      unit: 'pt',
+      pageSize: 'A4',
+      locked: false,
+      maxPages: 5,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    },
+    fonts: [],
+    groups: [],
+    pages: [],
+    fields: [],
+    header: {
+      enabled: true,
+      applyToFirstPage: true,
+      style: BAND_STYLE,
+      fields: [
+        bandImageField('hdr-logo', { mode: 'static', value: { filename: 'logo.png' } }),
+        bandImageField('hdr-photo', {
+          mode: 'dynamic',
+          jsonKey: 'photo',
+          required: false,
+          placeholder: { filename: 'dp.png' },
+        }),
+      ],
+    },
+  }
+}
+
+beforeEach(() => {
+  storage.clear()
+  useTemplateStore.getState().reset()
+})
+
+describe('openTemplate — band-field image assets (#61)', () => {
+  it('loads static + placeholder bytes referenced only by band fields', async () => {
+    const zip = new JSZip()
+    zip.file('manifest.json', JSON.stringify(buildManifest()))
+    zip.file('images/logo.png', PNG_BYTES)
+    zip.file('placeholders/dp.png', PNG_BYTES)
+    const blob = await zip.generateAsync({ type: 'arraybuffer' })
+    await openTemplate(new File([blob], 'tpl.tgbl', { type: 'application/zip' }))
+
+    const state = useTemplateStore.getState()
+    expect(state.header?.fields).toHaveLength(2)
+    // Pre-fix both maps stayed EMPTY for band-only references.
+    expect(state.staticImageBuffers.has('logo.png')).toBe(true)
+    expect(state.placeholderBuffers.has('dp.png')).toBe(true)
+  })
+})

--- a/packages/ui/src/utils/jsonApply.ts
+++ b/packages/ui/src/utils/jsonApply.ts
@@ -148,9 +148,44 @@ function diffTables(
     }
     const rows = normalizeRows(value)
     if (JSON.stringify(rows) === JSON.stringify(baseline[key])) continue
-    const placeholder = rows.length === 0 ? null : rows
-    for (const f of targets) result.patches.push({ fieldId: f.id, placeholder })
+    // Per-field write-back that preserves sparseness: cells the user did
+    // NOT change keep the field's ORIGINAL placeholder cell (including
+    // its absence) instead of the projected column-key fallback —
+    // otherwise editing one cell stamped literal "qty": "qty" strings
+    // into the placeholder for every untouched sparse cell.
+    for (const f of targets) {
+      const merged = mergeUneditedCells(rows, baseline[key] ?? [], f)
+      result.patches.push({ fieldId: f.id, placeholder: merged.length === 0 ? null : merged })
+    }
   }
+}
+
+/** Keep the original placeholder's cell wherever the edited value equals
+ *  the projected baseline (i.e. the user didn't touch it). */
+function mergeUneditedCells(
+  edited: TableRow[],
+  baseline: TableRow[],
+  field: FieldDefinition,
+): TableRow[] {
+  const original =
+    field.source?.mode === 'dynamic' && Array.isArray(field.source.placeholder)
+      ? (field.source.placeholder as Record<string, unknown>[])
+      : []
+  return edited.map((row, i) => {
+    const baseRow = baseline[i] ?? {}
+    const origRow = original[i] && typeof original[i] === 'object' ? original[i] : {}
+    const out: TableRow = {}
+    for (const [k, v] of Object.entries(row)) {
+      if (v === baseRow[k]) {
+        const ov = (origRow as Record<string, unknown>)[k]
+        if (typeof ov === 'string') out[k] = ov
+        // untouched fallback cell with no original value → stays absent
+      } else {
+        out[k] = v
+      }
+    }
+    return out
+  })
 }
 
 /** Keep object rows; keep string cells, stringify numbers/booleans, drop

--- a/packages/ui/src/utils/saveOpen.ts
+++ b/packages/ui/src/utils/saveOpen.ts
@@ -3,6 +3,7 @@ import type { TemplateManifest, PageDefinition, PageBand } from '@template-gobli
 import { TemplateGoblinError } from '@template-goblin/types'
 import { validateManifest } from 'template-goblin/validateManifest'
 import { useTemplateStore } from '../store/templateStore.js'
+import { useUiStore } from '../store/uiStore.js'
 import {
   MANIFEST_FILENAME,
   BACKGROUND_FILENAME,
@@ -205,8 +206,18 @@ export async function openTemplate(file: File): Promise<void> {
   // a save→reopen round-trip in a clean browser session showed the
   // filename text instead of the bitmap and (worse) re-saved an
   // archive missing every placeholder under `placeholders/`.
+  // #61 — header/footer band fields reference assets in the same archive
+  // folders. Loading only `manifest.fields` lost every band image: it
+  // rendered blank after open, and the next save's orphan sweep dropped
+  // the bytes from the archive for good.
+  const allFields = [
+    ...manifest.fields,
+    ...(manifest.header?.fields ?? []),
+    ...(manifest.footer?.fields ?? []),
+  ]
+
   const placeholderBuffers = new Map<string, ArrayBuffer>()
-  for (const field of manifest.fields) {
+  for (const field of allFields) {
     if (field.type !== 'image') continue
     if (field.source.mode !== 'dynamic') continue
     const ph = field.source.placeholder
@@ -226,7 +237,7 @@ export async function openTemplate(file: File): Promise<void> {
   // `images/<filename>`.
   const staticImageBuffers = new Map<string, ArrayBuffer>()
   const staticImageDataUrls = new Map<string, string>()
-  for (const field of manifest.fields) {
+  for (const field of allFields) {
     if (field.type !== 'image') continue
     if (field.source.mode !== 'static') continue
     // GH #81 — solid-colour static fields carry no asset; skip.
@@ -268,6 +279,13 @@ export async function openTemplate(file: File): Promise<void> {
     backfillEnabledFlag(manifest.footer),
     manifest.pageNumber,
   )
+
+  // The PREVIOUS template's view state must not leak into the opened one:
+  // `currentPageId` is persisted, and an id no new page has makes
+  // `deriveCanvasFields` filter every body field — the template opened
+  // "empty" until the user happened to click a page tab.
+  useUiStore.getState().setCurrentPage(null)
+  useUiStore.getState().clearSelection()
 }
 
 /**


### PR DESCRIPTION
## What

Full-project QA pass: 32 findings audited across canvas, stores/persistence, panels/preview, and the core engine; 24 verified-real bugs fixed, each pinned by a regression test.

## Core (`template-goblin`)

- **Phantom pages / corrupt clip state**: `addPage({size})` REPLACES constructor options, so every page after the first got PDFKit's default 72pt margins — bottom-strip content auto-paginated onto phantom pages and split clip q/Q pairs across pages. Both call sites now pass `margin: 0`.
- **Band fields were invisible to `validateData`/preflight/`loadTemplate`** — required header fields went unvalidated, band images rendered blank, and load→save round-trips dropped band assets permanently. New `utils/manifestFields.allManifestFields` walks body + bands everywhere (also adopted by assetRefs + font-subset extraction, which now covers pageNumber glyphs).
- **Per-page backgrounds lost on reload**: writer used a synthetic `page-<index>.png` name while the loader resolves via `page.backgroundFilename`.
- **`generateBatchPDF` hung forever** when a worker died without replying (only `exit` fires for an OS-killed child). Settle-once guard across message/error/exit.
- Fields after a multiPage table rendered on the table's last continuation page; `validateManifest` crashed on legacy no-`pages` manifests; `loadTemplate` rejected dir-prefixed asset filenames; table header labels overflowed their cell (Hard Rule #10); bare `Error`s → `TemplateGoblinError` (new `INVALID_ARGUMENT` code in types).

## UI (`template-goblin-ui`)

- **Band-field data loss on open**: `openTemplate` loaded image assets for body fields only.
- **Undo blind to bands** (new `store/history.ts`): hiding a band then Ctrl+Z lost its fields from BOTH pools, unrecoverably. Snapshots now include bands; every band mutation pushes history; `removeFields` / `setFieldMode` / `duplicateField` gain band routing (all three silently no-op'd on band fields).
- **Multi-select drags never committed** — Fabric reports the gesture on the ActiveSelection (no field id); the move was dropped and fields snapped back on the next reconcile.
- **WYSIWYG parity**: canvas text wrap now mirrors core's `wrapText` exactly (newline paragraphs + mid-word breaks), pinned by a parity suite. (Preview already runs the real `generatePDF`, so every core fix applies to it by construction.)
- Hyperlink drafts leaked across field selections (could silently overwrite/delete a link on blur) — per-type editors now keyed by field id.
- Footer gesture math uses the viewed page's own height (new `bandGeometry.ts`, also fixes `applyToFirstPage` zones in draw-to-create and the smart-guides clamp); File→Open resets stale page view; first action after reload is undoable; PNG/JPEG+10MB validation on panel image uploads; WEBP no longer invited in the Preview dialog; sub-4-byte fonts rejected; FontManager surfaces all rejection reasons; JSON-panel table edits keep sparse placeholders sparse.

## Testing
- core: 490 Jest tests (8 new in `qaRegressions.test.ts`, incl. PDF.js page-placement assertions and an exits-silently batch worker)
- ui: 597 Vitest tests (12 new: band history/routing, band asset open, wrap parity, sparse-table write-back)
- e2e smoke (json-preview, header-footer regressions, save-drops-warn, preview gates): 18/18
- Full monorepo build + type-check + lint clean; changeset: types minor, core minor, ui patch

## Deferred (known, lower-stakes)
Ctrl+0 fit-zoom shrink bug; band re-enable reclaiming unrelated fields; unreachable `ImageCompressor.tsx`; FontManager/PageSizeDialog Escape handling; rotated multiPage-table clip split; font subsetting still pass-through.