### PR TITLE
feat(ui): "Same as A4" hint for preset-matching custom page dimensions (#118)

### DIFF
--- a/.changeset/custom-dims-preset-hint.md
+++ b/.changeset/custom-dims-preset-hint.md
@@ -1,0 +1,10 @@
+---
+'template-goblin-ui': patch
+---
+
+Page-size step: when the custom width/height match a known preset, show a
+small "Same as A4" hint beneath the inputs (#118). The custom fields pre-fill
+with 595 × 842 — which is A4 — but nothing told the user that; the hint now
+makes it clear (and reads "Same as A4 (landscape)" for rotated dimensions). It
+appears in both the add-page / onboarding picker and the post-image-upload
+page-size dialog.

--- a/packages/ui/src/components/Canvas/PageSizePicker.tsx
+++ b/packages/ui/src/components/Canvas/PageSizePicker.tsx
@@ -27,6 +27,39 @@ function checkOne(value: number, label: string): string | null {
   return null
 }
 
+/** A page size that equals a named preset, possibly rotated to landscape. */
+export interface PresetMatch {
+  name: Exclude<PageSize, 'custom'>
+  landscape: boolean
+}
+
+/**
+ * Identify whether `width × height` equals a known preset in either
+ * orientation (#118). Portrait presets in `PAGE_SIZE_PRESETS` also match
+ * their rotated (landscape) dimensions. Returns `null` for genuine custom
+ * sizes.
+ */
+export function matchPreset(width: number, height: number): PresetMatch | null {
+  for (const name of Object.keys(PAGE_SIZE_PRESETS) as Exclude<PageSize, 'custom'>[]) {
+    const dims = PAGE_SIZE_PRESETS[name]
+    if (dims.width === width && dims.height === height) return { name, landscape: false }
+    if (dims.width === height && dims.height === width) return { name, landscape: true }
+  }
+  return null
+}
+
+/**
+ * Human-readable hint for a preset match — e.g. `"Same as A4"` or
+ * `"Same as A4 (landscape)"`. `null` when the dimensions are genuinely
+ * custom. Used to reassure users that the pre-filled custom defaults
+ * (595 × 842) are in fact A4.
+ */
+export function presetMatchLabel(width: number, height: number): string | null {
+  const match = matchPreset(width, height)
+  if (!match) return null
+  return `Same as ${match.name}${match.landscape ? ' (landscape)' : ''}`
+}
+
 /**
  * Reusable page-size radio picker. The "Same as previous" option is shown
  * when `previousSize` is supplied (i.e. on second-and-later pages); when
@@ -75,6 +108,9 @@ export function PageSizePicker({
   matchImage,
 }: PageSizePickerProps) {
   const { widthError, heightError } = validateCustomDims(customWidth, customHeight)
+  // #118 — reassure the user that the pre-filled custom defaults map to a
+  // known preset (e.g. 595 × 842 = A4) so the numbers aren't a mystery.
+  const customMatch = presetMatchLabel(customWidth, customHeight)
   const presets: { key: PageSize; label: string }[] = [
     { key: 'A4', label: 'A4 (595 × 842 pt)' },
     { key: 'A3', label: 'A3 (842 × 1191 pt)' },
@@ -117,83 +153,91 @@ export function PageSizePicker({
       <div style={{ minHeight: 60, marginTop: 8 }}>
         <div
           style={{
-            display: 'flex',
-            gap: 12,
             visibility: value === 'custom' ? 'visible' : 'hidden',
             pointerEvents: value === 'custom' ? 'auto' : 'none',
           }}
           aria-hidden={value !== 'custom'}
         >
-          <div style={{ flex: 1 }}>
-            <label
-              style={{
-                fontSize: 12,
-                color: 'var(--text-secondary)',
-                display: 'block',
-                marginBottom: 4,
-              }}
-            >
-              Width (pt)
-            </label>
-            <input
-              className="tg-input"
-              type="number"
-              min={1}
-              value={customWidth}
-              onChange={(e) => setCustomWidth(Number(e.target.value))}
-              tabIndex={value === 'custom' ? 0 : -1}
-              aria-invalid={value === 'custom' && !!widthError}
-              aria-describedby={
-                value === 'custom' && widthError ? 'page-size-width-error' : undefined
-              }
-              data-testid="page-size-custom-width"
-            />
-            {value === 'custom' && widthError && (
-              <div
-                id="page-size-width-error"
-                data-testid="page-size-width-error"
-                role="alert"
-                style={{ fontSize: 11, color: 'var(--error)', marginTop: 4 }}
+          <div style={{ display: 'flex', gap: 12 }}>
+            <div style={{ flex: 1 }}>
+              <label
+                style={{
+                  fontSize: 12,
+                  color: 'var(--text-secondary)',
+                  display: 'block',
+                  marginBottom: 4,
+                }}
               >
-                {widthError}
-              </div>
-            )}
-          </div>
-          <div style={{ flex: 1 }}>
-            <label
-              style={{
-                fontSize: 12,
-                color: 'var(--text-secondary)',
-                display: 'block',
-                marginBottom: 4,
-              }}
-            >
-              Height (pt)
-            </label>
-            <input
-              className="tg-input"
-              type="number"
-              min={1}
-              value={customHeight}
-              onChange={(e) => setCustomHeight(Number(e.target.value))}
-              tabIndex={value === 'custom' ? 0 : -1}
-              aria-invalid={value === 'custom' && !!heightError}
-              aria-describedby={
-                value === 'custom' && heightError ? 'page-size-height-error' : undefined
-              }
-              data-testid="page-size-custom-height"
-            />
-            {value === 'custom' && heightError && (
-              <div
-                id="page-size-height-error"
-                data-testid="page-size-height-error"
-                role="alert"
-                style={{ fontSize: 11, color: 'var(--error)', marginTop: 4 }}
+                Width (pt)
+              </label>
+              <input
+                className="tg-input"
+                type="number"
+                min={1}
+                value={customWidth}
+                onChange={(e) => setCustomWidth(Number(e.target.value))}
+                tabIndex={value === 'custom' ? 0 : -1}
+                aria-invalid={value === 'custom' && !!widthError}
+                aria-describedby={
+                  value === 'custom' && widthError ? 'page-size-width-error' : undefined
+                }
+                data-testid="page-size-custom-width"
+              />
+              {value === 'custom' && widthError && (
+                <div
+                  id="page-size-width-error"
+                  data-testid="page-size-width-error"
+                  role="alert"
+                  style={{ fontSize: 11, color: 'var(--error)', marginTop: 4 }}
+                >
+                  {widthError}
+                </div>
+              )}
+            </div>
+            <div style={{ flex: 1 }}>
+              <label
+                style={{
+                  fontSize: 12,
+                  color: 'var(--text-secondary)',
+                  display: 'block',
+                  marginBottom: 4,
+                }}
               >
-                {heightError}
-              </div>
-            )}
+                Height (pt)
+              </label>
+              <input
+                className="tg-input"
+                type="number"
+                min={1}
+                value={customHeight}
+                onChange={(e) => setCustomHeight(Number(e.target.value))}
+                tabIndex={value === 'custom' ? 0 : -1}
+                aria-invalid={value === 'custom' && !!heightError}
+                aria-describedby={
+                  value === 'custom' && heightError ? 'page-size-height-error' : undefined
+                }
+                data-testid="page-size-custom-height"
+              />
+              {value === 'custom' && heightError && (
+                <div
+                  id="page-size-height-error"
+                  data-testid="page-size-height-error"
+                  role="alert"
+                  style={{ fontSize: 11, color: 'var(--error)', marginTop: 4 }}
+                >
+                  {heightError}
+                </div>
+              )}
+            </div>
           </div>
+          {customMatch && (
+            <div
+              data-testid="page-size-preset-match"
+              style={{ fontSize: 11, color: 'var(--text-muted)', marginTop: 6 }}
+            >
+              {customMatch}
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/packages/ui/src/components/Canvas/__tests__/presetMatch.test.ts
+++ b/packages/ui/src/components/Canvas/__tests__/presetMatch.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Pure-logic tests for the page-size preset-match helpers (#118) — used to
+ * tell the user when their custom dimensions equal a known preset.
+ */
+import { describe, it, expect } from 'vitest'
+import { matchPreset, presetMatchLabel } from '../PageSizePicker.js'
+
+describe('matchPreset', () => {
+  it('matches A4 in portrait orientation', () => {
+    expect(matchPreset(595, 842)).toEqual({ name: 'A4', landscape: false })
+  })
+
+  it('matches A4 rotated to landscape', () => {
+    expect(matchPreset(842, 595)).toEqual({ name: 'A4', landscape: true })
+  })
+
+  it('matches Letter portrait', () => {
+    expect(matchPreset(612, 792)).toEqual({ name: 'Letter', landscape: false })
+  })
+
+  it('returns null for a genuinely custom size', () => {
+    expect(matchPreset(1000, 700)).toBeNull()
+  })
+
+  it('returns null for a square page (no preset is square)', () => {
+    expect(matchPreset(500, 500)).toBeNull()
+  })
+})
+
+describe('presetMatchLabel', () => {
+  it('labels a portrait match', () => {
+    expect(presetMatchLabel(595, 842)).toBe('Same as A4')
+  })
+
+  it('labels a landscape match', () => {
+    expect(presetMatchLabel(842, 595)).toBe('Same as A4 (landscape)')
+  })
+
+  it('is null for a custom size', () => {
+    expect(presetMatchLabel(321, 654)).toBeNull()
+  })
+})

--- a/packages/ui/src/components/Toolbar/PageSizeDialog.tsx
+++ b/packages/ui/src/components/Toolbar/PageSizeDialog.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { useTemplateStore } from '../../store/templateStore.js'
 import { useUiStore } from '../../store/uiStore.js'
 import type { PageSize } from '@template-goblin/types'
-import { validateCustomDims } from '../Canvas/PageSizePicker.js'
+import { validateCustomDims, presetMatchLabel } from '../Canvas/PageSizePicker.js'
 
 interface PageSizeOption {
   label: string
@@ -28,6 +28,8 @@ export function PageSizeDialog() {
   // user should see WHY their value was rejected before hitting Apply.
   const customDimValidation = validateCustomDims(customWidth, customHeight)
   const applyDisabled = selected === 'custom' && customDimValidation.hasError
+  // #118 — tell the user when the custom defaults equal a known preset.
+  const customMatch = presetMatchLabel(customWidth, customHeight)
 
   if (!showDialog || !pendingBackground) return null
 
@@ -111,75 +113,85 @@ export function PageSizeDialog() {
         </div>
 
         {selected === 'custom' && (
-          <div style={{ display: 'flex', gap: 12, marginBottom: 16 }}>
-            <div style={{ flex: 1 }}>
-              <label
-                style={{
-                  fontSize: 12,
-                  color: 'var(--text-secondary)',
-                  display: 'block',
-                  marginBottom: 4,
-                }}
-              >
-                Width (pt)
-              </label>
-              <input
-                className="tg-input"
-                type="number"
-                min={1}
-                value={customWidth}
-                onChange={(e) => setCustomWidth(Number(e.target.value))}
-                aria-invalid={!!customDimValidation.widthError}
-                aria-describedby={
-                  customDimValidation.widthError ? 'toolbar-page-size-width-error' : undefined
-                }
-                data-testid="toolbar-page-size-custom-width"
-              />
-              {customDimValidation.widthError && (
-                <div
-                  id="toolbar-page-size-width-error"
-                  data-testid="toolbar-page-size-width-error"
-                  role="alert"
-                  style={{ fontSize: 11, color: 'var(--error)', marginTop: 4 }}
+          <div style={{ marginBottom: 16 }}>
+            <div style={{ display: 'flex', gap: 12 }}>
+              <div style={{ flex: 1 }}>
+                <label
+                  style={{
+                    fontSize: 12,
+                    color: 'var(--text-secondary)',
+                    display: 'block',
+                    marginBottom: 4,
+                  }}
                 >
-                  {customDimValidation.widthError}
-                </div>
-              )}
-            </div>
-            <div style={{ flex: 1 }}>
-              <label
-                style={{
-                  fontSize: 12,
-                  color: 'var(--text-secondary)',
-                  display: 'block',
-                  marginBottom: 4,
-                }}
-              >
-                Height (pt)
-              </label>
-              <input
-                className="tg-input"
-                type="number"
-                min={1}
-                value={customHeight}
-                onChange={(e) => setCustomHeight(Number(e.target.value))}
-                aria-invalid={!!customDimValidation.heightError}
-                aria-describedby={
-                  customDimValidation.heightError ? 'toolbar-page-size-height-error' : undefined
-                }
-                data-testid="toolbar-page-size-custom-height"
-              />
-              {customDimValidation.heightError && (
-                <div
-                  id="toolbar-page-size-height-error"
-                  data-testid="toolbar-page-size-height-error"
-                  role="alert"
-                  style={{ fontSize: 11, color: 'var(--error)', marginTop: 4 }}
+                  Width (pt)
+                </label>
+                <input
+                  className="tg-input"
+                  type="number"
+                  min={1}
+                  value={customWidth}
+                  onChange={(e) => setCustomWidth(Number(e.target.value))}
+                  aria-invalid={!!customDimValidation.widthError}
+                  aria-describedby={
+                    customDimValidation.widthError ? 'toolbar-page-size-width-error' : undefined
+                  }
+                  data-testid="toolbar-page-size-custom-width"
+                />
+                {customDimValidation.widthError && (
+                  <div
+                    id="toolbar-page-size-width-error"
+                    data-testid="toolbar-page-size-width-error"
+                    role="alert"
+                    style={{ fontSize: 11, color: 'var(--error)', marginTop: 4 }}
+                  >
+                    {customDimValidation.widthError}
+                  </div>
+                )}
+              </div>
+              <div style={{ flex: 1 }}>
+                <label
+                  style={{
+                    fontSize: 12,
+                    color: 'var(--text-secondary)',
+                    display: 'block',
+                    marginBottom: 4,
+                  }}
                 >
-                  {customDimValidation.heightError}
-                </div>
-              )}
+                  Height (pt)
+                </label>
+                <input
+                  className="tg-input"
+                  type="number"
+                  min={1}
+                  value={customHeight}
+                  onChange={(e) => setCustomHeight(Number(e.target.value))}
+                  aria-invalid={!!customDimValidation.heightError}
+                  aria-describedby={
+                    customDimValidation.heightError ? 'toolbar-page-size-height-error' : undefined
+                  }
+                  data-testid="toolbar-page-size-custom-height"
+                />
+                {customDimValidation.heightError && (
+                  <div
+                    id="toolbar-page-size-height-error"
+                    data-testid="toolbar-page-size-height-error"
+                    role="alert"
+                    style={{ fontSize: 11, color: 'var(--error)', marginTop: 4 }}
+                  >
+                    {customDimValidation.heightError}
+                  </div>
+                )}
+              </div>
             </div>
+            {customMatch && (
+              <div
+                data-testid="toolbar-page-size-preset-match"
+                style={{ fontSize: 11, color: 'var(--text-muted)', marginTop: 6 }}
+              >
+                {customMatch}
+              </div>
+            )}
           </div>
         )}
 


### PR DESCRIPTION
Closes #118.

## Problem
On the page-size step, choosing **Custom** pre-fills the width/height with `595 × 842`. Those are A4 dimensions in points — but nothing tells the user that, so the numbers look arbitrary.

## Solution
When the custom width/height match a known preset, show a small muted hint beneath the inputs:

- `595 × 842` → **"Same as A4"**
- `842 × 595` → **"Same as A4 (landscape)"**
- a genuine custom size → no hint

New pure helpers `matchPreset` / `presetMatchLabel` (in `PageSizePicker.tsx`) detect a preset match in either orientation. The hint is wired into both page-size surfaces: the add-page / onboarding picker (`PageSizePicker`) and the post-image-upload dialog (`PageSizeDialog`).

The hint sits inside the existing reserved input slot, so switching to Custom still doesn't change the dialog's bounding box (the #47 regression test still passes).

## Tests
- Unit (`presetMatch.test.ts`): `matchPreset` (portrait, landscape, Letter, custom, square) and `presetMatchLabel`.
- Full UI unit suite green (605 tests); the `add-page-dialog` e2e (incl. the bounding-box guard) passes; type-check + lint + build green.

## Note
While here I noticed the Vitest `include` glob (`src/**/__tests__/**/*.test.ts`) doesn't match `.test.tsx`, so the existing `pageSizePicker.test.tsx` isn't being collected. Left as-is to keep this PR scoped — worth a follow-up to broaden the glob.
