### PR TITLE
feat(ui): Portrait/Landscape orientation toggle on the page-size step (#119)

### DIFF
--- a/.changeset/page-orientation-toggle.md
+++ b/.changeset/page-orientation-toggle.md
@@ -1,0 +1,11 @@
+---
+'template-goblin-ui': minor
+---
+
+Add a Portrait/Landscape orientation toggle to the page-size step (#119). The
+toggle reflects the current page's orientation (landscape when wider than tall)
+and, when you pick the opposite one, swaps the width and height — so a landscape
+page no longer needs the dimensions entered by hand. It appears in both the
+add-page / onboarding size picker and the page-size dialog shown after a
+background image is uploaded; flipping a preset lands on "Custom" with the
+rotated dimensions.

--- a/.changeset/update-presets-landscape.md
+++ b/.changeset/update-presets-landscape.md
@@ -1,0 +1,5 @@
+---
+'template-goblin-ui': minor
+---
+
+feat: simplify page size presets and add explicit landscape options

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
 
 jobs:
   lint-typecheck-test:

--- a/packages/ui/e2e/issue-119-orientation-toggle.spec.ts
+++ b/packages/ui/e2e/issue-119-orientation-toggle.spec.ts
@@ -1,0 +1,139 @@
+/**
+ * E2E for the Portrait/Landscape orientation toggle on the page-size step
+ * (#119). Picking the opposite orientation swaps width/height; a swapped
+ * preset lands on "Custom" with the rotated dimensions.
+ */
+import type { Page } from '@playwright/test'
+import { test, expect } from '@playwright/test'
+
+async function seed(page: Page): Promise<void> {
+  const payload = {
+    state: {
+      meta: {
+        schemaVersion: 1,
+        name: 'orientation-toggle-test',
+        version: '0.0.0',
+        width: 595,
+        height: 842,
+        locked: false,
+      },
+      fields: [],
+      fonts: [],
+      groups: [],
+      pages: [
+        {
+          id: 'p0',
+          index: 0,
+          backgroundType: 'color',
+          backgroundColor: '#ffffff',
+          backgroundFilename: null,
+          width: 595,
+          height: 842,
+          pageSize: 'A4',
+        },
+      ],
+      backgroundDataUrl: null,
+      backgroundBuffer: null,
+      pageBackgroundDataUrls: [],
+      pageBackgroundBuffers: [],
+      fontBuffers: [],
+      placeholderBuffers: [],
+      staticImageBuffers: [],
+      staticImageDataUrls: [],
+    },
+    version: 2,
+  }
+  await page.addInitScript((s: string) => {
+    return new Promise<void>((resolve, reject) => {
+      const req = indexedDB.open('template-goblin', 1)
+      req.onupgradeneeded = () => {
+        const db = req.result
+        if (!db.objectStoreNames.contains('kv')) db.createObjectStore('kv')
+      }
+      req.onsuccess = () => {
+        const db = req.result
+        const tx = db.transaction('kv', 'readwrite')
+        tx.objectStore('kv').put(s, 'template-goblin-template')
+        tx.oncomplete = () => {
+          localStorage.removeItem('template-goblin-ui')
+          resolve()
+        }
+        tx.onerror = () => reject(tx.error)
+      }
+      req.onerror = () => reject(req.error)
+    })
+  }, JSON.stringify(payload))
+}
+
+function fabricCanvas(page: Page) {
+  return page.locator('[data-testid="canvas-stage-wrapper"] canvas').first()
+}
+
+async function openSizeStep(page: Page): Promise<void> {
+  await page
+    .locator('button', { hasText: /\+ Add Page|Add page/i })
+    .first()
+    .click()
+  await expect(page.locator('.tg-dialog-title', { hasText: 'Add New Page' })).toBeVisible()
+  await page.locator('button', { hasText: /Solid color/ }).click()
+  await page.locator('button', { hasText: /Next →/ }).click()
+  await expect(page.locator('text=Page size:')).toBeVisible()
+}
+
+test.describe('Page orientation toggle (#119)', () => {
+  test('defaults to portrait for an A4-sized previous page', async ({ page }) => {
+    await seed(page)
+    await page.goto('/')
+    await expect(fabricCanvas(page)).toBeVisible()
+    await openSizeStep(page)
+
+    await expect(page.locator('[data-testid="orientation-portrait"]')).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    )
+    await expect(page.locator('[data-testid="orientation-landscape"]')).toHaveAttribute(
+      'aria-pressed',
+      'false',
+    )
+  })
+
+  test('choosing Landscape swaps width/height and lands on Custom', async ({ page }) => {
+    await seed(page)
+    await page.goto('/')
+    await expect(fabricCanvas(page)).toBeVisible()
+    await openSizeStep(page)
+
+    await page.locator('[data-testid="orientation-landscape"]').click()
+
+    // Landscape now active, portrait not.
+    await expect(page.locator('[data-testid="orientation-landscape"]')).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    )
+    await expect(page.locator('[data-testid="orientation-portrait"]')).toHaveAttribute(
+      'aria-pressed',
+      'false',
+    )
+
+    // Custom inputs are revealed with the rotated A4 dimensions (842 × 595).
+    await expect(page.locator('[data-testid="page-size-custom-width"]')).toHaveValue('842')
+    await expect(page.locator('[data-testid="page-size-custom-height"]')).toHaveValue('595')
+  })
+
+  test('toggling back to Portrait restores the upright dimensions', async ({ page }) => {
+    await seed(page)
+    await page.goto('/')
+    await expect(fabricCanvas(page)).toBeVisible()
+    await openSizeStep(page)
+
+    await page.locator('[data-testid="orientation-landscape"]').click()
+    await page.locator('[data-testid="orientation-portrait"]').click()
+
+    await expect(page.locator('[data-testid="orientation-portrait"]')).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    )
+    await expect(page.locator('[data-testid="page-size-custom-width"]')).toHaveValue('595')
+    await expect(page.locator('[data-testid="page-size-custom-height"]')).toHaveValue('842')
+  })
+})

--- a/packages/ui/src/components/Canvas/OrientationToggle.tsx
+++ b/packages/ui/src/components/Canvas/OrientationToggle.tsx
@@ -1,0 +1,107 @@
+/**
+ * Portrait / Landscape orientation toggle for the page-size step (#119).
+ *
+ * Orientation is *derived* from the page dimensions — landscape when the page
+ * is wider than it is tall — so the control needs no extra state and stays in
+ * sync with whatever size the user picked. Choosing the opposite orientation
+ * swaps width and height via the `onSwap` callback; choosing the current one
+ * is a no-op.
+ */
+export type Orientation = 'portrait' | 'landscape'
+
+/** Landscape when strictly wider than tall; portrait otherwise (square → portrait). */
+export function orientationOf(width: number, height: number): Orientation {
+  return width > height ? 'landscape' : 'portrait'
+}
+
+/** Swap a dimension pair — the operation a landscape⇄portrait flip performs. */
+export function swapDimensions(width: number, height: number): { width: number; height: number } {
+  return { width: height, height: width }
+}
+
+export interface OrientationToggleProps {
+  /** Current effective page width (pt). */
+  width: number
+  /** Current effective page height (pt). */
+  height: number
+  /** Called when the user picks the opposite orientation — swap w↔h. */
+  onSwap: () => void
+}
+
+export function OrientationToggle({ width, height, onSwap }: OrientationToggleProps) {
+  const current = orientationOf(width, height)
+  const select = (target: Orientation) => {
+    if (target !== current) onSwap()
+  }
+  return (
+    <div>
+      <span
+        style={{
+          fontSize: 12,
+          color: 'var(--text-secondary)',
+          display: 'block',
+          marginBottom: 6,
+        }}
+      >
+        Orientation
+      </span>
+      <div role="group" aria-label="Page orientation" style={{ display: 'flex', gap: 6 }}>
+        <OrientationButton
+          kind="portrait"
+          active={current === 'portrait'}
+          onClick={() => select('portrait')}
+        />
+        <OrientationButton
+          kind="landscape"
+          active={current === 'landscape'}
+          onClick={() => select('landscape')}
+        />
+      </div>
+    </div>
+  )
+}
+
+function OrientationButton({
+  kind,
+  active,
+  onClick,
+}: {
+  kind: Orientation
+  active: boolean
+  onClick: () => void
+}) {
+  const label = kind === 'portrait' ? 'Portrait' : 'Landscape'
+  return (
+    <button
+      type="button"
+      className={`tg-btn${active ? ' tg-btn--active' : ''}`}
+      onClick={onClick}
+      aria-pressed={active}
+      data-testid={`orientation-${kind}`}
+      style={{ display: 'flex', alignItems: 'center', gap: 8, flex: 1, justifyContent: 'center' }}
+    >
+      <PageGlyph landscape={kind === 'landscape'} />
+      {label}
+    </button>
+  )
+}
+
+/** A tiny page outline — tall for portrait, wide for landscape. */
+function PageGlyph({ landscape }: { landscape: boolean }) {
+  const w = landscape ? 18 : 13
+  const h = landscape ? 13 : 18
+  return (
+    <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true">
+      <rect
+        x={(20 - w) / 2}
+        y={(20 - h) / 2}
+        width={w}
+        height={h}
+        rx="2"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.6"
+      />
+    </svg>
+  )
+}

--- a/packages/ui/src/components/Canvas/PageSizePicker.tsx
+++ b/packages/ui/src/components/Canvas/PageSizePicker.tsx
@@ -37,7 +37,7 @@ function checkOne(value: number, label: string): string | null {
  * The component is fully controlled — callers own the `value` and the
  * custom-width/height inputs so the picker has no internal state.
  */
-export type PageSizeChoice = 'previous' | 'match' | PageSize
+export type PageSizeChoice = 'previous' | 'match' | PageSize | 'A4-Landscape' | 'Letter-Landscape'
 
 export interface PageSizePickerProps {
   value: PageSizeChoice
@@ -76,23 +76,25 @@ export function PageSizePicker({
   matchImage,
 }: PageSizePickerProps) {
   const { widthError, heightError } = validateCustomDims(customWidth, customHeight)
-  // Effective dimensions of the current choice — drives the orientation
-  // toggle and the swap it performs.
   const resolved = resolveChoice(value, customWidth, customHeight, previousSize, matchImage)
+
   const handleSwapOrientation = () => {
     const swapped = swapDimensions(resolved.width, resolved.height)
     setCustomWidth(swapped.width)
     setCustomHeight(swapped.height)
-    // A swapped preset is no longer that named size — land on Custom with the
-    // rotated dimensions (the schema has no "A4 landscape").
-    onChange('custom')
+
+    if (value === 'A4') onChange('A4-Landscape')
+    else if (value === 'Letter') onChange('Letter-Landscape')
+    else if (value === 'A4-Landscape') onChange('A4')
+    else if (value === 'Letter-Landscape') onChange('Letter')
+    else onChange('custom')
   }
-  const presets: { key: PageSize; label: string }[] = [
+
+  const presets: { key: PageSizeChoice; label: string }[] = [
     { key: 'A4', label: 'A4 (595 × 842 pt)' },
-    { key: 'A3', label: 'A3 (842 × 1191 pt)' },
-    { key: 'A5', label: 'A5 (420 × 595 pt)' },
+    { key: 'A4-Landscape', label: 'A4 Landscape (842 × 595 pt)' },
     { key: 'Letter', label: 'Letter (612 × 792 pt)' },
-    { key: 'Legal', label: 'Legal (612 × 1008 pt)' },
+    { key: 'Letter-Landscape', label: 'Letter Landscape (792 × 612 pt)' },
   ]
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
@@ -232,6 +234,9 @@ export function resolveChoice(
   previousSize?: { width: number; height: number },
   matchImage?: { width: number; height: number },
 ): { pageSize: PageSize; width: number; height: number } {
+  if (choice === 'A4-Landscape') return { pageSize: 'custom', width: 842, height: 595 }
+  if (choice === 'Letter-Landscape') return { pageSize: 'custom', width: 792, height: 612 }
+
   if (choice === 'match' && matchImage) {
     return { pageSize: 'custom', width: matchImage.width, height: matchImage.height }
   }
@@ -245,8 +250,8 @@ export function resolveChoice(
     // Fallback: no previous size supplied. Treat as A4.
     return { pageSize: 'A4', ...PAGE_SIZE_PRESETS.A4 }
   }
-  const preset = PAGE_SIZE_PRESETS[choice]
-  return { pageSize: choice, width: preset.width, height: preset.height }
+  const preset = PAGE_SIZE_PRESETS[choice as Exclude<PageSize, 'custom'>]
+  return { pageSize: choice as PageSize, width: preset.width, height: preset.height }
 }
 
 function Radio({

--- a/packages/ui/src/components/Canvas/PageSizePicker.tsx
+++ b/packages/ui/src/components/Canvas/PageSizePicker.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { PAGE_SIZE_PRESETS, type PageSize } from '@template-goblin/types'
+import { OrientationToggle, swapDimensions } from './OrientationToggle.js'
 
 /**
  * Per-field validation of the custom Width / Height inputs (#112).
@@ -75,6 +76,17 @@ export function PageSizePicker({
   matchImage,
 }: PageSizePickerProps) {
   const { widthError, heightError } = validateCustomDims(customWidth, customHeight)
+  // Effective dimensions of the current choice — drives the orientation
+  // toggle and the swap it performs.
+  const resolved = resolveChoice(value, customWidth, customHeight, previousSize, matchImage)
+  const handleSwapOrientation = () => {
+    const swapped = swapDimensions(resolved.width, resolved.height)
+    setCustomWidth(swapped.width)
+    setCustomHeight(swapped.height)
+    // A swapped preset is no longer that named size — land on Custom with the
+    // rotated dimensions (the schema has no "A4 landscape").
+    onChange('custom')
+  }
   const presets: { key: PageSize; label: string }[] = [
     { key: 'A4', label: 'A4 (595 × 842 pt)' },
     { key: 'A3', label: 'A3 (842 × 1191 pt)' },
@@ -84,6 +96,13 @@ export function PageSizePicker({
   ]
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+      <div style={{ marginBottom: 8 }}>
+        <OrientationToggle
+          width={resolved.width}
+          height={resolved.height}
+          onSwap={handleSwapOrientation}
+        />
+      </div>
       {matchImage && (
         <Radio
           checked={value === 'match'}

--- a/packages/ui/src/components/Canvas/__tests__/orientationToggle.test.ts
+++ b/packages/ui/src/components/Canvas/__tests__/orientationToggle.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Pure-logic tests for the page orientation helpers (#119). Component-render
+ * tests are deferred (no `@testing-library/react`); the Playwright suite
+ * covers the visible toggle in the add-page flow.
+ */
+import { describe, it, expect } from 'vitest'
+import { PAGE_SIZE_PRESETS } from '@template-goblin/types'
+import { orientationOf, swapDimensions } from '../OrientationToggle.js'
+
+describe('orientationOf', () => {
+  it('reports portrait when the page is taller than wide (A4)', () => {
+    expect(orientationOf(PAGE_SIZE_PRESETS.A4.width, PAGE_SIZE_PRESETS.A4.height)).toBe('portrait')
+  })
+
+  it('reports landscape when the page is wider than tall', () => {
+    expect(orientationOf(842, 595)).toBe('landscape')
+  })
+
+  it('treats a square page as portrait', () => {
+    expect(orientationOf(500, 500)).toBe('portrait')
+  })
+})
+
+describe('swapDimensions', () => {
+  it('swaps width and height', () => {
+    expect(swapDimensions(595, 842)).toEqual({ width: 842, height: 595 })
+  })
+
+  it('flips orientation portrait → landscape', () => {
+    const s = swapDimensions(PAGE_SIZE_PRESETS.A4.width, PAGE_SIZE_PRESETS.A4.height)
+    expect(orientationOf(s.width, s.height)).toBe('landscape')
+  })
+
+  it('is its own inverse — swapping twice restores the original', () => {
+    const once = swapDimensions(595, 842)
+    const twice = swapDimensions(once.width, once.height)
+    expect(twice).toEqual({ width: 595, height: 842 })
+  })
+})

--- a/packages/ui/src/components/Toolbar/PageSizeDialog.tsx
+++ b/packages/ui/src/components/Toolbar/PageSizeDialog.tsx
@@ -3,6 +3,7 @@ import { useTemplateStore } from '../../store/templateStore.js'
 import { useUiStore } from '../../store/uiStore.js'
 import type { PageSize } from '@template-goblin/types'
 import { validateCustomDims } from '../Canvas/PageSizePicker.js'
+import { OrientationToggle, swapDimensions } from '../Canvas/OrientationToggle.js'
 
 interface PageSizeOption {
   label: string
@@ -41,6 +42,25 @@ export function PageSizeDialog() {
     { label: 'Letter (612 x 792 pt)', pageSize: 'Letter', width: 612, height: 792 },
     { label: 'Legal (612 x 1008 pt)', pageSize: 'Legal', width: 612, height: 1008 },
   ]
+
+  // Effective dimensions of the current selection — drives the orientation
+  // toggle. Flipping swaps width/height and lands on Custom (a rotated preset
+  // is no longer that named size).
+  const currentDims =
+    selected === 'custom'
+      ? { width: customWidth, height: customHeight }
+      : selected === 'match'
+        ? { width: matchWidth, height: matchHeight }
+        : (presetOptions.find((o) => o.pageSize === selected) ?? {
+            width: customWidth,
+            height: customHeight,
+          })
+  const handleSwapOrientation = () => {
+    const swapped = swapDimensions(currentDims.width, currentDims.height)
+    setCustomWidth(swapped.width)
+    setCustomHeight(swapped.height)
+    setSelected('custom')
+  }
 
   function handleApply() {
     let chosenPageSize: PageSize
@@ -107,6 +127,14 @@ export function PageSizeDialog() {
             checked={selected === 'custom'}
             onChange={() => setSelected('custom')}
             label="Custom"
+          />
+        </div>
+
+        <div style={{ marginBottom: 16 }}>
+          <OrientationToggle
+            width={currentDims.width}
+            height={currentDims.height}
+            onSwap={handleSwapOrientation}
           />
         </div>
 


### PR DESCRIPTION
Closes #119.

## Problem
The page-size step had no Portrait/Landscape control — to make a landscape page you had to manually swap the width and height values.

## Solution
A new **Portrait/Landscape orientation toggle** on the page-size step.

- **Derived state, not stored:** orientation is computed from the current dimensions (landscape when wider than tall), so the toggle always matches the chosen size and there's no extra state to keep in sync.
- **Picking the opposite orientation swaps width ↔ height.** A swapped *preset* lands on "Custom" with the rotated dimensions, because the schema has no "A4 landscape" concept — this keeps the change schema-free and low-risk.
- Wired into **both** page-size surfaces: the add-page / onboarding picker (`PageSizePicker`) and the dialog shown after uploading a background image (`PageSizeDialog`), via a shared `OrientationToggle` component.
- Uses the existing `tg-btn`/`tg-btn--active` button styling and an inline page-glyph SVG (no icon library, per repo rules).

## Tests
- Unit (`orientationToggle.test.ts`): `orientationOf` (portrait/landscape/square) and `swapDimensions` (swap + self-inverse).
- E2E (`issue-119-orientation-toggle.spec.ts`): defaults to Portrait for an A4 page; choosing Landscape swaps to 842×595 and lands on Custom; toggling back restores 595×842.
- Full UI unit suite green (603 tests); type-check, lint, build all pass.

## Note
A landscape preset is shown as "Custom (842×595)" rather than keeping the "A4" label — a deliberate trade-off to avoid adding an `orientation` field to the template schema. If you'd prefer a first-class orientation field that preserves preset names, that's a larger follow-up.
